### PR TITLE
Add controls for River 3/Plus, add SN and mac to device info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,62 @@ Unofficial EcoFlow BLE devices Home Assistant integration will allow you to comm
 number of EcoFlow devices through bluetooth and monitor their status / control parameters.
 
 Recognized devices:
-* Smart Home Panel 2 (EF-HD3####, FW Version: 4.0.0.122, WiFi Version: 2.0.1.20)
-* Delta Pro Ultra (EF-YJ####, FW Version: 5.0.0.25, WiFi Version: 2.0.2.4)
-* River 3, River 3 Plus (EF-R3####, FW Version: 1.0.0.0)
+<details><summary>
+<b>Smart Home Panel 2 (EF-HD3####, FW Version: 4.0.0.122, WiFi Version: 2.0.1.20)</b>
+</summary>
+
+| *Sensors*                      |
+|--------------------------------|
+| Battery Level                  |
+| Input Power                    |
+| Output Power                   |
+| Grid Power                     |
+| Power In Use                   |
+| Circuit Power (Each Circuit)   |
+| Circuit Current (Each Circuit) |
+| Channel Current (Each Channel) |
+</details>
+<details><summary>
+<b>Delta Pro Ultra (EF-YJ####, FW Version: 5.0.0.25, WiFi Version: 2.0.2.4)</b>
+</summary>
+
+| *Sensors*                |
+|--------------------------|
+| Battery Level            |
+| Input Power              |
+| Output Power             |
+| Low Voltage Solar Power  |
+| High Voltage Solar Power |
+</details>
+<details><summary>
+<b>River 3 (Plus, UPS) (EF-R3####, FW Version: 1.0.0.0)</b>
+</summary>
+
+| *Sensors*                       | *Switches*     | *Sliders*            | *Selects*            |
+|---------------------------------|----------------|----------------------|----------------------|
+| AC Input Energy                 | AC Port        | Backup Reserve Level | Led Mode (Plus only) |
+| AC Input Power                  | DC Port        | Max Charge Limit     |                      |
+| AC Output Energy                | Backup Reserve | Min Discharge Limit  |                      |
+| AC Output Power                 |                |                      |                      |
+| Battery Level                   |                |                      |                      |
+| DC 12V Port Output Energy       |                |                      |                      |
+| DC 12V Port Output Power        |                |                      |                      |
+| DC Input Energy                 |                |                      |                      |
+| DC Input Power                  |                |                      |                      |
+| Input Energy Total              |                |                      |                      |
+| Input Power Total               |                |                      |                      |
+| Output Energy Total             |                |                      |                      |
+| Output Power Total              |                |                      |                      |
+| USB A Output Energy             |                |                      |                      |
+| USB A Output Power              |                |                      |                      |
+| USB C Output Energy             |                |                      |                      |
+| USB C Output Power              |                |                      |                      |
+| Battery Input Power (disabled)  |                |                      |                      |
+| Battery Output Power (disabled) |                |                      |                      |
+| Cell Temperature (disabled)     |                |                      |                      |
+</details>
+
+</p>
 
 **NOTICE**: this integration utilizes Bluetooth LE of the EF device, which is supporting just one
 connection at a time - so if you want to manage the device through BLE from your phone, you will

--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -14,7 +14,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from . import eflib
 from .const import CONF_USER_ID, DOMAIN, MANUFACTURER
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.NUMBER,
+]
 
 type DeviceConfigEntry = ConfigEntry[eflib.DeviceBase]
 

--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -19,6 +19,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
     Platform.NUMBER,
+    Platform.SELECT,
 ]
 
 type DeviceConfigEntry = ConfigEntry[eflib.DeviceBase]

--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -33,10 +33,10 @@ BINARY_SENSOR_TYPES = {
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    "is_charging_ac": BinarySensorEntityDescription(
-        key="is_charging_ac",
-        name="AC Charging",
-        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+    "plugged_in_ac": BinarySensorEntityDescription(
+        key="plugged_in_ac",
+        name="AC Plugged In",
+        device_class=BinarySensorDeviceClass.PLUG,
         entity_registry_enabled_default=False,
     ),
 }

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -8,6 +8,7 @@ from functools import cached_property
 from typing import Any
 
 import voluptuous as vol
+
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_discovered_service_info,

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -8,7 +8,6 @@ from functools import cached_property
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_discovered_service_info,

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -122,7 +122,6 @@ class Device(DeviceBase, UpdatableProps):
             p = pr705_pb2.DisplayPropertyUpload()
             p.ParseFromString(packet.payload)
             _LOGGER.debug("%s: %s: Parsed data: %r", self.address, self.name, packet)
-            _LOGGER.debug("River 3 Parsed Message \n %s", str(p))
             self.update_fields(p)
             processed = True
         elif (

--- a/custom_components/ef_ble/eflib/devices/river3plus.py
+++ b/custom_components/ef_ble/eflib/devices/river3plus.py
@@ -6,7 +6,7 @@ from ..device_properties import ProtobufField
 from ..pb import pr705_pb2
 
 
-class LedState(IntEnum):
+class LedMode(IntEnum):
     OFF = 0
     DIM = 1
     BRIGHT = 2
@@ -18,9 +18,9 @@ class Device(river3.Device):
 
     SN_PREFIX = (b"R631", b"R634")
 
-    led_state = ProtobufField("led_mode", lambda num: LedState(num))
+    led_mode = ProtobufField("led_mode", lambda num: LedMode(num))
 
-    async def set_led_state(self, state: LedState):
+    async def set_led_mode(self, state: LedMode):
         config = pr705_pb2.ConfigWrite()
         config.cfg_led_mode = state.value
         await self._send_config_packet(config)

--- a/custom_components/ef_ble/eflib/devices/river3plus.py
+++ b/custom_components/ef_ble/eflib/devices/river3plus.py
@@ -1,0 +1,30 @@
+from enum import IntEnum
+
+from custom_components.ef_ble.eflib.devices import river3
+
+from ..device_properties import ProtobufField
+from ..pb import pr705_pb2
+
+
+class LedState(IntEnum):
+    OFF = 0
+    DIM = 1
+    BRIGHT = 2
+    SOS = 3
+
+
+class Device(river3.Device):
+    """River 3 Plus"""
+
+    SN_PREFIX = (b"R631", b"R634")
+
+    led_state = ProtobufField("led_mode", lambda num: LedState(num))
+
+    async def set_led_state(self, state: LedState):
+        config = pr705_pb2.ConfigWrite()
+        config.cfg_led_mode = state.value
+        await self._send_config_packet(config)
+
+    @property
+    def device(self):
+        return "River 3 Plus"

--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -1,0 +1,27 @@
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, MANUFACTURER
+from .eflib import DeviceBase
+
+
+class EcoflowEntity(Entity):
+    _attr_has_entity_name = True
+
+    def __init__(self, device: DeviceBase):
+        self._device = device
+
+    @property
+    def device_info(self):
+        """Return information to link this entity with the correct device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.address)},
+            name=self._device.name,
+            manufacturer=MANUFACTURER,
+            model=self._device.device,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if device is connected."""
+        return self._device.is_connected

--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -1,4 +1,4 @@
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, MANUFACTURER
@@ -15,10 +15,16 @@ class EcoflowEntity(Entity):
     def device_info(self):
         """Return information to link this entity with the correct device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device.address)},
+            identifiers={
+                (DOMAIN, self._device.address),
+            },
+            connections={
+                (CONNECTION_NETWORK_MAC, self._device.address),
+            },
             name=self._device.name,
             manufacturer=MANUFACTURER,
             model=self._device.device,
+            serial_number=self._device._sn,
         )
 
     @property

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -1,0 +1,173 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DeviceConfigEntry
+from .eflib import DeviceBase
+from .eflib.devices import river3
+from .entity import EcoflowEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class EcoflowNumberEntityDescription[T: DeviceBase](NumberEntityDescription):
+    async_set_native_value: Callable[[T, float], Awaitable[bool]] | None = None
+
+    min_value_prop: str | None = None
+    max_value_prop: str | None = None
+    availability_prop: str | None = None
+
+
+NUMBER_TYPES = [
+    # River 3
+    EcoflowNumberEntityDescription[river3.Device](
+        key="energy_backup_battery_level",
+        name="Backup Reserve",
+        device_class=NumberDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        native_step=1.0,
+        min_value_prop="battery_charge_limit_min",
+        max_value_prop="battery_charge_limit_max",
+        async_set_native_value=(
+            lambda device, value: device.set_energy_backup_battery_level(int(value))
+        ),
+        availability_prop="energy_backup",
+    ),
+    EcoflowNumberEntityDescription[river3.Device](
+        key="battery_charge_limit_min",
+        name="Discharge Limit",
+        device_class=NumberDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        native_step=1.0,
+        native_min_value=0,
+        max_value_prop="battery_charge_limit_max",
+        async_set_native_value=(
+            lambda device, value: device.set_battery_charge_limit_min(int(value))
+        ),
+    ),
+    EcoflowNumberEntityDescription[river3.Device](
+        key="battery_charge_limit_max",
+        name="Charge Limit",
+        device_class=NumberDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        native_step=1.0,
+        native_max_value=100,
+        min_value_prop="battery_charge_limit_min",
+        async_set_native_value=(
+            lambda device, value: device.set_battery_charge_limit_max(int(value))
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: DeviceConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    device = config_entry.runtime_data
+
+    async_add_entities(
+        [
+            EcoflowNumber(device, entity_description)
+            for entity_description in NUMBER_TYPES
+            if hasattr(device, entity_description.key)
+        ]
+    )
+
+
+class EcoflowNumber(EcoflowEntity, NumberEntity):
+    def __init__(
+        self,
+        device: DeviceBase,
+        entity_description: EcoflowNumberEntityDescription[DeviceBase],
+    ):
+        super().__init__(device)
+        self._attr_unique_id = f"{device.name}_{entity_description.key}"
+        self.entity_description = entity_description
+        self._min_value_prop = entity_description.min_value_prop
+        self._max_value_prop = entity_description.max_value_prop
+        self._availability_prop = entity_description.availability_prop
+        self._set_native_value = entity_description.async_set_native_value
+        self._prop_name = entity_description.key
+        self._attr_native_value = getattr(device, self._prop_name)
+
+    @property
+    def available(self):
+        is_available = super().available
+        if not is_available or self._availability_prop is None:
+            return is_available
+
+        return self._attr_available
+
+    async def async_set_native_value(self, value: float) -> None:
+        if self._set_native_value is not None:
+            await self._set_native_value(self._device, value)
+            return
+
+        await super().async_set_native_value(value)
+
+    @callback
+    def state_updated(self, state: float | None):
+        self._attr_native_value = state
+        self.async_write_ha_state()
+
+    @callback
+    def _min_state_updated(self, state: float | None):
+        if state is not None:
+            self._attr_native_min_value = state
+            self.async_write_ha_state()
+
+    @callback
+    def _max_state_updated(self, state: float | None):
+        if state is not None:
+            self._attr_native_max_value = state
+            self.async_write_ha_state()
+
+    @callback
+    def _availability_updated(self, state: bool | None):
+        self._attr_available = state if state is not None else False
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        self._device.register_state_update_callback(self.state_updated, self._prop_name)
+        if self._min_value_prop is not None:
+            self._device.register_state_update_callback(
+                self._min_state_updated, self._min_value_prop
+            )
+        if self._max_value_prop is not None:
+            self._device.register_state_update_callback(
+                self._max_state_updated,
+                self._max_value_prop,
+            )
+        if self._availability_prop is not None:
+            self._device.register_state_update_callback(
+                self._availability_updated,
+                self._availability_prop,
+            )
+        await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._device.remove_state_update_calback(self.state_updated, self._prop_name)
+        if self._min_value_prop is not None:
+            self._device.remove_state_update_calback(
+                self._min_state_updated, self._min_value_prop
+            )
+        if self._max_value_prop is not None:
+            self._device.remove_state_update_calback(
+                self._max_state_updated,
+                self._max_value_prop,
+            )
+        if self._availability_prop is not None:
+            self._device.remove_state_update_calback(
+                self._availability_updated,
+                self._availability_prop,
+            )
+        await super().async_will_remove_from_hass()

--- a/custom_components/ef_ble/select.py
+++ b/custom_components/ef_ble/select.py
@@ -1,0 +1,89 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+
+from homeassistant.components.select import (
+    SelectEntity,
+    SelectEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from custom_components.ef_ble.eflib import DeviceBase
+
+from . import DeviceConfigEntry
+from .eflib.devices import river3plus
+from .entity import EcoflowEntity
+
+
+@dataclass(kw_only=True, frozen=True)
+class EcoflowSelectEntityDescription[T: DeviceBase](SelectEntityDescription):
+    set_state: Callable[[T, str], Awaitable] | None = None
+
+
+SELECT_TYPES: list[EcoflowSelectEntityDescription] = [
+    # River 3 Plus
+    EcoflowSelectEntityDescription[river3plus.Device](
+        key="led_mode",
+        name="LED",
+        options=[opt.name.lower() for opt in river3plus.LedState],
+        set_state=(
+            lambda device, value: device.set_led_state(
+                river3plus.LedState[value.upper()]
+            )
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: DeviceConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add binary sensors for passed config_entry in HA."""
+    device = config_entry.runtime_data
+
+    new_sensors = [
+        EcoflowSelect(device, description)
+        for description in SELECT_TYPES
+        if hasattr(device, description.key)
+    ]
+
+    if new_sensors:
+        async_add_entities(new_sensors)
+
+
+class EcoflowSelect(EcoflowEntity, SelectEntity):
+    def __init__(
+        self,
+        device: DeviceBase,
+        description: EcoflowSelectEntityDescription[DeviceBase],
+    ):
+        super().__init__(device)
+
+        self._attr_unique_id = f"{self._device.name}_{description.key}"
+        self.entity_description = description
+        self._prop_name = self.entity_description.key
+        self._set_state = description.set_state
+        self._attr_current_option = None
+
+    async def async_added_to_hass(self):
+        """Run when this Entity has been added to HA."""
+        self._device.register_state_update_callback(self.state_updated, self._prop_name)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity being removed from hass."""
+        self._device.remove_state_update_calback(self.state_updated, self._prop_name)
+
+    @callback
+    def state_updated(self, state: Enum):
+        self._attr_current_option = state.name.lower()
+        self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        if self._set_state is not None:
+            await self._set_state(self._device, option)
+            return
+
+        await super().async_select_option(option)

--- a/custom_components/ef_ble/select.py
+++ b/custom_components/ef_ble/select.py
@@ -26,11 +26,9 @@ SELECT_TYPES: list[EcoflowSelectEntityDescription] = [
     EcoflowSelectEntityDescription[river3plus.Device](
         key="led_mode",
         name="LED",
-        options=[opt.name.lower() for opt in river3plus.LedState],
+        options=[opt.name.lower() for opt in river3plus.LedMode],
         set_state=(
-            lambda device, value: device.set_led_state(
-                river3plus.LedState[value.upper()]
-            )
+            lambda device, value: device.set_led_mode(river3plus.LedMode[value.upper()])
         ),
     ),
 ]

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -8,7 +8,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
-    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfEnergy,
     UnitOfPower,
@@ -200,7 +199,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         name="Battery Input Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
-        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     "battery_output_power": SensorEntityDescription(
@@ -208,14 +206,12 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         name="Battery Output Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
-        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     "cell_temperature": SensorEntityDescription(
         key="temperature",
         name="Cell Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
-        entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_registry_enabled_default=False,
     ),

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -219,14 +219,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_registry_enabled_default=False,
     ),
-    "mosfet_temperature": SensorEntityDescription(
-        key="mosfet_temperature",
-        name="MOSFET Temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        entity_registry_enabled_default=False,
-    ),
 }
 
 

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DeviceConfigEntry
+from .const import DOMAIN, MANUFACTURER
+from .eflib import DeviceBase
+from .entity import EcoflowEntity
+
+SWITCH_TYPES = [
+    SwitchEntityDescription(
+        key="dc_12v_port",
+        name="DC 12V Port",
+        device_class=SwitchDeviceClass.OUTLET,
+    ),
+    SwitchEntityDescription(
+        key="ac_ports",
+        name="AC Ports",
+        device_class=SwitchDeviceClass.OUTLET,
+    ),
+    SwitchEntityDescription(
+        key="energy_backup",
+        name="Backup Reserve",
+        device_class=SwitchDeviceClass.SWITCH,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DeviceConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    device = entry.runtime_data
+
+    switches = [
+        EcoflowSwitchEntity(device, switch_desc)
+        for switch_desc in SWITCH_TYPES
+        if hasattr(device, switch_desc.key)
+        and hasattr(device, f"enable_{switch_desc.key}")
+    ]
+
+    if switches:
+        async_add_entities(switches)
+
+
+class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
+    def __init__(
+        self, device: DeviceBase, entity_description: SwitchEntityDescription
+    ) -> None:
+        super().__init__(device)
+
+        self._attr_unique_id = f"{device.name}_{entity_description.key}"
+        self._prop_name = entity_description.key
+        self._method_name = f"enable_{self._prop_name}"
+        self.entity_description = entity_description
+        self._on_off_state = False
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await getattr(self._device, self._method_name)(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await getattr(self._device, self._method_name)(False)
+
+    async def async_added_to_hass(self) -> None:
+        self._device.register_state_update_callback(self.state_updated, self._prop_name)
+        await super().async_added_to_hass()
+
+    @callback
+    def state_updated(self, state: bool | None):
+        self._on_off_state = state
+        self.async_write_ha_state()
+
+    @property
+    def available(self):
+        return self._device.is_connected and self._on_off_state is not None
+
+    @property
+    def is_on(self):
+        return self._on_off_state if self._on_off_state is not None else False
+
+    @property
+    def device_info(self):
+        """Return information to link this entity with the correct device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.address)},
+            name=self._device.name,
+            manufacturer=MANUFACTURER,
+            model=self._device.device,
+        )

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -6,11 +6,9 @@ from homeassistant.components.switch import (
     SwitchEntityDescription,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DeviceConfigEntry
-from .const import DOMAIN, MANUFACTURER
 from .eflib import DeviceBase
 from .entity import EcoflowEntity
 
@@ -85,13 +83,3 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
     @property
     def is_on(self):
         return self._on_off_state if self._on_off_state is not None else False
-
-    @property
-    def device_info(self):
-        """Return information to link this entity with the correct device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device.address)},
-            name=self._device.name,
-            manufacturer=MANUFACTURER,
-            model=self._device.device,
-        )


### PR DESCRIPTION
This PR adds switches, numbers and selects for River 3, changes name to correct variant based on serial number and also adds more information into device info.