### PR TITLE
Change battery level reporting to include additional batteries for R3+ and D3, add main battery level sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Recognized devices:
 | AC Input Power                  | DC Port        | Max Charge Limit     |                      |
 | AC Output Energy                | Backup Reserve | Min Discharge Limit  |                      |
 | AC Output Power                 |                |                      |                      |
+| Main Battery Level (Plus only)  |                |                      |                      |
 | Battery Level                   |                |                      |                      |
 | DC 12V Port Output Energy       |                |                      |                      |
 | DC 12V Port Output Power        |                |                      |                      |
@@ -69,10 +70,11 @@ Recognized devices:
 
 | *Sensors*                           | *Switches*     | *Sliders*            |
 |-------------------------------------|----------------|----------------------|
-| Battery Level                       | AC Ports       | Backup Reserve Level |
-| AC Input Power                      | DC Ports       | Max Charge Limit     |
-| AC Output Power                     | Backup Reserve | Min Discharge Limit  |
-| DC 12V Port Output Power            | USB Ports      |                      |
+| Main Battery Level                  | AC Ports       | Backup Reserve Level |
+| Battery Level                       | DC Ports       | Max Charge Limit     |
+| AC Input Power                      | Backup Reserve | Min Discharge Limit  |
+| AC Output Power                     | USB Ports      |                      |
+| DC 12V Port Output Power            |                |                      |
 | DC Port Input Power                 |                |                      |
 | DC Port Input State                 |                |                      |
 | DC Port (2) Input Power (Plus only) |                |                      |
@@ -81,10 +83,10 @@ Recognized devices:
 | Solar Power (2) (Plus only)         |                |                      |
 | Input Power Total                   |                |                      |
 | Output Power Total                  |                |                      |
-| Left USB A Output Power             |                |                      |
-| Right USB A Output Power            |                |                      |
-| Left USB C Output Power             |                |                      |
-| Right USB C Output Power            |                |                      |
+| USB A Output Power                  |                |                      |
+| USB A (2) Output Power              |                |                      |
+| USB C Output Power                  |                |                      |
+| USB C (2) Output Power              |                |                      |
 | AC Plugged In                       |                |                      |
 | Battery Input Power (disabled)      |                |                      |
 | Battery Output Power (disabled)     |                |                      |

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -56,7 +56,8 @@ class Device(DeviceBase, ProtobufProps):
     SN_PREFIX = (b"P231", b"D361")
     NAME_PREFIX = "EF-D3"
 
-    battery_level = pb_field(pb.bms_batt_soc, lambda value: round(value, 2))
+    battery_level = pb_field(pb.cms_batt_soc, lambda value: round(value, 2))
+    battery_level_main = pb_field(pb.bms_batt_soc, lambda value: round(value, 2))
 
     ac_input_power = pb_field(pb.pow_get_ac_in)
     ac_output_power = pb_field(pb.pow_get_ac_out, _out_power)

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -12,11 +12,11 @@ from ..devicebase import DeviceBase
 from ..packet import Packet
 from ..pb import pr705_pb2
 from ..props import (
+    Field,
     ProtobufProps,
     pb_field,
     proto_attr_mapper,
     repeated_pb_field_type,
-    Field,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class Device(DeviceBase, ProtobufProps):
     SN_PREFIX = (b"R651", b"R653", b"R654", b"R655")
     NAME_PREFIX = "EF-R3"
 
-    battery_level = pb_field(pb.bms_batt_soc)
+    battery_level = pb_field(pb.cms_batt_soc)
 
     ac_input_power = pb_field(pb.pow_get_ac_in)
     ac_input_energy = _StatField(pr705_pb2.STATISTICS_OBJECT_AC_IN_ENERGY)

--- a/custom_components/ef_ble/eflib/devices/river3plus.py
+++ b/custom_components/ef_ble/eflib/devices/river3plus.py
@@ -18,6 +18,8 @@ class Device(river3.Device):
 
     SN_PREFIX = (b"R631", b"R634")
 
+    battery_level_main = pb_field(river3.pb.bms_batt_soc)
+
     led_mode = pb_field(river3.pb.led_mode, lambda num: LedMode(num))
 
     async def set_led_mode(self, state: LedMode):

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -25,7 +25,14 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     # Common
     "battery_level": SensorEntityDescription(
         key="battery_level",
-        name="Battery",
+        name="Battery Level",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "battery_level_main": SensorEntityDescription(
+        key="battery_level_main",
+        name="Main Battery Level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
This PR changes how battery level sensor is reported - before we used value from BMS field which only reports main unit battery level but with this change, we use value from CMS that averages all connected batteries. BMS sensor is now available as main_battery_level.

Resolves #14 