### PR TITLE
Add AC charging speed controls for D3, R3, DP3 and DC controls for D3, R3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Recognized devices:
 | *Sensors*                       | *Switches*     | *Sliders*            | *Selects*            |
 |---------------------------------|----------------|----------------------|----------------------|
 | AC Input Energy                 | AC Port        | Backup Reserve Level | Led Mode (Plus only) |
-| AC Input Power                  | DC Port        | Max Charge Limit     |                      |
+| AC Input Power                  | DC Port        | Max Charge Limit     | DC Charging Type     |
 | AC Output Energy                | Backup Reserve | Min Discharge Limit  |                      |
 | AC Output Power                 |                | AC Charging Speed    |                      |
-| Main Battery Level (Plus only)  |                |                      |                      |
+| Main Battery Level (Plus only)  |                | DC Charging Max Amps |                      |
 | Battery Level                   |                |                      |                      |
 | DC 12V Port Output Energy       |                |                      |                      |
 | DC 12V Port Output Power        |                |                      |                      |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Recognized devices:
 | AC Input Energy                 | AC Port        | Backup Reserve Level | Led Mode (Plus only) |
 | AC Input Power                  | DC Port        | Max Charge Limit     |                      |
 | AC Output Energy                | Backup Reserve | Min Discharge Limit  |                      |
-| AC Output Power                 |                |                      |                      |
+| AC Output Power                 |                | AC Charging Speed    |                      |
 | Main Battery Level (Plus only)  |                |                      |                      |
 | Battery Level                   |                |                      |                      |
 | DC 12V Port Output Energy       |                |                      |                      |
@@ -73,7 +73,7 @@ Recognized devices:
 | Main Battery Level                  | AC Ports       | Backup Reserve Level |
 | Battery Level                       | DC Ports       | Max Charge Limit     |
 | AC Input Power                      | Backup Reserve | Min Discharge Limit  |
-| AC Output Power                     | USB Ports      |                      |
+| AC Output Power                     | USB Ports      | AC Charging Speed    |
 | DC 12V Port Output Power            |                |                      |
 | DC Port Input Power                 |                |                      |
 | DC Port Input State                 |                |                      |
@@ -102,7 +102,7 @@ Recognized devices:
 | Main Battery Level          | AC Ports       | Backup Reserve Level |
 | Battery Level               | DC Ports       | Max Charge Limit     |
 | AC Input Power              | Backup Reserve | Min Discharge Limit  |
-| AC LV Output Power          |                |                      |
+| AC LV Output Power          |                | AC Charging Speed    |
 | AC HV Output Power          |                |                      |
 | DC 12V Output Power         |                |                      |
 | DC LV Input Power           |                |                      |

--- a/README.md
+++ b/README.md
@@ -68,29 +68,29 @@ Recognized devices:
 <b>Delta 3 (Plus, 1500) (EF-D3####, FW Version: 6.49.76.57)</b>
 </summary>
 
-| *Sensors*                           | *Switches*     | *Sliders*            |
-|-------------------------------------|----------------|----------------------|
-| Main Battery Level                  | AC Ports       | Backup Reserve Level |
-| Battery Level                       | DC Ports       | Max Charge Limit     |
-| AC Input Power                      | Backup Reserve | Min Discharge Limit  |
-| AC Output Power                     | USB Ports      | AC Charging Speed    |
-| DC 12V Port Output Power            |                |                      |
-| DC Port Input Power                 |                |                      |
-| DC Port Input State                 |                |                      |
-| DC Port (2) Input Power (Plus only) |                |                      |
-| DC Port (2) Input State (Plus only) |                |                      |
-| Solar Power                         |                |                      |
-| Solar Power (2) (Plus only)         |                |                      |
-| Input Power Total                   |                |                      |
-| Output Power Total                  |                |                      |
-| USB A Output Power                  |                |                      |
-| USB A (2) Output Power              |                |                      |
-| USB C Output Power                  |                |                      |
-| USB C (2) Output Power              |                |                      |
-| AC Plugged In                       |                |                      |
-| Battery Input Power (disabled)      |                |                      |
-| Battery Output Power (disabled)     |                |                      |
-| Cell Temperature (disabled)         |                |                      |
+| *Sensors*                           | *Switches*     | *Sliders*                            |
+|-------------------------------------|----------------|--------------------------------------|
+| Main Battery Level                  | AC Ports       | Backup Reserve Level                 |
+| Battery Level                       | DC Ports       | Max Charge Limit                     |
+| AC Input Power                      | Backup Reserve | Min Discharge Limit                  |
+| AC Output Power                     | USB Ports      | AC Charging Speed                    |
+| DC 12V Port Output Power            |                | DC Charging Max Amps                 |
+| DC Port Input Power                 |                | DC (2) Charging Max Amps (Plus only) |
+| DC Port Input State                 |                |                                      |
+| DC Port (2) Input Power (Plus only) |                |                                      |
+| DC Port (2) Input State (Plus only) |                |                                      |
+| Solar Power                         |                |                                      |
+| Solar Power (2) (Plus only)         |                |                                      |
+| Input Power Total                   |                |                                      |
+| Output Power Total                  |                |                                      |
+| USB A Output Power                  |                |                                      |
+| USB A (2) Output Power              |                |                                      |
+| USB C Output Power                  |                |                                      |
+| USB C (2) Output Power              |                |                                      |
+| AC Plugged In                       |                |                                      |
+| Battery Input Power (disabled)      |                |                                      |
+| Battery Output Power (disabled)     |                |                                      |
+| Cell Temperature (disabled)         |                |                                      |
 </details>
 
 <details><summary>

--- a/custom_components/ef_ble/eflib/commands.py
+++ b/custom_components/ef_ble/eflib/commands.py
@@ -1,8 +1,8 @@
 import asyncio
-from dataclasses import dataclass
 import logging
 import struct
 import time
+from dataclasses import dataclass
 
 from .devicebase import DeviceBase
 from .packet import Packet

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -1,5 +1,4 @@
 import logging
-from enum import IntEnum
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
@@ -14,7 +13,9 @@ from ..props import (
     ProtobufProps,
     pb_field,
     proto_attr_mapper,
+    repeated_pb_field_type,
 )
+from ..props.enums import IntFieldValue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,23 +33,41 @@ def _flow_is_on(x):
 pb = proto_attr_mapper(pd335_sys_pb2.DisplayPropertyUpload)
 
 
-class DCPortState(IntEnum):
+class _DcChargingMaxField(
+    repeated_pb_field_type(
+        list_field=pb.plug_in_info_pv_chg_max_list.pv_chg_max_item,
+        value_field=lambda x: x.pv_chg_amp_max,
+    )
+):
+    vol_type: int
+
+    def process_item(self, value: pd335_sys_pb2.PvChgMaxItem) -> int | None:
+        return value.pv_chg_amp_max if value.pv_chg_vol_type == self.vol_type else None
+
+
+class _DcAmpSettingField(
+    repeated_pb_field_type(
+        list_field=pb.pv_dc_chg_setting_list.list_info,
+        value_field=lambda x: x.pv_chg_amp_limit,
+    )
+):
+    vol_type: int
+    plug_index: int
+
+    def process_item(self, value: pd335_sys_pb2.PvDcChgSetting) -> int | None:
+        return (
+            value.pv_chg_amp_limit
+            if value.pv_plug_index == self.plug_index
+            and value.pv_chg_vol_spec == self.vol_type
+            else None
+        )
+
+
+class DCPortState(IntFieldValue):
     UNKNOWN = -1
     OFF = 0
     CAR = 1
     SOLAR = 2
-
-    @classmethod
-    def from_value(cls, value: int):
-        try:
-            return cls(value)
-        except ValueError:
-            logging.debug("Encountered invalid value %s for DCPortState", value)
-            return cls.UNKNOWN
-
-    @property
-    def state_name(self):
-        return self.name.lower()
 
 
 class Device(DeviceBase, ProtobufProps):
@@ -95,6 +114,11 @@ class Device(DeviceBase, ProtobufProps):
 
     ac_charging_speed = pb_field(pb.plug_in_info_ac_in_chg_pow_max)
     max_ac_charging_power = Field[int]()
+
+    dc_charging_max_amps = _DcAmpSettingField(
+        pd335_sys_pb2.PV_CHG_VOL_SPEC_12V, pd335_sys_pb2.PV_PLUG_INDEX_1
+    )
+    dc_charging_current_max = _DcChargingMaxField(pd335_sys_pb2.PV_CHG_VOL_SPEC_12V)
 
     def __init__(
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
@@ -228,4 +252,24 @@ class Device(DeviceBase, ProtobufProps):
                 cfg_plug_in_info_ac_in_chg_pow_max=value,
             )
         )
+        return True
+
+    async def set_dc_charging_amps_max(
+        self,
+        value: int,
+        plug_index: pd335_sys_pb2.PV_PLUG_INDEX = pd335_sys_pb2.PV_PLUG_INDEX_1,
+    ) -> bool:
+        if (
+            self.dc_charging_current_max is None
+            or value < 0
+            or value > self.dc_charging_current_max
+        ):
+            return False
+
+        config = pd335_sys_pb2.ConfigWrite()
+        config.cfg_pv_dc_chg_setting.pv_plug_index = plug_index
+        config.cfg_pv_dc_chg_setting.pv_chg_vol_spec = pd335_sys_pb2.PV_CHG_VOL_SPEC_12V
+        config.cfg_pv_dc_chg_setting.pv_chg_amp_limit = value
+
+        await self._send_config_packet(config)
         return True

--- a/custom_components/ef_ble/eflib/devices/delta3_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_plus.py
@@ -1,12 +1,21 @@
+from functools import partialmethod
+
+from custom_components.ef_ble.eflib.pb import pd335_sys_pb2
+
 from ..props import Field, pb_field
 from . import delta3
-from .delta3 import DCPortState, pb
+from .delta3 import DCPortState, _DcAmpSettingField, _DcChargingMaxField, pb
 
 
 class Device(delta3.Device):
     """Delta 3 Plus"""
 
     SN_PREFIX = (b"P351",)
+
+    dc_charging_max_amps_2 = _DcAmpSettingField(
+        pd335_sys_pb2.PV_CHG_VOL_SPEC_12V, pd335_sys_pb2.PV_PLUG_INDEX_2
+    )
+    dc_charging_current_max_2 = _DcChargingMaxField(pd335_sys_pb2.PV_CHG_VOL_SPEC_12V)
 
     dc_port_2_input_power = pb_field(pb.pow_get_pv2)
     dc_port_2_state = pb_field(
@@ -24,3 +33,7 @@ class Device(delta3.Device):
             )
             else 0
         )
+
+    set_dc_charging_amps_max_2 = partialmethod(
+        delta3.Device.set_dc_charging_amps_max, plug_index=pd335_sys_pb2.PV_PLUG_INDEX_2
+    )

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -84,6 +84,9 @@ class Device(DeviceBase, ProtobufProps):
     usba_output_power = pb_field(pb.pow_get_qcusb1, _out_power)
     usba2_output_power = pb_field(pb.pow_get_qcusb2, _out_power)
 
+    ac_charging_speed = pb_field(pb.plug_in_info_ac_in_chg_pow_max)
+    max_ac_charging_power = pb_field(pb.plug_in_info_ac_in_chg_hal_pow_max)
+
     plugged_in_ac = pb_field(pb.plug_in_info_ac_charger_flag)
     energy_backup = pb_field(pb.energy_backup_en)
     energy_backup_battery_level = pb_field(pb.energy_backup_start_soc)
@@ -208,4 +211,17 @@ class Device(DeviceBase, ProtobufProps):
             return False
 
         await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_max_chg_soc=limit))
+        return True
+
+    async def set_ac_charging_speed(self, value: int):
+        if (
+            self.max_ac_charging_power is None
+            or value > self.max_ac_charging_power
+            or value < 0
+        ):
+            return False
+
+        await self._send_config_packet(
+            mr521_pb2.ConfigWrite(cfg_plug_in_info_ac_in_chg_pow_max=value)
+        )
         return True

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -81,6 +81,9 @@ class Device(DeviceBase, ProtobufProps):
     usba_output_power = pb_field(pb.pow_get_qcusb1, _out_power)
     usba_output_energy = _StatField(pr705_pb2.STATISTICS_OBJECT_USBA_OUT_ENERGY)
 
+    ac_charging_speed = pb_field(pb.plug_in_info_ac_in_chg_pow_max)
+    max_ac_charging_power = pb_field(pb.plug_in_info_ac_in_chg_hal_pow_max)
+
     plugged_in_ac = pb_field(pb.plug_in_info_ac_charger_flag)
     energy_backup = pb_field(pb.energy_backup_en)
     energy_backup_battery_level = pb_field(pb.energy_backup_start_soc)
@@ -187,14 +190,12 @@ class Device(DeviceBase, ProtobufProps):
         await self._send_config_packet(config)
 
     async def enable_dc_12v_port(self, enabled: bool):
-        config = pr705_pb2.ConfigWrite()
-        config.cfg_dc_12v_out_open = enabled
-        await self._send_config_packet(config)
+        await self._send_config_packet(
+            pr705_pb2.ConfigWrite(cfg_dc_12v_out_open=enabled)
+        )
 
     async def enable_ac_ports(self, enabled: bool):
-        config = pr705_pb2.ConfigWrite()
-        config.cfg_ac_out_open = enabled
-        await self._send_config_packet(config)
+        await self._send_config_packet(pr705_pb2.ConfigWrite(cfg_ac_out_open=enabled))
 
     async def set_battery_charge_limit_min(self, limit: int):
         if (
@@ -203,10 +204,7 @@ class Device(DeviceBase, ProtobufProps):
         ):
             return False
 
-        config = pr705_pb2.ConfigWrite()
-        config.cfg_min_dsg_soc = limit
-
-        await self._send_config_packet(config)
+        await self._send_config_packet(pr705_pb2.ConfigWrite(cfg_min_dsg_soc=limit))
         return True
 
     async def set_battery_charge_limit_max(self, limit: int):
@@ -216,8 +214,20 @@ class Device(DeviceBase, ProtobufProps):
         ):
             return False
 
-        config = pr705_pb2.ConfigWrite()
-        config.cfg_max_chg_soc = limit
+        await self._send_config_packet(
+            message=pr705_pb2.ConfigWrite(cfg_max_chg_soc=limit)
+        )
+        return True
 
-        await self._send_config_packet(config)
+    async def set_ac_charging_speed(self, value: int):
+        if (
+            self.max_ac_charging_power is None
+            or value > self.max_ac_charging_power
+            or value < 0
+        ):
+            return False
+
+        await self._send_config_packet(
+            pr705_pb2.ConfigWrite(cfg_plug_in_info_ac_in_chg_pow_max=value)
+        )
         return True

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -139,8 +139,8 @@ class Device(DeviceBase, ProtobufProps):
         if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             p = pr705_pb2.DisplayPropertyUpload()
             p.ParseFromString(packet.payload)
-            # _LOGGER.debug("%s: %s: Parsed data: %r", self.address, self.name, packet)
-            _LOGGER.debug("River 3 Parsed Message \n %s", str(p))
+            _LOGGER.debug("%s: %s: Parsed data: %r", self.address, self.name, packet)
+            # _LOGGER.debug("River 3 Parsed Message \n %s", str(p))
             self.update_from_message(p)
             processed = True
         elif (

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -1,11 +1,7 @@
 import logging
-from collections.abc import Sequence
-from dataclasses import dataclass
-from typing import Any
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-from google.protobuf.message import Message
 
 from ..commands import TimeCommands
 from ..devicebase import DeviceBase
@@ -18,13 +14,20 @@ from ..props import (
     proto_attr_mapper,
     repeated_pb_field_type,
 )
+from ..props.enums import IntFieldValue
 
 _LOGGER = logging.getLogger(__name__)
 
 pb = proto_attr_mapper(pr705_pb2.DisplayPropertyUpload)
 
 
-@dataclass
+class DcChargingType(IntFieldValue):
+    UNKNOWN = -1
+    AUTO = 0
+    CAR = 1
+    SOLAR = 2
+
+
 class _StatField(
     repeated_pb_field_type(
         list_field=pb.display_statistics_sum.list_info,
@@ -98,11 +101,16 @@ class Device(DeviceBase, ProtobufProps):
     dc_12v_port = pb_field(pb.flow_info_12v, _flow_is_on)
     ac_ports = pb_field(pb.flow_info_ac_out, _flow_is_on)
 
+    dc_charging_type = pb_field(pb.pv_chg_type, lambda x: DcChargingType.from_value(x))
+    dc_charging_max_amps = pb_field(pb.plug_in_info_pv_dc_amp_max)
+    dc_charging_current_max = Field[int]()
+
     def __init__(
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
         self._time_commands = TimeCommands(self)
+        self.dc_charging_current_max = 8
 
     @classmethod
     def check(cls, sn):
@@ -131,8 +139,8 @@ class Device(DeviceBase, ProtobufProps):
         if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             p = pr705_pb2.DisplayPropertyUpload()
             p.ParseFromString(packet.payload)
-            _LOGGER.debug("%s: %s: Parsed data: %r", self.address, self.name, packet)
-            # _LOGGER.debug("River 3 Parsed Message \n %s", str(p))
+            # _LOGGER.debug("%s: %s: Parsed data: %r", self.address, self.name, packet)
+            _LOGGER.debug("River 3 Parsed Message \n %s", str(p))
             self.update_from_message(p)
             processed = True
         elif (
@@ -229,5 +237,23 @@ class Device(DeviceBase, ProtobufProps):
 
         await self._send_config_packet(
             pr705_pb2.ConfigWrite(cfg_plug_in_info_ac_in_chg_pow_max=value)
+        )
+        return True
+
+    async def set_dc_charging_type(self, state: DcChargingType):
+        await self._send_config_packet(
+            pr705_pb2.ConfigWrite(cfg_pv_chg_type=state.value)
+        )
+
+    async def set_dc_charging_amps_max(self, value: int):
+        if (
+            self.dc_charging_current_max is None
+            or value < 0
+            or value > self.dc_charging_current_max
+        ):
+            return False
+
+        await self._send_config_packet(
+            pr705_pb2.ConfigWrite(cfg_plug_in_info_pv_dc_amp_max=value)
         )
         return True

--- a/custom_components/ef_ble/eflib/devices/river3_plus.py
+++ b/custom_components/ef_ble/eflib/devices/river3_plus.py
@@ -1,12 +1,11 @@
-from enum import IntEnum
-
 from custom_components.ef_ble.eflib.devices import river3
 
 from ..pb import pr705_pb2
 from ..props import pb_field
+from ..props.enums import IntFieldValue
 
 
-class LedMode(IntEnum):
+class LedMode(IntFieldValue):
     OFF = 0
     DIM = 1
     BRIGHT = 2
@@ -20,7 +19,12 @@ class Device(river3.Device):
 
     battery_level_main = pb_field(river3.pb.bms_batt_soc)
 
-    led_mode = pb_field(river3.pb.led_mode, lambda num: LedMode(num))
+    def __init__(
+        self, ble_dev: river3.BLEDevice, adv_data: river3.AdvertisementData, sn: str
+    ) -> None:
+        super().__init__(ble_dev, adv_data, sn)
+
+    led_mode = pb_field(river3.pb.led_mode, lambda num: LedMode.from_value(num))
 
     async def set_led_mode(self, state: LedMode):
         await self._send_config_packet(pr705_pb2.ConfigWrite(cfg_led_mode=state.value))

--- a/custom_components/ef_ble/eflib/props/enums.py
+++ b/custom_components/ef_ble/eflib/props/enums.py
@@ -1,0 +1,16 @@
+import logging
+from enum import IntEnum
+
+
+class IntFieldValue(IntEnum):
+    @classmethod
+    def from_value(cls, value: int):
+        try:
+            return cls(value)
+        except ValueError:
+            logging.debug("Encountered invalid value %s for %s", value, cls.__name__)
+            return getattr(cls, "UNKNOWN")
+
+    @property
+    def state_name(self):
+        return self.name.lower()

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -7,13 +7,13 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfPower
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DeviceConfigEntry
 from .eflib import DeviceBase
-from .eflib.devices import river3
+from .eflib.devices import delta3, delta3_plus, delta_pro_3, river3
 from .entity import EcoflowEntity
 
 
@@ -66,6 +66,20 @@ NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
         min_value_prop="battery_charge_limit_min",
         async_set_native_value=(
             lambda device, value: device.set_battery_charge_limit_max(int(value))
+        ),
+    ),
+    EcoflowNumberEntityDescription[
+        river3.Device | delta3.Device | delta3_plus.Device | delta_pro_3.Device
+    ](
+        key="ac_charging_speed",
+        name="AC Charging Speed",
+        device_class=NumberDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        native_step=1,
+        native_min_value=0,
+        max_value_prop="max_ac_charging_power",
+        async_set_native_value=(
+            lambda device, value: device.set_ac_charging_speed(int(value))
         ),
     ),
 ]

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -7,7 +7,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, UnitOfPower
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent, UnitOfPower
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -27,7 +27,6 @@ class EcoflowNumberEntityDescription[T: DeviceBase](NumberEntityDescription):
 
 
 NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
-    # River 3
     EcoflowNumberEntityDescription[river3.Device](
         key="energy_backup_battery_level",
         name="Backup Reserve",
@@ -68,9 +67,7 @@ NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
             lambda device, value: device.set_battery_charge_limit_max(int(value))
         ),
     ),
-    EcoflowNumberEntityDescription[
-        river3.Device | delta3.Device | delta3_plus.Device | delta_pro_3.Device
-    ](
+    EcoflowNumberEntityDescription[river3.Device | delta3.Device | delta_pro_3.Device](
         key="ac_charging_speed",
         name="AC Charging Speed",
         device_class=NumberDeviceClass.POWER,
@@ -80,6 +77,18 @@ NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
         max_value_prop="max_ac_charging_power",
         async_set_native_value=(
             lambda device, value: device.set_ac_charging_speed(int(value))
+        ),
+    ),
+    EcoflowNumberEntityDescription[river3.Device](
+        key="dc_charging_max_amps",
+        name="DC Charging Max Amps",
+        device_class=NumberDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        native_step=1,
+        native_min_value=0,
+        max_value_prop="dc_charging_current_max",
+        async_set_native_value=(
+            lambda device, value: device.set_dc_charging_amps_max(int(value))
         ),
     ),
 ]

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -79,7 +79,7 @@ NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
             lambda device, value: device.set_ac_charging_speed(int(value))
         ),
     ),
-    EcoflowNumberEntityDescription[river3.Device](
+    EcoflowNumberEntityDescription[river3.Device | delta3.Device](
         key="dc_charging_max_amps",
         name="DC Charging Max Amps",
         device_class=NumberDeviceClass.CURRENT,
@@ -89,6 +89,18 @@ NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
         max_value_prop="dc_charging_current_max",
         async_set_native_value=(
             lambda device, value: device.set_dc_charging_amps_max(int(value))
+        ),
+    ),
+    EcoflowNumberEntityDescription[delta3_plus.Device](
+        key="dc_charging_max_amps_2",
+        name="DC (2) Charging Max Amps",
+        device_class=NumberDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        native_step=1,
+        native_min_value=0,
+        max_value_prop="dc_charging_current_max_2",
+        async_set_native_value=(
+            lambda device, value: device.set_dc_charging_amps_max_2(int(value))
         ),
     ),
 ]

--- a/custom_components/ef_ble/select.py
+++ b/custom_components/ef_ble/select.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from custom_components.ef_ble.eflib import DeviceBase
 
 from . import DeviceConfigEntry
-from .eflib.devices import river3plus
+from .eflib.devices import river3, river3_plus
 from .entity import EcoflowEntity
 
 
@@ -23,12 +23,28 @@ class EcoflowSelectEntityDescription[T: DeviceBase](SelectEntityDescription):
 
 SELECT_TYPES: list[EcoflowSelectEntityDescription] = [
     # River 3 Plus
-    EcoflowSelectEntityDescription[river3plus.Device](
+    EcoflowSelectEntityDescription[river3_plus.Device](
         key="led_mode",
         name="LED",
-        options=[opt.name.lower() for opt in river3plus.LedMode],
+        options=[opt.name.lower() for opt in river3_plus.LedMode],
         set_state=(
-            lambda device, value: device.set_led_mode(river3plus.LedMode[value.upper()])
+            lambda device, value: device.set_led_mode(
+                river3_plus.LedMode[value.upper()]
+            )
+        ),
+    ),
+    EcoflowSelectEntityDescription[river3.Device](
+        key="dc_charging_type",
+        name="DC Charging Type",
+        options=[
+            opt.name.lower()
+            for opt in river3.DcChargingType
+            if opt is not river3.DcChargingType.UNKNOWN
+        ],
+        set_state=(
+            lambda device, value: device.set_dc_charging_type(
+                river3.DcChargingType[value.upper()]
+            )
         ),
     ),
 ]


### PR DESCRIPTION
This PR implements controls for setting AC charging speed as requested in #23 for River 3 (tested), Delta 3 (tested on D3+) and Delta Pro 3. The Ecoflow app does limit input values for some devices and sets lower limits, but it does still work (at least on R3 and D3+).

It also includes DC charging controls for D3 and R3 requested in #25

Resolves #23
Resolves #25