### PR TITLE
Use fields for DPU and SHP2, add individual battery sensors and AC port sensors to DPU, use translations for all sensor icons and names

### DIFF
--- a/custom_components/ef_ble/eflib/commands.py
+++ b/custom_components/ef_ble/eflib/commands.py
@@ -94,7 +94,7 @@ class TimeCommands:
 
         await self.device._conn.sendPacket(packet)
 
-    def async_send_all(self):
-        asyncio.create_task(self.sendUtcTime())
-        asyncio.create_task(self.sendRTCRespond())
-        asyncio.create_task(self.sendRTCCheck())
+    async def async_send_all(self):
+        await self.device._conn._add_task(asyncio.create_task(self.sendUtcTime()))
+        await self.device._conn._add_task(asyncio.create_task(self.sendRTCRespond()))
+        await self.device._conn._add_task(asyncio.create_task(self.sendRTCCheck()))

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -57,7 +57,10 @@ class ConnectionState(Enum):
 
 
 class Connection:
-    """Connection object manages client creation, authentification and sends the packets to parse back"""
+    """
+    Connection object manages client creation, authentification and sends the packets
+    to parse back
+    """
 
     NOTIFY_CHARACTERISTIC = "00000003-0000-1000-8000-00805f9b34fb"
     WRITE_CHARACTERISTIC = "00000002-0000-1000-8000-00805f9b34fb"

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -38,28 +38,30 @@ class _DcChargingMaxField(
     repeated_pb_field_type(
         list_field=pb.plug_in_info_pv_chg_max_list.pv_chg_max_item,
         value_field=lambda x: x.pv_chg_amp_max,
+        per_item=True,
     )
 ):
     vol_type: int
 
-    def process_item(self, value: pd335_sys_pb2.PvChgMaxItem) -> int | None:
-        return value.pv_chg_amp_max if value.pv_chg_vol_type == self.vol_type else None
+    def get_value(self, item: pd335_sys_pb2.PvChgMaxItem) -> int | None:
+        return item.pv_chg_amp_max if item.pv_chg_vol_type == self.vol_type else None
 
 
 class _DcAmpSettingField(
     repeated_pb_field_type(
         list_field=pb.pv_dc_chg_setting_list.list_info,
         value_field=lambda x: x.pv_chg_amp_limit,
+        per_item=True,
     )
 ):
     vol_type: int
     plug_index: int
 
-    def process_item(self, value: pd335_sys_pb2.PvDcChgSetting) -> int | None:
+    def get_value(self, item: pd335_sys_pb2.PvDcChgSetting) -> int | None:
         return (
-            value.pv_chg_amp_limit
-            if value.pv_plug_index == self.plug_index
-            and value.pv_chg_vol_spec == self.vol_type
+            item.pv_chg_amp_limit
+            if item.pv_plug_index == self.plug_index
+            and item.pv_chg_vol_spec == self.vol_type
             else None
         )
 
@@ -168,8 +170,6 @@ class Device(DeviceBase, ProtobufProps):
             and packet.cmdSet == 0x01
             and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
-            # Device requested for time and timezone offset, so responding with that
-            # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
                 self._time_commands.async_send_all()
             processed = True

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -7,7 +7,7 @@ from google.protobuf.message import Message
 from ..commands import TimeCommands
 from ..devicebase import DeviceBase
 from ..packet import Packet
-from ..pb import pd335_sys_pb2
+from ..pb import pd335_bms_bp_pb2, pd335_sys_pb2
 from ..props import (
     Field,
     ProtobufProps,
@@ -31,6 +31,7 @@ def _flow_is_on(x):
 
 
 pb = proto_attr_mapper(pd335_sys_pb2.DisplayPropertyUpload)
+pb_bms = proto_attr_mapper(pd335_bms_bp_pb2.BMSHeartBeatReport)
 
 
 class _DcChargingMaxField(
@@ -120,6 +121,8 @@ class Device(DeviceBase, ProtobufProps):
     )
     dc_charging_current_max = _DcChargingMaxField(pd335_sys_pb2.PV_CHG_VOL_SPEC_12V)
 
+    cycles = pb_field(pb_bms.cycles)
+
     def __init__(
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
@@ -152,7 +155,13 @@ class Device(DeviceBase, ProtobufProps):
             p.ParseFromString(packet.payload)
             _LOGGER.debug("%s: %s: Parsed data: %r", self.address, self.name, packet)
             # _LOGGER.debug("Delta 3 Parsed Message \n %s", str(p))
+            self.update_from_message(p, reset=True)
+
+            p = pd335_bms_bp_pb2.BMSHeartBeatReport()
+            p.ParseFromString(packet.payload)
             self.update_from_message(p)
+
+            # _LOGGER.debug("Delta 3 BMS Report \n %s", str(p))
             processed = True
         elif (
             packet.src == 0x35

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -171,7 +171,7 @@ class Device(DeviceBase, ProtobufProps):
             and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             if len(packet.payload) == 0:
-                self._time_commands.async_send_all()
+                await self._time_commands.async_send_all()
             processed = True
 
         self.solar_input_power = (

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -134,7 +134,7 @@ class Device(DeviceBase, ProtobufProps):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                self._time_commands.async_send_all()
+                await self._time_commands.async_send_all()
             processed = True
 
         self.solar_lv_power = self._get_solar_power(

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -1,4 +1,12 @@
 import logging
+from dataclasses import dataclass
+
+from custom_components.ef_ble.eflib.props import (
+    ProtobufProps,
+    pb_field,
+    proto_attr_mapper,
+    repeated_pb_field_type,
+)
 
 from ..commands import TimeCommands
 from ..devicebase import AdvertisementData, BLEDevice, DeviceBase
@@ -12,7 +20,20 @@ from ..props import (
 
 _LOGGER = logging.getLogger(__name__)
 
-pb = proto_attr_mapper(yj751_sys_pb2.AppShowHeartbeatReport)
+pb_heartbeat = proto_attr_mapper(yj751_sys_pb2.AppShowHeartbeatReport)
+pb_bp_info = proto_attr_mapper(yj751_sys_pb2.BpInfoReport)
+
+
+@dataclass
+class _BatteryLevel(
+    repeated_pb_field_type(
+        list_field=pb_bp_info.bp_info, value_field=lambda x: x.bp_soc, per_item=True
+    )
+):
+    battery_no: int
+
+    def get_value(self, item: yj751_sys_pb2.BPInfo) -> int | None:
+        return item.bp_soc if item.bp_no == self.battery_no else None
 
 
 class Device(DeviceBase, ProtobufProps):
@@ -21,13 +42,27 @@ class Device(DeviceBase, ProtobufProps):
     SN_PREFIX = b"Y711"
     NAME_PREFIX = "EF-YJ"
 
-    battery_level = pb_field(pb.soc)
+    battery_level = pb_field(pb_heartbeat.soc)
 
-    hv_solar_power = pb_field(pb.in_hv_mppt_pwr, lambda x: round(x, 2))
-    lv_solar_power = pb_field(pb.in_lv_mppt_pwr, lambda x: round(x, 2))
+    lv_solar_power = pb_field(pb_heartbeat.in_lv_mppt_pwr, lambda x: round(x, 2))
+    hv_solar_power = pb_field(pb_heartbeat.in_hv_mppt_pwr, lambda x: round(x, 2))
 
-    input_power = pb_field(pb.watts_in_sum)
-    output_power = pb_field(pb.watts_out_sum)
+    input_power = pb_field(pb_heartbeat.watts_in_sum)
+    output_power = pb_field(pb_heartbeat.watts_out_sum)
+
+    battery_1_battery_level = _BatteryLevel(1)
+    battery_2_battery_level = _BatteryLevel(2)
+    battery_3_battery_level = _BatteryLevel(3)
+    battery_4_battery_level = _BatteryLevel(4)
+    battery_5_battery_level = _BatteryLevel(5)
+
+    ac_l1_1_out_power = pb_field(pb_heartbeat.out_ac_l1_1_pwr)
+    ac_l1_2_out_power = pb_field(pb_heartbeat.out_ac_l1_2_pwr)
+    ac_l2_1_out_power = pb_field(pb_heartbeat.out_ac_l2_1_pwr)
+    ac_l2_2_out_power = pb_field(pb_heartbeat.out_ac_l2_2_pwr)
+    ac_tt_out_power = pb_field(pb_heartbeat.out_ac_tt_pwr)
+    ac_l14_out_power = pb_field(pb_heartbeat.out_ac_l14_pwr)
+    ac_5p8_out_power = pb_field(pb_heartbeat.out_ac_5p8_pwr)
 
     @staticmethod
     def check(sn):
@@ -47,6 +82,7 @@ class Device(DeviceBase, ProtobufProps):
         """Processing the incoming notifications from the device"""
         processed = False
         updated_props: list[str] = []
+        self.reset_updated()
 
         if packet.src == 0x02 and packet.cmdSet == 0x02:
             if packet.cmdId == 0x01:  # Ping
@@ -57,9 +93,22 @@ class Device(DeviceBase, ProtobufProps):
                 _LOGGER.debug(
                     "%s: %s: Parsed data: %r", self.address, self.name, packet
                 )
+                # _LOGGER.debug("DPU AppShowHeartbeatReport: \n %s", str(p))
 
-                self.update_from_message(p, reset=True)
+                self.update_from_message(p)
+                processed = True
+            elif packet.cmdId == 0x04:
+                await self._conn.replyPacket(packet)
 
+                p = yj751_sys_pb2.BpInfoReport()
+                p.ParseFromString(packet.payload)
+                _LOGGER.debug(
+                    "%s: %s: Parsed data: %r", self.address, self.name, packet
+                )
+                # _LOGGER.debug("DPU BpInfoReport: \n %s", str(p))
+
+                self.update_from_message(p)
+                processed = True
         elif packet.src == 0x35 and packet.cmdSet == 0x35 and packet.cmdId == 0x20:
             _LOGGER.debug("%s: %s: Ping received: %r", self.address, self.name, packet)
             processed = True

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -1,21 +1,33 @@
-import asyncio
 import logging
-import time
-import struct
 
-from ..devicebase import DeviceBase, BLEDevice, AdvertisementData
+from ..commands import TimeCommands
+from ..devicebase import AdvertisementData, BLEDevice, DeviceBase
 from ..packet import Packet
 from ..pb import yj751_sys_pb2_v4 as yj751_sys_pb2
-from ..pb import utc_sys_pb2_v4 as utc_sys_pb2
+from ..props import (
+    ProtobufProps,
+    pb_field,
+    proto_attr_mapper,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
+pb = proto_attr_mapper(yj751_sys_pb2.AppShowHeartbeatReport)
 
-class Device(DeviceBase):
+
+class Device(DeviceBase, ProtobufProps):
     """Delta Pro Ultra"""
 
     SN_PREFIX = b"Y711"
     NAME_PREFIX = "EF-YJ"
+
+    battery_level = pb_field(pb.soc)
+
+    hv_solar_power = pb_field(pb.in_hv_mppt_pwr, lambda x: round(x, 2))
+    lv_solar_power = pb_field(pb.in_lv_mppt_pwr)
+
+    input_power = pb_field(pb.watts_in_sum)
+    output_power = pb_field(pb.watts_out_sum)
 
     @staticmethod
     def check(sn):
@@ -25,50 +37,11 @@ class Device(DeviceBase):
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
-
-        # AppShowHeartbeatReport
-
-        # in_hv_mppt_pwr: 62.3074646
-        self._data_hv_solar_power = None
-        # in_lv_mppt_pwr: 0
-        self._data_lv_solar_power = None
-
-        # watts_in_sum: 62
-        self._data_input_power = None
-        # watts_out_sum: 518
-        self._data_output_power = None
-
-        # soc: 62
-        self._data_battery_level = None
+        self._time_commands = TimeCommands(self)
 
     async def packet_parse(self, data: bytes) -> Packet:
         """Need to override because packet payload is xor-encoded by the first byte of seq"""
         return Packet.fromBytes(data, True)
-
-    @property
-    def hv_solar_power(self) -> float | None:
-        """High Voltage solar MPPT input in watts."""
-        return self._data_hv_solar_power
-
-    @property
-    def lv_solar_power(self) -> float | None:
-        """Low Voltage solar MPPT input in watts."""
-        return self._data_lv_solar_power
-
-    @property
-    def input_power(self) -> int | None:
-        """Total inverter input in watts."""
-        return self._data_input_power
-
-    @property
-    def output_power(self) -> int | None:
-        """Total inverter output in watts."""
-        return self._data_output_power
-
-    @property
-    def battery_level(self) -> int | None:
-        """Battery level as a percentage."""
-        return self._data_battery_level
 
     async def data_parse(self, packet: Packet) -> bool:
         """Processing the incoming notifications from the device"""
@@ -85,38 +58,7 @@ class Device(DeviceBase):
                     "%s: %s: Parsed data: %r", self.address, self.name, packet
                 )
 
-                if p.HasField("in_hv_mppt_pwr"):
-                    if self._data_hv_solar_power != p.in_hv_mppt_pwr:
-                        self._data_hv_solar_power = p.in_hv_mppt_pwr
-                        updated_props.append("hv_solar_power")
-                elif self._data_hv_solar_power != 0:
-                    self._data_hv_solar_power = 0
-                    updated_props.append("hv_solar_power")
-
-                if p.HasField("in_lv_mppt_pwr"):
-                    if self._data_lv_solar_power != p.in_lv_mppt_pwr:
-                        self._data_lv_solar_power = p.in_lv_mppt_pwr
-                        updated_props.append("lv_solar_power")
-                elif self._data_lv_solar_power != 0:
-                    self._data_lv_solar_power = 0
-                    updated_props.append("lv_solar_power")
-
-                if p.HasField("watts_in_sum"):
-                    if self._data_input_power != p.watts_in_sum:
-                        self._data_input_power = p.watts_in_sum
-                        updated_props.append("input_power")
-
-                if p.HasField("watts_out_sum"):
-                    if self._data_output_power != p.watts_out_sum:
-                        self._data_output_power = p.watts_out_sum
-                        updated_props.append("output_power")
-
-                if p.HasField("soc"):
-                    if self._data_battery_level != p.soc:
-                        self._data_battery_level = p.soc
-                        updated_props.append("battery_level")
-
-                processed = True
+                self.update_from_message(p, reset=True)
 
         elif packet.src == 0x35 and packet.cmdSet == 0x35 and packet.cmdId == 0x20:
             _LOGGER.debug("%s: %s: Ping received: %r", self.address, self.name, packet)
@@ -130,91 +72,10 @@ class Device(DeviceBase):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                asyncio.create_task(self.sendUtcTime())
-                asyncio.create_task(self.sendRTCRespond())
-                asyncio.create_task(self.sendRTCCheck())
+                await self._time_commands.async_send_all()
             processed = True
 
         for prop_name in updated_props:
             self.update_callback(prop_name)
 
         return processed
-
-    async def sendUtcTime(self):
-        """Sends UTC time as unix timestamp seconds through PB"""
-        _LOGGER.debug("%s: sendUtcTime", self._address)
-
-        utcs = utc_sys_pb2.SysUTCSync()
-        utcs.sys_utc_time = int(time.time())
-        payload = utcs.SerializeToString()
-        packet = Packet(0x21, 0x0B, 0x01, 0x55, payload, 0x01, 0x01, 0x13)
-
-        await self._conn.sendPacket(packet)
-
-    async def sendRTCRespond(self):
-        """Sends RTC timestamp seconds and TZ as respond to device's request"""
-        _LOGGER.debug("%s: sendRTCRespond", self._address)
-
-        # Building payload
-        tz_offset = (
-            (time.timezone if (time.localtime().tm_isdst == 0) else time.altzone)
-            / 60
-            / 60
-            * -1
-        )
-        tz_maj = int(tz_offset)
-        tz_min = int((tz_offset - tz_maj) * 100)
-        time_sec = int(time.time())
-        payload = (
-            struct.pack("<L", time_sec)
-            + struct.pack("<b", tz_maj)
-            + struct.pack("<b", tz_min)
-        )
-
-        # Forming packet
-        packet = Packet(
-            0x21,
-            0x35,
-            0x01,
-            Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME,
-            payload,
-            0x01,
-            0x01,
-            0x03,
-        )
-
-        await self._conn.sendPacket(packet)
-
-    async def sendRTCCheck(self):
-        """Sends command to check RTC of the device"""
-        _LOGGER.debug("%s: sendRTCCheck", self._address)
-
-        # Building payload
-        tz_offset = (
-            (time.timezone if (time.localtime().tm_isdst == 0) else time.altzone)
-            / 60
-            / 60
-            * -1
-        )
-        tz_maj = int(tz_offset)
-        tz_min = int((tz_offset - tz_maj) * 100)
-        time_sec = int(time.time())
-        payload = (
-            struct.pack("<L", time_sec)
-            + struct.pack("<b", tz_maj)
-            + struct.pack("<b", tz_min)
-        )
-
-        # Forming packet
-        packet = Packet(
-            0x21,
-            0x35,
-            0x01,
-            Packet.NET_BLE_COMMAND_CMD_CHECK_RET_TIME,
-            payload,
-            0x01,
-            0x01,
-            0x03,
-        )
-
-        await self._conn.sendPacket(packet)

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -24,7 +24,7 @@ class Device(DeviceBase, ProtobufProps):
     battery_level = pb_field(pb.soc)
 
     hv_solar_power = pb_field(pb.in_hv_mppt_pwr, lambda x: round(x, 2))
-    lv_solar_power = pb_field(pb.in_lv_mppt_pwr)
+    lv_solar_power = pb_field(pb.in_lv_mppt_pwr, lambda x: round(x, 2))
 
     input_power = pb_field(pb.watts_in_sum)
     output_power = pb_field(pb.watts_out_sum)

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -32,14 +32,13 @@ class _StatField(
     repeated_pb_field_type(
         list_field=pb.display_statistics_sum.list_info,
         value_field=lambda x: x.statistics_content,
+        per_item=True,
     )
 ):
     stat: pr705_pb2.STATISTICS_OBJECT
 
-    def process_item(self, value: pr705_pb2.StatisticsRecordItem) -> int | None:
-        return (
-            value.statistics_content if value.statistics_object == self.stat else None
-        )
+    def get_value(self, item: pr705_pb2.StatisticsRecordItem) -> int | None:
+        return item.statistics_content if item.statistics_object == self.stat else None
 
 
 def _out_power(x) -> float:
@@ -135,6 +134,7 @@ class Device(DeviceBase, ProtobufProps):
 
     async def data_parse(self, packet: Packet):
         processed = False
+        self.reset_updated()
 
         if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             p = pr705_pb2.DisplayPropertyUpload()

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -151,7 +151,7 @@ class Device(DeviceBase, ProtobufProps):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                self._time_commands.async_send_all()
+                await self._time_commands.async_send_all()
             processed = True
 
         if self.ac_input_energy is not None and self.dc_input_energy is not None:

--- a/custom_components/ef_ble/eflib/devices/river3_plus.py
+++ b/custom_components/ef_ble/eflib/devices/river3_plus.py
@@ -1,8 +1,7 @@
-from custom_components.ef_ble.eflib.devices import river3
-
 from ..pb import pr705_pb2
 from ..props import pb_field
 from ..props.enums import IntFieldValue
+from . import river3
 
 
 class LedMode(IntFieldValue):

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -1,17 +1,58 @@
-import asyncio
 import logging
-import time
-import struct
+from collections.abc import Sequence
+from dataclasses import dataclass
 
-from ..devicebase import DeviceBase, BLEDevice, AdvertisementData
+from ..commands import TimeCommands
+from ..devicebase import AdvertisementData, BLEDevice, DeviceBase
 from ..packet import Packet
-from ..pb import pd303_pb2_v4 as pd303_pb2
-from ..pb import utc_sys_pb2_v4 as utc_sys_pb2
+from ..pb import pd303_pb2
+from ..props import (
+    Field,
+    ProtobufProps,
+    pb_field,
+    proto_attr_mapper,
+    repeated_pb_field_type,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
+pb_time = proto_attr_mapper(pd303_pb2.ProtoTime)
+pb_push_set = proto_attr_mapper(pd303_pb2.ProtoPushAndSet)
 
-class Device(DeviceBase):
+
+@dataclass
+class CircuitPowerField(
+    repeated_pb_field_type(list_field=pb_time.load_info.hall1_watt)
+):
+    idx: int
+
+    def get_item(self, value: Sequence[float]) -> float | None:
+        return value[self.idx] if len(value) > self.idx else None
+
+
+@dataclass
+class CircuitCurrentField(
+    repeated_pb_field_type(list_field=pb_time.load_info.hall1_curr)
+):
+    idx: int
+
+    def get_item(self, value: Sequence[float]) -> float | None:
+        return round(value[self.idx], 4) if len(value) > self.idx else None
+
+
+@dataclass
+class ChannelPowerField(repeated_pb_field_type(list_field=pb_time.watt_info.ch_watt)):
+    idx: int
+
+    def get_item(self, value: Sequence[float]) -> float | None:
+        return round(value[self.idx], 2) if len(value) > self.idx else None
+
+
+def _errors(error_codes: pd303_pb2.ErrCode):
+    return [e for e in error_codes.err_code if e != b"\x00\x00\x00\x00\x00\x00\x00\x00"]
+
+
+class Device(DeviceBase, ProtobufProps):
     """Smart Home Panel 2"""
 
     SN_PREFIX = b"HD31"
@@ -19,6 +60,45 @@ class Device(DeviceBase):
 
     NUM_OF_CIRCUITS = 12
     NUM_OF_CHANNELS = 3
+
+    battery_level = pb_field(pb_push_set.backup_incre_info.backup_bat_per)
+
+    circuit_power_1 = CircuitPowerField(0)
+    circuit_power_2 = CircuitPowerField(1)
+    circuit_power_3 = CircuitPowerField(2)
+    circuit_power_4 = CircuitPowerField(3)
+    circuit_power_5 = CircuitPowerField(4)
+    circuit_power_6 = CircuitPowerField(5)
+    circuit_power_7 = CircuitPowerField(6)
+    circuit_power_8 = CircuitPowerField(7)
+    circuit_power_9 = CircuitPowerField(8)
+    circuit_power_10 = CircuitPowerField(9)
+    circuit_power_11 = CircuitPowerField(10)
+    circuit_power_12 = CircuitPowerField(11)
+
+    circuit_current_1 = CircuitCurrentField(0)
+    circuit_current_2 = CircuitCurrentField(1)
+    circuit_current_3 = CircuitCurrentField(2)
+    circuit_current_4 = CircuitCurrentField(3)
+    circuit_current_5 = CircuitCurrentField(4)
+    circuit_current_6 = CircuitCurrentField(5)
+    circuit_current_7 = CircuitCurrentField(6)
+    circuit_current_8 = CircuitCurrentField(7)
+    circuit_current_9 = CircuitCurrentField(8)
+    circuit_current_10 = CircuitCurrentField(9)
+    circuit_current_11 = CircuitCurrentField(10)
+    circuit_current_12 = CircuitCurrentField(11)
+
+    channel_power_1 = ChannelPowerField(0)
+    channel_power_2 = ChannelPowerField(1)
+    channel_power_3 = ChannelPowerField(2)
+
+    in_use_power = pb_field(pb_time.watt_info.all_hall_watt)
+    grid_power = pb_field(pb_time.watt_info.grid_watt)
+
+    errors = pb_field(pb_push_set.backup_incre_info.errcode, _errors)
+    error_count = Field[int]()
+    error_happened = Field[bool]()
 
     @staticmethod
     def check(sn):
@@ -28,64 +108,15 @@ class Device(DeviceBase):
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
-
-        self._data_circuit_power = [None] * Device.NUM_OF_CIRCUITS
-        self._data_circuit_current = [None] * Device.NUM_OF_CIRCUITS
-
-        self._data_grid_power = None
-        self._data_in_use_power = None
-
-        self._data_channel_power = [None] * Device.NUM_OF_CHANNELS
-
-        self._data_error_count = 0
-        self._data_battery_level = None
-
-    @property
-    def battery_level(self) -> int | None:
-        """Battery level as a percentage."""
-        return self._data_battery_level
-
-    @battery_level.setter
-    def battery_level(self, value: int) -> None:
-        """Sets Battery level as a percentage and calls callbacks."""
-        if self._data_battery_level != value:
-            self._data_battery_level = value
-            self.update_callback("battery_level")
-
-    @property
-    def channel_power(self) -> list[int | None]:
-        """Backup channels wattage in W."""
-        return self._data_channel_power
-
-    @property
-    def circuit_power(self) -> list[int | None]:
-        """Circuit consuming wattage in W."""
-        return self._data_circuit_power
-
-    @property
-    def circuit_current(self) -> list[float | None]:
-        """Circuit consuming amperage in A."""
-        return self._data_circuit_current
-
-    @property
-    def grid_power(self) -> int | None:
-        """Grid intake wattage in W."""
-        return self._data_grid_power
-
-    @property
-    def in_use_power(self) -> int | None:
-        """In use wattage in W."""
-        return self._data_in_use_power
-
-    @property
-    def error_happened(self) -> bool:
-        """Will return true if error happened during the last update."""
-        return self._data_error_count > 0
+        self._time_commands = TimeCommands(self)
 
     async def data_parse(self, packet: Packet) -> bool:
         """Processing the incoming notifications from the device"""
         processed = False
-        updated_fields = []
+        self.reset_updated()
+
+        prev_error_count = self.error_count
+
         if packet.src == 0x0B and packet.cmdSet == 0x0C:
             if (
                 packet.cmdId == 0x01
@@ -94,39 +125,11 @@ class Device(DeviceBase):
 
                 p = pd303_pb2.ProtoTime()
                 p.ParseFromString(packet.payload)
+                self.update_from_message(p)
+
                 _LOGGER.debug(
                     "%s: %s: Parsed data: %r", self.address, self.name, packet
                 )
-
-                if p.HasField("load_info"):
-                    for i, w in enumerate(p.load_info.hall1_watt):
-                        if self._data_circuit_power[i] != w:
-                            self._data_circuit_power[i] = w
-                            updated_fields.append(f"circuit_power_{i}")
-                    for i, a in enumerate(p.load_info.hall1_curr):
-                        if self._data_circuit_current[i] != a:
-                            self._data_circuit_current[i] = a
-                            updated_fields.append(f"circuit_current_{i}")
-
-                if p.HasField("watt_info"):
-                    wi = p.watt_info
-                    if wi.HasField("grid_watt"):
-                        if self._data_grid_power != wi.grid_watt:
-                            self._data_grid_power = wi.grid_watt
-                            updated_fields.append("grid_power")
-                    elif self._data_grid_power != 0:
-                        self._data_grid_power = 0
-                        updated_fields.append("grid_power")
-
-                    for i, w in enumerate(wi.ch_watt):
-                        if self._data_channel_power[i] != w:
-                            self._data_channel_power[i] = w
-                            updated_fields.append(f"channel_power_{i}")
-
-                    if wi.HasField("all_hall_watt"):
-                        if self._data_in_use_power != wi.all_hall_watt:
-                            self._data_in_use_power = wi.all_hall_watt
-                            updated_fields.append("in_use_power")
 
                 processed = True
 
@@ -135,32 +138,14 @@ class Device(DeviceBase):
 
                 p = pd303_pb2.ProtoPushAndSet()
                 p.ParseFromString(packet.payload)
+                self.update_from_message(p)
+
                 _LOGGER.debug(
                     "%s: %s: Parsed data: %r", self.address, self.name, packet
                 )
 
-                if p.HasField("backup_incre_info"):
-                    info = p.backup_incre_info
-                    if info.HasField("errcode"):
-                        errors = []
-                        for e in info.errcode.err_code:
-                            if e != b"\x00\x00\x00\x00\x00\x00\x00\x00":
-                                errors.append(e)
-                        if self._data_error_count != len(errors):
-                            if len(errors) > self._data_error_count:
-                                _LOGGER.warning(
-                                    "%s: %s: Error happened on device: %s",
-                                    self.address,
-                                    self.name,
-                                    errors,
-                                )
-                            self._data_error_count = len(errors)
-
-                    if info.HasField("backup_bat_per"):
-                        self.battery_level = info.backup_bat_per
-
-                    # TODO: Energy2_info.pv_height_charge_watts
-                    # TODO: Energy2_info.pv_low_charge_watts
+                # TODO: Energy2_info.pv_height_charge_watts
+                # TODO: Energy2_info.pv_low_charge_watts
 
                 processed = True
 
@@ -184,23 +169,37 @@ class Device(DeviceBase):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                asyncio.create_task(self.sendUtcTime())
-                asyncio.create_task(self.sendRTCRespond())
-                asyncio.create_task(self.sendRTCCheck())
+                await self._time_commands.async_send_all()
             processed = True
 
         elif packet.src == 0x0B and packet.cmdSet == 0x01 and packet.cmdId == 0x55:
             # Device reply that it's online and ready
-            asyncio.create_task(self.setConfigFlag(True))
+            await self._conn._add_task(self.set_config_flag(True))
             processed = True
 
-        for prop_name in updated_fields:
-            self.update_callback(prop_name)
+        self.error_count = len(self.errors) if self.errors is not None else None
+
+        if (
+            self.error_count is not None
+            and prev_error_count is not None
+            and self.error_count > prev_error_count
+        ) or (self.error_count is not None and prev_error_count is None):
+            self.error_happened = True
+            _LOGGER.warning(
+                "%s: %s: Error happened on device: %s",
+                self.address,
+                self.name,
+                self.errors,
+            )
+
+        for field_name in self.updated_fields:
+            self.update_callback(field_name)
+            self.update_state(field_name, getattr(self, field_name))
 
         return processed
 
-    async def setConfigFlag(self, enable):
-        """Sends command to enable/disable sending config data from device to the host"""
+    async def set_config_flag(self, enable):
+        """Send command to enable/disable sending config data from device to the host"""
         _LOGGER.debug("%s: setConfigFlag: %s", self._address, enable)
 
         ppas = pd303_pb2.ProtoPushAndSet()
@@ -210,87 +209,8 @@ class Device(DeviceBase):
 
         await self._conn.sendPacket(packet)
 
-    async def sendUtcTime(self):
-        """Sends UTC time as unix timestamp seconds through PB"""
-        _LOGGER.debug("%s: sendUtcTime", self._address)
-
-        utcs = utc_sys_pb2.SysUTCSync()
-        utcs.sys_utc_time = int(time.time())
-        payload = utcs.SerializeToString()
-        packet = Packet(0x21, 0x0B, 0x01, 0x55, payload, 0x01, 0x01, 0x13)
-
-        await self._conn.sendPacket(packet)
-
-    async def sendRTCRespond(self):
-        """Sends RTC timestamp seconds and TZ as respond to device's request"""
-        _LOGGER.debug("%s: sendRTCRespond", self._address)
-
-        # Building payload
-        tz_offset = (
-            (time.timezone if (time.localtime().tm_isdst == 0) else time.altzone)
-            / 60
-            / 60
-            * -1
-        )
-        tz_maj = int(tz_offset)
-        tz_min = int((tz_offset - tz_maj) * 100)
-        time_sec = int(time.time())
-        payload = (
-            struct.pack("<L", time_sec)
-            + struct.pack("<b", tz_maj)
-            + struct.pack("<b", tz_min)
-        )
-
-        # Forming packet
-        packet = Packet(
-            0x21,
-            0x35,
-            0x01,
-            Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME,
-            payload,
-            0x01,
-            0x01,
-            0x03,
-        )
-
-        await self._conn.sendPacket(packet)
-
-    async def sendRTCCheck(self):
-        """Sends command to check RTC of the device"""
-        _LOGGER.debug("%s: sendRTCCheck", self._address)
-
-        # Building payload
-        tz_offset = (
-            (time.timezone if (time.localtime().tm_isdst == 0) else time.altzone)
-            / 60
-            / 60
-            * -1
-        )
-        tz_maj = int(tz_offset)
-        tz_min = int((tz_offset - tz_maj) * 100)
-        time_sec = int(time.time())
-        payload = (
-            struct.pack("<L", time_sec)
-            + struct.pack("<b", tz_maj)
-            + struct.pack("<b", tz_min)
-        )
-
-        # Forming packet
-        packet = Packet(
-            0x21,
-            0x35,
-            0x01,
-            Packet.NET_BLE_COMMAND_CMD_CHECK_RET_TIME,
-            payload,
-            0x01,
-            0x01,
-            0x03,
-        )
-
-        await self._conn.sendPacket(packet)
-
-    async def setCircuitPower(self, circuit_id, enable):
-        """Sends command to power on / off the specific circuit of the panel"""
+    async def set_circuit_power(self, circuit_id, enable):
+        """Send command to power on / off the specific circuit of the panel"""
         _LOGGER.debug(
             "%s: setCircuitPower for %d: %s", self._address, circuit_id, enable
         )
@@ -300,11 +220,9 @@ class Device(DeviceBase):
             ppas.load_incre_info.hall1_incre_info, "ch" + str(circuit_id + 1) + "_sta"
         )
         sta.load_sta = (
-            pd303_pb2.LOAD_CH_STA.LOAD_CH_POWER_ON
-            if enable
-            else pd303_pb2.LOAD_CH_STA.LOAD_CH_POWER_OFF
+            pd303_pb2.LOAD_CH_POWER_ON if enable else pd303_pb2.LOAD_CH_POWER_OFF
         )
-        sta.ctrl_mode = pd303_pb2.CTRL_MODE.RLY_HAND_CTRL_MODE
+        sta.ctrl_mode = pd303_pb2.RLY_HAND_CTRL_MODE
         payload = ppas.SerializeToString()
         packet = Packet(0x21, 0x0B, 0x0C, 0x21, payload, 0x01, 0x01, 0x13)
 

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -27,7 +27,7 @@ class CircuitPowerField(
     idx: int
 
     def get_item(self, value: Sequence[float]) -> float | None:
-        return value[self.idx] if len(value) > self.idx else None
+        return value[self.idx] if value and len(value) > self.idx else None
 
 
 @dataclass
@@ -37,7 +37,7 @@ class CircuitCurrentField(
     idx: int
 
     def get_item(self, value: Sequence[float]) -> float | None:
-        return round(value[self.idx], 4) if len(value) > self.idx else None
+        return round(value[self.idx], 4) if value and len(value) > self.idx else None
 
 
 @dataclass
@@ -45,7 +45,7 @@ class ChannelPowerField(repeated_pb_field_type(list_field=pb_time.watt_info.ch_w
     idx: int
 
     def get_item(self, value: Sequence[float]) -> float | None:
-        return round(value[self.idx], 2) if len(value) > self.idx else None
+        return round(value[self.idx], 2) if value and len(value) > self.idx else None
 
 
 def _errors(error_codes: pd303_pb2.ErrCode):

--- a/custom_components/ef_ble/eflib/props/protobuf_field.py
+++ b/custom_components/ef_ble/eflib/props/protobuf_field.py
@@ -10,8 +10,9 @@ if TYPE_CHECKING:
 
 
 class _ProtoAttr:
-    def __init__(self, name: str):
+    def __init__(self, message_type: type[Message], name: str):
         self.attrs = [name]
+        self.message_type = message_type
 
     def __getattr__(self, name):
         self.attrs.append(name)
@@ -34,7 +35,7 @@ class _ProtoAttrAccessor[T1: Message]:
             raise AttributeError(
                 f"{self.message_type} does not contain field named '{name}'"
             )
-        return _ProtoAttr(name)
+        return _ProtoAttr(self.message_type, name)
 
 
 def proto_attr_mapper[T: Message](pb: type[T]) -> type[T]:

--- a/custom_components/ef_ble/eflib/props/protobuf_props.py
+++ b/custom_components/ef_ble/eflib/props/protobuf_props.py
@@ -1,4 +1,3 @@
-import itertools
 from collections import defaultdict
 from functools import cached_property
 
@@ -85,5 +84,5 @@ class ProtobufProps(UpdatableProps):
             if field_list is None:
                 continue
 
-            for item, field in itertools.product(field_list, repeated_fields):
-                setattr(self, field.public_name, item)
+            for field in repeated_fields:
+                setattr(self, field.public_name, field_list)

--- a/custom_components/ef_ble/eflib/props/protobuf_props.py
+++ b/custom_components/ef_ble/eflib/props/protobuf_props.py
@@ -1,5 +1,6 @@
 import itertools
 from collections import defaultdict
+from functools import cached_property
 
 from google.protobuf.message import Message
 
@@ -35,21 +36,36 @@ class ProtobufProps(UpdatableProps):
 
     """
 
-    _repeated_field_map: dict[str, list[ProtobufRepeatedField]] = defaultdict(list)
+    _repeated_field_map: dict[type[Message], dict[str, list[ProtobufRepeatedField]]] = (
+        defaultdict(lambda: defaultdict(list))
+    )
 
     @classmethod
-    def add_repeated_field(  # noqa: D102 - internal method
-        cls, repeated_field: ProtobufRepeatedField
-    ):
+    def add_repeated_field(cls, repeated_field: ProtobufRepeatedField):
         updated_field_map = cls._repeated_field_map.copy()
-        updated_field_map[repeated_field.pb_field.name].append(repeated_field)
+        updated_field_map[repeated_field.pb_field.message_type][
+            repeated_field.pb_field.name
+        ].append(repeated_field)
         cls._repeated_field_map = updated_field_map
 
-    def reset_updated(self):  # noqa: D102 - inherited
+    @cached_property
+    def message_to_field(self) -> dict[type[Message], list[ProtobufField]]:
+        field_map = defaultdict(list)
+        for field in self._fields:
+            if isinstance(field, ProtobufRepeatedField):
+                continue
+
+            if not isinstance(field, ProtobufField):
+                continue
+
+            field_map[field.pb_field.message_type].append(field)
+        return field_map
+
+    def reset_updated(self):
         self._processed_fields = []
         return super().reset_updated()
 
-    def update_from_message(self, message: Message):
+    def update_from_message(self, message: Message, reset: bool = False):
         """
         Update defined fields values from provided message
 
@@ -58,16 +74,13 @@ class ProtobufProps(UpdatableProps):
         message
             Protocol buffer message to update fields from
         """
-        self.reset_updated()
+        if reset:
+            self.reset_updated()
 
-        for field in self._fields:
-            if isinstance(field, ProtobufRepeatedField):
-                continue
+        for field in self.message_to_field[type(message)]:
+            setattr(self, field.public_name, message)
 
-            if isinstance(field, ProtobufField):
-                setattr(self, field.public_name, message)
-
-        for repeated_fields in self._repeated_field_map.values():
+        for repeated_fields in self._repeated_field_map[type(message)].values():
             field_list = repeated_fields[0].get_list(message)
             if field_list is None:
                 continue

--- a/custom_components/ef_ble/eflib/props/repeated_protobuf_field.py
+++ b/custom_components/ef_ble/eflib/props/repeated_protobuf_field.py
@@ -47,8 +47,12 @@ class ProtobufRepeatedField[T_ITEM, T_OUT](ProtobufField[T_OUT]):
         if not list_attrs:
             raise ValueError(f"Received accessor with no attributes: '{self.pb_field}'")
 
-        if not value.HasField(list_attrs[0]):
-            return []
+        try:
+            if not value.HasField(list_attrs[0]):
+                return []
+        except ValueError as e:
+            if "not have presence" not in str(e):
+                return []
 
         for attr in list_attrs:
             value = getattr(value, attr)

--- a/custom_components/ef_ble/eflib/props/repeated_protobuf_field.py
+++ b/custom_components/ef_ble/eflib/props/repeated_protobuf_field.py
@@ -1,7 +1,15 @@
 import abc
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, cast, dataclass_transform
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    cast,
+    dataclass_transform,
+    overload,
+)
 
 from google.protobuf.message import Message
 
@@ -48,28 +56,61 @@ class ProtobufRepeatedField[T_ITEM, T_OUT](ProtobufField[T_OUT]):
         return cast(Sequence[Message], value)
 
     @abc.abstractmethod
-    def process_item(self, value: T_ITEM) -> T_OUT | None:
+    def get_item(self, value: Sequence[T_ITEM]) -> T_OUT | None:
         """Process item from sequence returned from `get_list`"""
 
     def __set_name__(self, owner: type["ProtobufProps"], name: str):
         super().__set_name__(owner, name)
         owner.add_repeated_field(self)
 
-    def __set__(self, instance: "ProtobufProps", value: Any):
-        if (value := self.process_item(value)) is None:
+    def __set__(self, instance: "ProtobufProps", value: Sequence[Any]):
+        if (item := self.get_item(value)) is None:
             return
 
-        self._set_value(instance, value)
+        self._set_value(instance, item)
+
+
+class ProtobufCompositeRepeatedField[T_ITEM, T_OUT](
+    ProtobufRepeatedField[T_ITEM, T_OUT]
+):
+    def get_item(self, value: Sequence[T_ITEM]) -> T_OUT | None:
+        for item in value:
+            if (result := self.get_value(item)) is not None:
+                return result
+        return None
+
+    @abc.abstractmethod
+    def get_value(self, item: T_ITEM) -> T_OUT | None: ...
 
 
 def _raise[T_IN](v: T_IN, exc: type[Exception]) -> T_IN:
     raise exc
 
 
+@overload
 def repeated_pb_field_type[T_ITEM, T_OUT](
     list_field: Sequence[T_ITEM],
     value_field: Callable[[T_ITEM], T_OUT] = lambda x: _raise(x, NotImplementedError),
-) -> type[ProtobufRepeatedField[T_ITEM, T_OUT]]:
+    per_item: Literal[True] = True,
+) -> type[ProtobufCompositeRepeatedField[T_ITEM, T_OUT]]: ...
+
+
+@overload
+def repeated_pb_field_type[T_ITEM, T_OUT](
+    list_field: Sequence[T_ITEM],
+    value_field: Callable[[T_ITEM], T_OUT] = lambda x: _raise(x, NotImplementedError),
+    per_item: Literal[False] = False,
+) -> type[ProtobufRepeatedField[T_ITEM, T_OUT]]: ...
+
+
+def repeated_pb_field_type[T_ITEM, T_OUT](
+    list_field: Sequence[T_ITEM],
+    value_field: Callable[[T_ITEM], T_OUT] = lambda x: _raise(x, NotImplementedError),
+    per_item: bool = False,
+) -> (
+    type[ProtobufRepeatedField[T_ITEM, T_OUT]]
+    | type[ProtobufCompositeRepeatedField[T_ITEM, T_OUT]]
+):
     """
     Create repeated field type from protobuf accessor repesenting sequence type
 
@@ -91,19 +132,22 @@ def repeated_pb_field_type[T_ITEM, T_OUT](
             value_field=lambda x: x.value,
         )
     ):
-        def process_item(self, value: some_pb2.RecordType):
-            return x.value
+        def get_item(self, value: Sequence[some_pb2.RecordType]):
+            return value[1].value
     ```
 
     Returns
     -------
         Type of repeated protobuf message
     """
+    if not per_item:
 
-    class CustomRepeatedField(ProtobufRepeatedField[T_ITEM, T_OUT]):
+        class CustomRepeatedField(ProtobufRepeatedField[T_ITEM, T_OUT]):
+            pb_field = list_field
+
+        return CustomRepeatedField
+
+    class CustomPerItemRepeatedField(ProtobufCompositeRepeatedField[T_ITEM, T_OUT]):
         pb_field = list_field
 
-        def process_item(self, value: T_ITEM) -> T_OUT | None:
-            return value_field(value)
-
-    return CustomRepeatedField
+    return CustomPerItemRepeatedField

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -1,5 +1,109 @@
 {
     "entity": {
+        "sensor": {
+            "input_power": {
+                "default": "mdi:home-lightning-bolt-outline"
+            },
+            "output_power": {
+                "default": "mdi:home-lightning-bolt-outline"
+            },
+            "ac_input_power": {
+                "default": "mdi:current-ac"
+            },
+            "ac_output_power": {
+                "default": "mdi:current-ac"
+            },
+            "ac_input_energy": {
+                "default": "mdi:current-ac"
+            },
+            "ac_output_energy": {
+                "default": "mdi:current-ac"
+            },
+            "dc_input_power": {
+                "default": "mdi:current-dc"
+            },
+            "dc_input_energy": {
+                "default": "mdi:current-dc"
+            },
+            "dc12v_output_power": {
+                "default": "mdi:current-dc"
+            },
+            "dc12v_output_energy": {
+                "default": "mdi:current-dc"
+            },
+            "usbc_output_power": {
+                "default": "mdi:usb-c-port"
+            },
+            "usbc_output_energy": {
+                "default": "mdi:usb-c-port"
+            },
+            "usba_output_power": {
+                "default": "mdi:usb-port"
+            },
+            "usba_output_energy": {
+                "default": "mdi:usb-port"
+            },
+            "usbc2_output_power": {
+                "default": "mdi:usb-c-port"
+            },
+            "usba2_output_power": {
+                "default": "mdi:usb-port"
+            },
+            "dc_port_input_power": {
+                "default": "mdi:current-dc"
+            },
+            "dc_port_input_power_2": {
+                "default": "mdi:current-dc"
+            },
+            "dc_port_state": {
+                "default": "mdi:current-dc"
+            },
+            "dc_port_2_state": {
+                "default": "mdi:current-dc"
+            },
+            "input_power_solar": {
+                "default": "mdi:solar-power-variant-outline"
+            },
+            "input_power_solar_2": {
+                "default": "mdi:solar-power-variant-outline"
+            },
+            "ac_lv_output_power": {
+                "default": "mdi:current-ac"
+            },
+            "ac_hv_output_power": {
+                "default": "mdi:current-ac"
+            },
+            "input_power_solar_lv": {
+                "default": "mdi:solar-power-variant-outline"
+            },
+            "input_power_solar_hv": {
+                "default": "mdi:solar-power-variant-outline"
+            },
+            "dc_lv_input_power": {
+                "default": "mdi:current-dc"
+            },
+            "dc_hv_input_power": {
+                "default": "mdi:current-dc"
+            },
+            "dc_lv_state": {
+                "default": "mdi:current-dc"
+            },
+            "dc_hv_state": {
+                "default": "mdi:current-dc"
+            },
+            "grid_power": {
+                "default": "mdi:transmission-tower"
+            },
+            "in_use_power": {
+                "default": "mdi:home-lightning-bolt-outline"
+            },
+            "lv_solar_power": {
+                "default": "mdi:solar-panel"
+            },
+            "hv_solar_power": {
+                "default": "mdi:solar-panel-large"
+            }
+        },
         "switch": {
             "battery_sync": {
                 "default": "mdi:battery-sync",
@@ -9,5 +113,4 @@
             }
         }
     }
-    
 }

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -82,7 +82,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
             state_class=SensorStateClass.MEASUREMENT,
             suggested_display_precision=2,
             translation_key="circuit_power",
-            translation_placeholders={"index": f"{i}"},
+            translation_placeholders={"index": f"{i:02}"},
         )
         for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
     },
@@ -94,6 +94,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
             suggested_display_precision=2,
             entity_registry_enabled_default=False,
             translation_key="circuit_current",
+            translation_placeholders={"index": f"{i:02}"},
         )
         for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
     },
@@ -104,7 +105,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
             native_unit_of_measurement=UnitOfPower.WATT,
             suggested_display_precision=2,
             translation_key="channel_power",
-            translation_placeholders={"index": f"{i}"},
+            translation_placeholders={"index": f"{i:02}"},
         )
         for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1)
     },

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -25,35 +25,29 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     # Common
     "battery_level": SensorEntityDescription(
         key="battery_level",
-        name="Battery Level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "battery_level_main": SensorEntityDescription(
         key="battery_level_main",
-        name="Main Battery Level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "input_power": SensorEntityDescription(
         key="input_power",
-        name="Input Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        icon="mdi:home-lightning-bolt-outline",
     ),
     "output_power": SensorEntityDescription(
         key="output_power",
-        name="Output Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        icon="mdi:home-lightning-bolt-outline",
     ),
     # SHP2
     "grid_power": SensorEntityDescription(
@@ -63,7 +57,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        icon="mdi:transmission-tower",
     ),
     "in_use_power": SensorEntityDescription(
         key="in_use_power",
@@ -72,7 +65,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        icon="mdi:home-lightning-bolt-outline",
     ),
     # DPU
     "lv_solar_power": SensorEntityDescription(
@@ -82,7 +74,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        icon="mdi:solar-panel",
     ),
     "hv_solar_power": SensorEntityDescription(
         key="hv_solar_power",
@@ -91,12 +82,10 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        icon="mdi:solar-panel-large",
     ),
     # River 3, Delta 3
     "input_energy": SensorEntityDescription(
         key="input_energy",
-        name="Input Energy Total",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -105,7 +94,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "output_energy": SensorEntityDescription(
         key="output_energy",
-        name="Output Energy Total",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -114,8 +102,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "ac_input_power": SensorEntityDescription(
         key="ac_input_power",
-        name="AC Input Power",
-        icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -123,8 +109,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "ac_output_power": SensorEntityDescription(
         key="ac_output_power",
-        name="AC Output Power",
-        icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -132,8 +116,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "ac_input_energy": SensorEntityDescription(
         key="ac_input_energy",
-        name="AC Input Energy",
-        icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -142,8 +124,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "ac_output_energy": SensorEntityDescription(
         key="ac_output_energy",
-        name="AC Output Energy",
-        icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -152,7 +132,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_input_power": SensorEntityDescription(
         key="dc_input_power",
-        name="DC Input Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -160,8 +139,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_input_energy": SensorEntityDescription(
         key="dc_input_energy",
-        name="DC Input Energy",
-        icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -170,8 +147,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc12v_output_power": SensorEntityDescription(
         key="dc12v_output_power",
-        name="DC 12V Output Power",
-        icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -179,8 +154,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc12v_output_energy": SensorEntityDescription(
         key="dc12v_output_energy",
-        name="DC 12V Output Energy",
-        icon="mdi:current-dc",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -189,16 +162,12 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "usbc_output_power": SensorEntityDescription(
         key="usbc_output_power",
-        name="USB C Output Power",
-        icon="mdi:usb-c-port",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "usbc_output_energy": SensorEntityDescription(
         key="usbc_output_energy",
-        name="USB C Output Energy",
-        icon="mdi:usb-c-port",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -207,16 +176,12 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "usba_output_power": SensorEntityDescription(
         key="usba_output_power",
-        name="USB A Output Power",
-        icon="mdi:usb-port",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "usba_output_energy": SensorEntityDescription(
         key="usba_output_energy",
-        name="USB A Output Energy",
-        icon="mdi:usb-port",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -225,23 +190,18 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "usbc2_output_power": SensorEntityDescription(
         key="usbc2_output_power",
-        name="USB C (2) Output Power",
-        icon="mdi:usb-c-port",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "usba2_output_power": SensorEntityDescription(
         key="usba2_output_power",
-        name="USB A (2) Output Power",
-        icon="mdi:usb-port",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "battery_input_power": SensorEntityDescription(
         key="battery_input_power",
-        name="Battery Input Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -249,15 +209,13 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "battery_output_power": SensorEntityDescription(
         key="battery_output_power",
-        name="Battery Output Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
     "cell_temperature": SensorEntityDescription(
-        key="temperature",
-        name="Cell Temperature",
+        key="cell_temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -265,8 +223,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_port_input_power": SensorEntityDescription(
         key="dc_port_input_power",
-        name="DC Port Input Power",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -274,29 +230,21 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_port_2_input_power": SensorEntityDescription(
         key="dc_port_input_power_2",
-        name="DC Port (2) Input Power",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_display_precision=2,
     ),
     "dc_port_state": SensorEntityDescription(
-        key="dc_port_1_state",
-        name="DC Input Port State",
-        icon="mdi:current-dc",
+        key="dc_port_state",
         device_class=SensorDeviceClass.ENUM,
     ),
     "dc_port_2_state": SensorEntityDescription(
         key="dc_port_2_state",
-        name="DC Input Port (2) State ",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.ENUM,
     ),
     "solar_input_power": SensorEntityDescription(
         key="input_power_solar",
-        name="Solar Power",
-        icon="mdi:solar-power-variant-outline",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -304,8 +252,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "solar_input_power_2": SensorEntityDescription(
         key="input_power_solar_2",
-        name="Solar Power (2)",
-        icon="mdi:solar-power-variant-outline",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -314,8 +260,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     # DP3
     "ac_lv_output_power": SensorEntityDescription(
         key="ac_lv_output_power",
-        name="AC LV Output Power",
-        icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -323,8 +267,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "ac_hv_output_power": SensorEntityDescription(
         key="ac_hv_output_power",
-        name="AC HV Output Power",
-        icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -332,8 +274,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "solar_lv_power": SensorEntityDescription(
         key="input_power_solar_lv",
-        name="LV Solar Power",
-        icon="mdi:solar-power-variant-outline",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -341,8 +281,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "solar_hv_power": SensorEntityDescription(
         key="input_power_solar_hv",
-        name="HV Solar Power",
-        icon="mdi:solar-power-variant-outline",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -350,8 +288,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_lv_input_power": SensorEntityDescription(
         key="dc_lv_input_power",
-        name="LV DC Port Input Power",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -359,8 +295,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_hv_input_power": SensorEntityDescription(
         key="dc_hv_input_power",
-        name="LV DC Port Input Power",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -368,14 +302,10 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "dc_lv_state": SensorEntityDescription(
         key="dc_lv_state",
-        name="LV DC Input Port State",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.ENUM,
     ),
     "dc_hv_state": SensorEntityDescription(
         key="dc_hv_state",
-        name="HV DC Input Port State",
-        icon="mdi:current-dc",
         device_class=SensorDeviceClass.ENUM,
     ),
 }
@@ -422,6 +352,7 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
 
         if sensor in SENSOR_TYPES:
             self.entity_description = SENSOR_TYPES[sensor]
+            self._attr_translation_key = self.entity_description.key
         else:
             self._attr_state_class = SensorStateClass.MEASUREMENT
 

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -19,9 +19,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.ef_ble.eflib import DeviceBase
-
 from . import DeviceConfigEntry
+from .eflib import DeviceBase
+from .eflib.devices import shp2
 from .entity import EcoflowEntity
 
 
@@ -62,7 +62,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     # SHP2
     "grid_power": SensorEntityDescription(
         key="grid_power",
-        name="Grid Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -70,16 +69,48 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "in_use_power": SensorEntityDescription(
         key="in_use_power",
-        name="In Use Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
+    **{
+        f"circuit_power_{i}": SensorEntityDescription(
+            key=f"circuit_power_{i}",
+            device_class=SensorDeviceClass.POWER,
+            native_unit_of_measurement=UnitOfPower.WATT,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=2,
+            translation_key="circuit_power",
+            translation_placeholders={"index": f"{i}"},
+        )
+        for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
+    },
+    **{
+        f"circuit_current_{i}": SensorEntityDescription(
+            key=f"circuit_current_{i}",
+            device_class=SensorDeviceClass.CURRENT,
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            suggested_display_precision=2,
+            entity_registry_enabled_default=False,
+            translation_key="circuit_current",
+        )
+        for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
+    },
+    **{
+        f"channel_power_{i}": SensorEntityDescription(
+            key=f"channel_power_{i}",
+            device_class=SensorDeviceClass.POWER,
+            native_unit_of_measurement=UnitOfPower.WATT,
+            suggested_display_precision=2,
+            translation_key="channel_power",
+            translation_placeholders={"index": f"{i}"},
+        )
+        for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1)
+    },
     # DPU
     "lv_solar_power": SensorEntityDescription(
         key="lv_solar_power",
-        name="LV Solar Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -87,7 +118,6 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     ),
     "hv_solar_power": SensorEntityDescription(
         key="hv_solar_power",
-        name="HV Solar Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -335,17 +365,6 @@ async def async_setup_entry(
         if hasattr(device, sensor)
     ]
 
-    # SHP2 sensors
-    if hasattr(device, "circuit_power"):
-        for i in range(len(device.circuit_power)):
-            new_sensors.append(CircuitPowerSensor(device, i))
-    if hasattr(device, "circuit_current"):
-        for i in range(len(device.circuit_current)):
-            new_sensors.append(CircuitCurrentSensor(device, i))
-    if hasattr(device, "channel_power"):
-        for i in range(len(device.channel_power)):
-            new_sensors.append(ChannelPowerSensor(device, i))
-
     if new_sensors:
         async_add_entities(new_sensors)
 
@@ -362,9 +381,8 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
 
         if sensor in SENSOR_TYPES:
             self.entity_description = SENSOR_TYPES[sensor]
-            self._attr_translation_key = self.entity_description.key
-        else:
-            self._attr_state_class = SensorStateClass.MEASUREMENT
+            if self.entity_description.translation_key is None:
+                self._attr_translation_key = self.entity_description.key
 
         self._attribute_fields = (
             self.entity_description.state_attribute_fields
@@ -395,67 +413,3 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
     async def async_will_remove_from_hass(self):
         """Entity being removed from hass."""
         self._device.remove_callback(self.async_write_ha_state, self._sensor)
-
-
-class CircuitPowerSensor(EcoflowSensor):
-    """Represents circuit consumed wattage."""
-
-    device_class = SensorDeviceClass.POWER
-    _attr_native_unit_of_measurement = UnitOfPower.WATT
-    _attr_suggested_display_precision = 2
-
-    def __init__(self, device, index):
-        """Initialize the sensor."""
-        super().__init__(device, f"circuit_power_{index}")
-
-        self._attr_unique_id = f"{self._device.name}_circuit_power_{index + 1}"
-        self._attr_name = f"Circuit Power {index + 1:02d}"
-        self._index = index
-
-    @property
-    def native_value(self) -> float:
-        """Return the value of the sensor."""
-        return self._device.circuit_power[self._index]
-
-
-class CircuitCurrentSensor(EcoflowSensor):
-    """Represents circuit consumed amperage."""
-
-    device_class = SensorDeviceClass.CURRENT
-    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
-    _attr_suggested_display_precision = 2
-    _attr_entity_registry_enabled_default = False
-
-    def __init__(self, device, index):
-        """Initialize the sensor."""
-        super().__init__(device, f"circuit_current_{index}")
-
-        self._attr_unique_id = f"{self._device.name}_circuit_current_{index + 1}"
-        self._attr_name = f"Circuit Current {index + 1:02d}"
-        self._index = index
-
-    @property
-    def native_value(self) -> float:
-        """Return the value of the sensor."""
-        return self._device.circuit_current[self._index]
-
-
-class ChannelPowerSensor(EcoflowSensor):
-    """Represents backup channel wattage."""
-
-    device_class = SensorDeviceClass.POWER
-    _attr_native_unit_of_measurement = UnitOfPower.WATT
-    _attr_suggested_display_precision = 2
-
-    def __init__(self, device, index):
-        """Initialize the sensor."""
-        super().__init__(device, f"channel_power_{index}")
-
-        self._attr_unique_id = f"{self._device.name}_channel_power_{index + 1}"
-        self._attr_name = f"Channel Power {index + 1}"
-        self._index = index
-
-    @property
-    def native_value(self) -> float:
-        """Return the value of the sensor."""
-        return self._device.channel_power[self._index]

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -1,5 +1,8 @@
 """EcoFlow BLE sensor"""
 
+from dataclasses import dataclass, field
+from typing import Any
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -21,13 +24,20 @@ from custom_components.ef_ble.eflib import DeviceBase
 from . import DeviceConfigEntry
 from .entity import EcoflowEntity
 
+
+@dataclass(frozen=True, kw_only=True)
+class EcoflowSensorEntityDescription(SensorEntityDescription):
+    state_attribute_fields: list[str] = field(default_factory=list)
+
+
 SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     # Common
-    "battery_level": SensorEntityDescription(
+    "battery_level": EcoflowSensorEntityDescription(
         key="battery_level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        state_attribute_fields=["cycles"],
     ),
     "battery_level_main": SensorEntityDescription(
         key="battery_level_main",
@@ -356,10 +366,27 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
         else:
             self._attr_state_class = SensorStateClass.MEASUREMENT
 
+        self._attribute_fields = (
+            self.entity_description.state_attribute_fields
+            if isinstance(self.entity_description, EcoflowSensorEntityDescription)
+            else []
+        )
+
     @property
     def native_value(self):
         """Return the value of the sensor."""
         return getattr(self._device, self._sensor, None)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self._attribute_fields:
+            return {}
+
+        return {
+            field_name: getattr(self._device, field_name)
+            for field_name in self._attribute_fields
+            if hasattr(self._device, field_name)
+        }
 
     async def async_added_to_hass(self):
         """Run when this Entity has been added to HA."""

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -71,6 +71,27 @@
       "output_power": {
         "name": "Output Power"
       },
+      "grid_power": {
+        "name": "Grid Power"
+      },
+      "in_use_power": {
+        "name": "In Use Power"
+      },
+      "lv_solar_power": {
+        "name": "LV Solar Power"
+      },
+      "hv_solar_power": {
+        "name": "HV Solar Power"
+      },
+      "circuit_power": {
+        "name": "Circuit Power {index}"
+      },
+      "circuit_current": {
+        "name": "Circuit Current {index}"
+      },
+      "channel_power": {
+        "name": "Channel Power {index}"
+      },
       "input_energy": {
         "name": "Input Energy Total"
       },

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -62,6 +62,9 @@
       "battery_level": {
         "name": "Battery Level"
       },
+      "additional_battery_level": {
+        "name": "Battery {index} Level"
+      },
       "battery_level_main": {
         "name": "Main Battery Level"
       },
@@ -77,11 +80,14 @@
       "in_use_power": {
         "name": "In Use Power"
       },
-      "lv_solar_power": {
-        "name": "LV Solar Power"
+      "port_voltage": {
+        "name": "{name} Voltage"
       },
-      "hv_solar_power": {
-        "name": "HV Solar Power"
+      "port_current": {
+        "name": "{name} Current"
+      },
+      "port_power": {
+        "name": "{name} Power"
       },
       "circuit_power": {
         "name": "Circuit Power {index}"

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -19,41 +19,162 @@
     },
     "step": {
       "bluetooth_confirm": {
-          "title": "Discovered Device Config",
-          "data": {
-            "user_id": "Ecoflow User ID",
-            "address": "BLE Device"
-          },
-          "sections": {
-            "login": {
-              "name": "Ecoflow Login (skip if you already have user id)",
-              "data": {
-                "email": "Email",
-                "password": "Password"
-              }
+        "title": "Discovered Device Config",
+        "data": {
+          "user_id": "Ecoflow User ID",
+          "address": "BLE Device"
+        },
+        "sections": {
+          "login": {
+            "name": "Ecoflow Login (skip if you already have user id)",
+            "data": {
+              "email": "Email",
+              "password": "Password"
             }
           }
+        }
       },
       "user": {
-          "title": "Add Ecoflow Device",
-          "data": {
-            "user_id": "Ecoflow User ID",
-            "address": "BLE Device"
-          },
-          "sections": {
-            "login": {
-              "name": "Ecoflow Login (skip if you already have user id)",
-              "data": {
-                "email": "Email",
-                "password": "Password"
-              }
+        "title": "Add Ecoflow Device",
+        "data": {
+          "user_id": "Ecoflow User ID",
+          "address": "BLE Device"
+        },
+        "sections": {
+          "login": {
+            "name": "Ecoflow Login (skip if you already have user id)",
+            "data": {
+              "email": "Email",
+              "password": "Password"
             }
           }
+        }
       },
       "reconfigure": {
         "data": {
           "user_id": "Ecoflow User ID"
         }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "battery_level": {
+        "name": "Battery Level"
+      },
+      "battery_level_main": {
+        "name": "Main Battery Level"
+      },
+      "input_power": {
+        "name": "Input Power"
+      },
+      "output_power": {
+        "name": "Output Power"
+      },
+      "input_energy": {
+        "name": "Input Energy Total"
+      },
+      "output_energy": {
+        "name": "Output Energy Total"
+      },
+      "ac_input_power": {
+        "name": "AC Input Power"
+      },
+      "ac_output_power": {
+        "name": "AC Output Power"
+      },
+      "ac_input_energy": {
+        "name": "AC Input Energy"
+      },
+      "ac_output_energy": {
+        "name": "AC Output Energy"
+      },
+      "dc_input_power": {
+        "name": "DC Input Power"
+      },
+      "dc_input_energy": {
+        "name": "DC Input Energy"
+      },
+      "dc12v_output_power": {
+        "name": "DC 12V Output Power"
+      },
+      "dc12v_output_energy": {
+        "name": "DC 12V Output Energy"
+      },
+      "usbc_output_power": {
+        "name": "USB C Output Power"
+      },
+      "usbc_output_energy": {
+        "name": "USB C Output Energy"
+      },
+      "usba_output_power": {
+        "name": "USB A Output Power"
+      },
+      "usba_output_energy": {
+        "name": "USB A Output Energy"
+      },
+      "usbc2_output_power": {
+        "name": "USB C (2) Output Power"
+      },
+      "usbc2_output_energy": {
+        "name": "USB C (2) Output Energy"
+      },
+      "usba2_output_power": {
+        "name": "USB A (2) Output Power"
+      },
+      "usba2_output_energy": {
+        "name": "USB A (2) Output Energy"
+      },
+      "battery_input_power": {
+        "name": "Battery Input Power"
+      },
+      "battery_output_power": {
+        "name": "Battery Output Power"
+      },
+      "cell_temperature": {
+        "name": "Cell Temperature"
+      },
+      "dc_port_input_power": {
+        "name": "DC Port Input Power"
+      },
+      "dc_port_input_power_2": {
+        "name": "DC Port (2) Input Power"
+      },
+      "dc_port_state": {
+        "name": "DC Input Port State"
+      },
+      "dc_port_2_state": {
+        "name": "DC Input Port (2) State"
+      },
+      "input_power_solar": {
+        "name": "Solar Power"
+      },
+      "input_power_solar_2": {
+        "name": "Solar Power (2)"
+      },
+      "ac_lv_output_power": {
+        "name": "AC LV Output Power"
+      },
+      "ac_hv_output_power": {
+        "name": "AC HV Output Power"
+      },
+      "input_power_solar_lv": {
+        "name": "LV Solar Power"
+      },
+      "input_power_solar_hv": {
+        "name": "HV Solar Power"
+      },
+      "dc_lv_input_power": {
+        "name": "LV DC Port Input Power"
+      },
+      "dc_hv_input_power": {
+        "name": "LV DC Port Input Power"
+      },
+      "dc_lv_state": {
+        "name": "LV DC Input Port State"
+      },
+      "dc_hv_state": {
+        "name": "HV DC Input Port State"
       }
     }
   }


### PR DESCRIPTION
This PR adds a way to use multiple messages types for pb_fields and uses pb_field defs from latest devices for DPU and SHP2 making it quite easy to add new fields. It also moves all sensor names and icons to translation jsons.