### PR TITLE
Add options to control logging output

### DIFF
--- a/custom_components/ef_ble/const.py
+++ b/custom_components/ef_ble/const.py
@@ -5,3 +5,11 @@ MANUFACTURER = "EcoFlow"
 
 CONF_USER_ID = "user_id"
 CONF_UPDATE_PERIOD = "update_period"
+
+CONF_LOG_MASKED = "log_masked"
+CONF_LOG_PACKETS = "log_packets"
+CONF_LOG_ENCRYPTED_PAYLOADS = "log_encrypted_payloads"
+CONF_LOG_PAYLOADS = "log_payloads"
+CONF_LOG_MESSAGES = "log_messages"
+CONF_LOG_CONNECTION = "log_connection"
+CONF_LOG_BLEAK = "log_bleak"

--- a/custom_components/ef_ble/eflib/commands.py
+++ b/custom_components/ef_ble/eflib/commands.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import struct
 import time
@@ -94,7 +93,7 @@ class TimeCommands:
 
         await self.device._conn.sendPacket(packet)
 
-    async def async_send_all(self):
-        await self.device._conn._add_task(asyncio.create_task(self.sendUtcTime()))
-        await self.device._conn._add_task(asyncio.create_task(self.sendRTCRespond()))
-        await self.device._conn._add_task(asyncio.create_task(self.sendRTCCheck()))
+    def async_send_all(self):
+        self.device._conn._add_task(self.sendUtcTime())
+        self.device._conn._add_task(self.sendRTCRespond())
+        self.device._conn._add_task(self.sendRTCCheck())

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -1,4 +1,4 @@
-import logging
+import abc
 import time
 from collections import defaultdict
 from collections.abc import Callable
@@ -9,9 +9,8 @@ from bleak.backends.scanner import AdvertisementData
 from bleak_retry_connector import MAX_CONNECT_ATTEMPTS
 
 from .connection import Connection
+from .logging_util import DeviceLogger, LogOptions
 from .packet import Packet
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class DeviceBase:
@@ -23,17 +22,20 @@ class DeviceBase:
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         self._sn = sn
-        _LOGGER.debug(
-            "%s: Creating new device: %s (%s)",
-            ble_dev.address,
-            self.device,
-            sn,
-        )
-        self._ble_dev = ble_dev
-        self._address = ble_dev.address
         # We can't use advertisement name here - it's prone to change to "Ecoflow-dev"
         self._name = self.NAME_PREFIX + self._sn[-4:]
         self._name_by_user = self._name
+        self._ble_dev = ble_dev
+        self._address = ble_dev.address
+
+        self._logger = DeviceLogger(self)
+        self._logging_options = LogOptions(0)
+
+        self._logger.debug(
+            "Creating new device: %s (%s)",
+            self.device,
+            sn,
+        )
 
         self._conn = None
         self._callbacks = set()
@@ -77,6 +79,12 @@ class DeviceBase:
         self._update_period = period
         return self
 
+    def with_logging_options(self, options: LogOptions):
+        self._logger.set_options(options)
+        if self._conn is not None:
+            self._conn.with_logging_options(options)
+        return self
+
     async def data_parse(self, packet: Packet) -> bool:
         """Function to parse incoming data and trigger sensors update"""
         return False
@@ -95,29 +103,29 @@ class DeviceBase:
                 user_id,
                 self.data_parse,
                 self.packet_parse,
-            )
-            _LOGGER.info("%s: Connecting to %s", self._address, self.__doc__)
+            ).with_logging_options(self._logger.options)
+            self._logger.info("Connecting to %s", self.__doc__)
         elif self._conn._user_id != user_id:
             self._conn._user_id = user_id
 
         await self._conn.connect(max_attempts=max_attempts)
 
     async def disconnect(self):
-        if self._conn == None:
-            _LOGGER.error("%s: Device has no connection", self._address)
+        if self._conn is None:
+            self._logger.error("Device has no connection")
             return
 
         await self._conn.disconnect()
 
     async def waitConnected(self, timeout: int = 20):
-        if self._conn == None:
-            _LOGGER.error("%s: Device has no connection", self._address)
+        if self._conn is None:
+            self._logger.error("Device has no connection")
             return
         await self._conn.waitConnected(timeout=timeout)
 
     async def waitDisconnected(self):
-        if self._conn == None:
-            _LOGGER.error("%s: Device has no connection", self._address)
+        if self._conn is None:
+            self._logger.error("Device has no connection")
             return
 
         await self._conn.waitDisconnected()

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -165,7 +165,7 @@ class Device(DeviceBase, ProtobufProps):
             and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             if len(packet.payload) == 0:
-                await self._time_commands.async_send_all()
+                self._time_commands.async_send_all()
             processed = True
 
         self.solar_input_power = (

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -132,7 +132,7 @@ class Device(DeviceBase, ProtobufProps):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                await self._time_commands.async_send_all()
+                self._time_commands.async_send_all()
             processed = True
 
         self.solar_lv_power = self._get_solar_power(

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -114,7 +114,7 @@ class Device(DeviceBase, ProtobufProps):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                await self._time_commands.async_send_all()
+                self._time_commands.async_send_all()
             processed = True
 
         for prop_name in self.updated_fields:

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -148,7 +148,7 @@ class Device(DeviceBase, ProtobufProps):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                await self._time_commands.async_send_all()
+                self._time_commands.async_send_all()
             processed = True
 
         if self.ac_input_energy is not None and self.dc_input_energy is not None:

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -162,12 +162,12 @@ class Device(DeviceBase, ProtobufProps):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
             if len(packet.payload) == 0:
-                await self._time_commands.async_send_all()
+                self._time_commands.async_send_all()
             processed = True
 
         elif packet.src == 0x0B and packet.cmdSet == 0x01 and packet.cmdId == 0x55:
             # Device reply that it's online and ready
-            await self._conn._add_task(self.set_config_flag(True))
+            self._conn._add_task(self.set_config_flag(True))
             processed = True
 
         self.error_count = len(self.errors) if self.errors is not None else None

--- a/custom_components/ef_ble/eflib/logging_util.py
+++ b/custom_components/ef_ble/eflib/logging_util.py
@@ -1,0 +1,141 @@
+import logging
+from collections.abc import Mapping
+from enum import Flag, auto
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+import bleak
+
+if TYPE_CHECKING:
+    from .connection import Connection
+    from .devicebase import DeviceBase
+
+
+class SensitiveMaskingFilter(logging.Filter):
+    def __init__(self, patterns: dict[str, str], name: str = "") -> None:
+        super().__init__(name)
+        self._patterns = patterns
+
+    def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
+        record.msg = self.mask_message(record.msg)
+        record.name = self.mask_message(record.name)
+
+        if isinstance(record.args, Mapping):
+            record.args = {k: self.mask_message(v) for k, v in record.args.items()}
+        elif record.args is not None:
+            record.args = tuple(self.mask_message(v) for v in record.args)
+
+        return True
+
+    def mask_message(self, msg: Any):
+        if not isinstance(msg, str):
+            return msg
+
+        for pattern, replacement in self._patterns.items():
+            msg = msg.replace(pattern, replacement)
+        return msg
+
+
+class LogOptions(Flag):
+    MASKED = auto()
+
+    ENCRYPTED_PAYLOADS = auto()
+    DECRYPTED_PAYLOADS = auto()
+    PACKETS = auto()
+    DESERIALIZED_MESSAGES = auto()
+
+    CONNECTION_DEBUG = auto()
+    BLEAK_DEBUG = auto()
+
+    @property
+    def enabled(self):
+        return self & (
+            LogOptions.ENCRYPTED_PAYLOADS
+            | LogOptions.DECRYPTED_PAYLOADS
+            | LogOptions.PACKETS
+            | LogOptions.DESERIALIZED_MESSAGES
+            | LogOptions.CONNECTION_DEBUG
+        )
+
+
+_BLEAK_LOGGER = logging.getLogger(bleak.__name__)
+_ORIGINAL_BLEAK_LOG_LEVEL = _BLEAK_LOGGER.level
+
+
+class MaskingLogger(logging.Logger):
+    def __init__(self, logger: logging.Logger, patterns: dict[str, str]) -> None:
+        self._logger = logger
+        self._patterns = patterns
+        self._options = LogOptions(0)
+
+    @cached_property
+    def _mask_filter(self):
+        return SensitiveMaskingFilter(self._patterns)
+
+    def __getattr__(self, name: str):
+        return getattr(self._logger, name)
+
+    @property
+    def options(self):
+        return self._options
+
+    def set_options(self, options: LogOptions):
+        self._options = options
+        self._logger.setLevel(logging.DEBUG if options.enabled else logging.INFO)
+
+        bleak_logger = logging.getLogger(bleak.__name__)
+        if LogOptions.BLEAK_DEBUG in options:
+            bleak_logger.setLevel(logging.DEBUG)
+        elif bleak_logger.isEnabledFor(logging.DEBUG):
+            bleak_logger.setLevel(_ORIGINAL_BLEAK_LOG_LEVEL)
+
+        if LogOptions.MASKED not in options:
+            self._logger.removeFilter(self._mask_filter)
+            return
+
+        self._logger.addFilter(self._mask_filter)
+
+    def log_filtered(
+        self,
+        options: LogOptions,
+        msg: object,
+        *args: object,
+        level: int = logging.DEBUG,
+    ) -> None:
+        if options in self._options:
+            self._logger.log(level, msg, *args)
+
+
+def _mask_sn(sn: str):
+    return f"{sn[:4]}{'*' * len(sn[4:-4])}{sn[-4:]}"
+
+
+def _mask_mac(mac_addr: str):
+    return f"{mac_addr[:5]}:**:**:**:**"
+
+
+def _mask_user_id(user_id: str):
+    return f"{user_id[:4]}{'*' * len(user_id[4:])}"
+
+
+class DeviceLogger(MaskingLogger):
+    def __init__(self, device: "DeviceBase"):
+        super().__init__(
+            logging.getLogger(f"{device.__module__} - {device._address}"),
+            patterns={
+                device._address: _mask_mac(device._address),
+                device._sn: _mask_sn(device._sn),
+            },
+        )
+
+
+class ConnectionLogger(MaskingLogger):
+    def __init__(self, connection: "Connection") -> None:
+        super().__init__(
+            logging.getLogger(f"{connection.__module__} - {connection._address}"),
+            patterns={
+                connection._address: _mask_mac(connection._address),
+                connection._dev_sn: _mask_sn(connection._dev_sn),
+                connection._user_id: _mask_user_id(connection._user_id),
+            },
+        )

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -9,12 +9,13 @@
     "error": {
       "cannot_connect": "Cannot connect",
       "invalid_auth": "Authentication is invalid",
-      "unknown": "Unexpected error, check logs",
+      "unknown": "An unexpected error occured, check the logs for details",
       "email_empty": "Email cannot be empty",
       "password_empty": "Password cannot be empty",
       "device_auth_failed": "Device authentication failed - user ID may be incorrect",
-      "bt_timeout": "Could not connect to the device - exceeded maximum attempts",
-      "bt_general_error": "Could not connect to the device - see logs for details",
+      "bt_timeout": "Could not connect to the device - connection timed out",
+      "bt_not_found": "Device was not found - try refreshing the bluetooth integration if this error occurs repeatedly",
+      "bt_general_error": "Could not connect to the device - see the logs for more details",
       "error_try_refresh": "Connection is in an invalid state - try refreshing before adding the device"
     },
     "step": {
@@ -26,7 +27,7 @@
           "update_period": "Update Period"
         },
         "data_description": {
-          "update_period": "Number of seconds to wait before processing the next device update. A default value of 0 means all updates are processed immediately (may result in a high number of DB writes)."
+          "update_period": "Number of seconds to wait before processing the next device update. A default value of 0 means all updates are processed immediately (this may result in a high number of database writes)."
         },
         "sections": {
           "login": {
@@ -34,6 +35,19 @@
             "data": {
               "email": "Email",
               "password": "Password"
+            }
+          },
+          "log_options": {
+            "name": "Logging Options",
+            "description": "Detailed logging options. Most of these will flood your logs, so avoid leaving them enabled for long periods.",
+            "data": {
+                "log_masked": "Mask sensitive information (useful when sharing logs publicly)",
+                "log_connection": "Log device connection requests and responses",
+                "log_messages": "Log deserialized device update messages",
+                "log_packets": "Log packet objects",
+                "log_encrypted_payloads": "Log encrypted payloads",
+                "log_payloads": "Log decrypted payloads",
+                "log_bleak": "Enable bleak debug log level (not masked and not filtered to this device)"
             }
           }
         }
@@ -55,6 +69,19 @@
               "email": "Email",
               "password": "Password"
             }
+          },
+          "log_options": {
+            "name": "Logging Options",
+            "description": "Detailed logging options. Most of these will flood your logs, so avoid leaving them enabled for long periods.",
+            "data": {
+                "log_masked": "Mask sensitive information (useful when sharing logs publicly)",
+                "log_connection": "Log device connection requests and responses",
+                "log_messages": "Log deserialized device update messages",
+                "log_packets": "Log packet objects",
+                "log_encrypted_payloads": "Log encrypted payloads",
+                "log_payloads": "Log decrypted payloads",
+                "log_bleak": "Enable bleak debug log level (not masked and not filtered to this device)"
+            }
           }
         }
       },
@@ -74,6 +101,21 @@
         },
         "data_description": {
           "update_period": "Number of seconds to wait before processing the next device update. A default value of 0 means all updates are processed immediately (may result in a high number of DB writes)."
+        },
+        "sections": {
+          "log_options": {
+            "name": "Logging Options",
+            "description": "Detailed logging options. Most of these will flood your logs, so avoid leaving them enabled for long periods.",
+            "data": {
+                "log_masked": "Mask sensitive information (useful when sharing logs publicly)",
+                "log_connection": "Log device connection requests and responses",
+                "log_messages": "Log deserialized device update messages",
+                "log_packets": "Log packet objects",
+                "log_encrypted_payloads": "Log encrypted payloads",
+                "log_payloads": "Log decrypted payloads",
+                "log_bleak": "Enable bleak debug log level (not masked and not filtered to this device)"
+            }
+          }
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "EcoFlow BLE",
   "render_readme": true,
-  "homeassistant": "2024.6.4"
+  "homeassistant": "2024.7.0"
 }


### PR DESCRIPTION
This PR adds options to enable debug logging for specific devices and groups messages into categories so only relevant info is displayed when debugging. It also adds option to mask mac addresses, serial numbers and user ids for pasting these into issues or forums, you never know who's watching.