### PR TITLE
Remove Delta 3 1500 from supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Recognized devices:
 </details>
 
 <details><summary>
-<b>Delta 3 (Plus, 1500) (EF-D3####)</b>
+<b>Delta 3 (Plus) (EF-D3####)</b>
 </summary>
 
 | *Sensors*                           | *Switches*     | *Sliders*                            |

--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -72,7 +72,7 @@ class DCPortState(IntFieldValue):
 class Device(DeviceBase, ProtobufProps):
     """Delta 3"""
 
-    SN_PREFIX = (b"P231", b"D361")
+    SN_PREFIX = (b"P231",)
     NAME_PREFIX = "EF-D3"
 
     battery_level = pb_field(pb.cms_batt_soc, lambda value: round(value, 2))
@@ -134,8 +134,6 @@ class Device(DeviceBase, ProtobufProps):
     def device(self):
         model = ""
         match self._sn[:4]:
-            case "D361":
-                model = "1500"
             case "P351":
                 model = "Plus"
         return f"Delta 3 {model}".strip()

--- a/custom_components/ef_ble/manifest.json
+++ b/custom_components/ef_ble/manifest.json
@@ -34,12 +34,6 @@
             "connectable": true
         },
         {
-            "local_name": "EF-D3*",
-            "manufacturer_id": 46517,
-            "manufacturer_data_start": [19, 68, 51, 54, 49],
-            "connectable": true
-        },
-        {
             "local_name": "EF-DP3*",
             "manufacturer_id": 46517,
             "manufacturer_data_start": [19, 77, 82, 53, 49],

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -3,7 +3,7 @@
     "abort": {
       "already_configured": "Device is already configured",
       "not_supported": "Device is not supported",
-      "no_devices_found": "No supported EcoFlow devices found",
+      "no_devices_found": "No supported EcoFlow devices found. Make sure your device is not connected to the EcoFlow app via Bluetooth.",
       "reconfigure_successful": "Reconfiguration was successful"
     },
     "error": {


### PR DESCRIPTION
I incorrectly assumed that Delta 3 1500 uses the same protocol as other Delta 3s but it seems that it uses Delta 2 firmware which probably makes sense as the port configuration is identical.