### PR TITLE
Use hass config retry instead of native reconnect logic, improve error handling

### DIFF
--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -1,19 +1,36 @@
 """The unofficial EcoFlow BLE devices integration"""
 
-from __future__ import annotations
-
 import logging
+from functools import partial
 
+import homeassistant.helpers.issue_registry as ir
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import eflib
 from .config_flow import ConfLogOptions, LogOptions
-from .const import CONF_UPDATE_PERIOD, CONF_USER_ID, DOMAIN, MANUFACTURER
+from .const import (
+    CONF_CONNECTION_TIMEOUT,
+    CONF_UPDATE_PERIOD,
+    CONF_USER_ID,
+    DEFAULT_CONNECTION_TIMEOUT,
+    DEFAULT_UPDATE_PERIOD,
+    DOMAIN,
+    MANUFACTURER,
+)
+from .eflib.connection import (
+    AuthFailedError,
+    BleakError,
+    ConnectionTimeout,
+    MaxConnectionAttemptsReached,
+)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -27,18 +44,8 @@ type DeviceConfigEntry = ConfigEntry[eflib.DeviceBase]
 
 _LOGGER = logging.getLogger(__name__)
 
-
-class _ConfigNotReady(ConfigEntryNotReady):
-    def __init__(
-        self,
-        translation_key: str | None = None,
-        translation_placeholders: dict[str, str] | None = None,
-    ) -> None:
-        super().__init__(
-            translation_domain=DOMAIN,
-            translation_key=translation_key,
-            translation_placeholders=translation_placeholders,
-        )
+ConfigEntryNotReady = partial(ConfigEntryNotReady, translation_domain=DOMAIN)
+ConfigEntryError = partial(ConfigEntryError, translation_domain=DOMAIN)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bool:
@@ -49,44 +56,90 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
     address = entry.data.get(CONF_ADDRESS)
     user_id = entry.data.get(CONF_USER_ID)
     merged_options = entry.data | entry.options
-    update_period = merged_options.get(CONF_UPDATE_PERIOD, 0)
+    update_period = merged_options.get(CONF_UPDATE_PERIOD, DEFAULT_UPDATE_PERIOD)
+    timeout = merged_options.get(CONF_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT)
 
     if address is None or user_id is None:
         return False
 
     if not bluetooth.async_address_present(hass, address):
-        raise _ConfigNotReady("device_not_present")
+        raise ConfigEntryNotReady(translation_key="device_not_present")
 
     _LOGGER.debug("Connecting Device")
-    discovery_info = bluetooth.async_last_service_info(hass, address, connectable=True)
-    device = eflib.NewDevice(discovery_info.device, discovery_info.advertisement)
+    device: eflib.DeviceBase | None = getattr(entry, "runtime_data", None)
     if device is None:
-        raise _ConfigNotReady("unable_to_create_device")
-
-    await (
-        device.with_update_period(update_period)
-        .with_logging_options(ConfLogOptions.from_config(merged_options))
-        .connect(user_id)
-    )
-    entry.runtime_data = device
-
-    timeout = 30
-    state = await device.wait_until_connected_or_error(timeout=timeout)
-
-    if state.connection_error():
-        raise _ConfigNotReady(
-            "could_not_connect", translation_placeholders={"time": str(timeout)}
+        discovery_info = bluetooth.async_last_service_info(
+            hass, address, connectable=True
         )
-    if state.is_error():
-        raise _ConfigNotReady("error_after_connected")
-    if not state.authenticated():
-        raise _ConfigNotReady("could_not_authenticate")
+        device = eflib.NewDevice(discovery_info.device, discovery_info.advertisement)
+        if device is None:
+            raise ConfigEntryNotReady(translation_key="unable_to_create_device")
+
+        entry.runtime_data = device
+
+    issue_id = f"{entry.entry_id}_max_connection_attempts"
+
+    try:
+        await (
+            device.with_update_period(update_period)
+            .with_logging_options(ConfLogOptions.from_config(merged_options))
+            .with_disabled_reconnect()
+            .connect(user_id, timeout=timeout)
+        )
+        state = await device.wait_until_authenticated_or_error(raise_on_error=True)
+    except (ConnectionTimeout, BleakError, TimeoutError) as e:
+        raise ConfigEntryNotReady(
+            translation_key="could_not_connect",
+            translation_placeholders={"time": str(timeout)},
+        ) from e
+    except AuthFailedError as e:
+        raise ConfigEntryNotReady(translation_key="authentication_failed") from e
+    except MaxConnectionAttemptsReached as e:
+        await device.disconnect()
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="max_connection_attempts_reached",
+            translation_placeholders={
+                "device_name": device.name,
+                "attempts": str(e.attempts),
+            },
+        )
+        raise ConfigEntryError(
+            translation_key="could_not_connect_no_retry",
+            translation_placeholders={"attempts": str(e.attempts)},
+        ) from e
+    except Exception as e:
+        _LOGGER.exception("Unknown error")
+        await device.disconnect()
+        raise ConfigEntryNotReady(
+            translation_key="unknown_error", translation_placeholders={"error": str(e)}
+        ) from e
+    else:
+        if not state.authenticated():
+            await device.disconnect()
+            raise ConfigEntryNotReady(
+                translation_key="failed_after_successful_connection",
+                translation_placeholders={"last_state": state},
+            )
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
 
     _LOGGER.debug("Creating entities")
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _LOGGER.debug("Setup done")
     entry.async_on_unload(entry.add_update_listener(_update_listener))
+
+    def _on_disconnect(exc: Exception | type[Exception] | None):
+        async def _disconnect_and_reload():
+            hass.config_entries.async_schedule_reload(entry.entry_id)
+
+        hass.async_create_task(_disconnect_and_reload())
+
+    entry.async_on_unload(device.on_disconnect(_on_disconnect))
 
     return True
 
@@ -112,7 +165,7 @@ def device_info(entry: ConfigEntry) -> DeviceInfo:
 async def _update_listener(hass: HomeAssistant, entry: DeviceConfigEntry):
     device = entry.runtime_data
     merged_options = entry.data | entry.options
-    update_period = merged_options.get(CONF_UPDATE_PERIOD, 0)
-    device.with_update_period(update_period).with_logging_options(
+    update_period = merged_options.get(CONF_UPDATE_PERIOD, DEFAULT_UPDATE_PERIOD)
+    device.with_update_period(period=update_period).with_logging_options(
         ConfLogOptions.from_config(merged_options)
     )

--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -28,6 +28,19 @@ type DeviceConfigEntry = ConfigEntry[eflib.DeviceBase]
 _LOGGER = logging.getLogger(__name__)
 
 
+class _ConfigNotReady(ConfigEntryNotReady):
+    def __init__(
+        self,
+        translation_key: str | None = None,
+        translation_placeholders: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders=translation_placeholders,
+        )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bool:
     """Set up EF BLE device from a config entry."""
 
@@ -42,13 +55,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
         return False
 
     if not bluetooth.async_address_present(hass, address):
-        raise ConfigEntryNotReady("EcoFlow BLE device not present")
+        raise _ConfigNotReady("device_not_present")
 
     _LOGGER.debug("Connecting Device")
     discovery_info = bluetooth.async_last_service_info(hass, address, connectable=True)
     device = eflib.NewDevice(discovery_info.device, discovery_info.advertisement)
     if device is None:
-        raise ConfigEntryNotReady("EcoFlow BLE Device unable to create")
+        raise _ConfigNotReady("unable_to_create_device")
 
     await (
         device.with_update_period(update_period)
@@ -57,11 +70,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
     )
     entry.runtime_data = device
 
+    timeout = 30
+    state = await device.wait_until_connected_or_error(timeout=timeout)
+
+    if state.connection_error():
+        raise _ConfigNotReady(
+            "could_not_connect", translation_placeholders={"time": str(timeout)}
+        )
+    if state.is_error():
+        raise _ConfigNotReady("error_after_connected")
+    if not state.authenticated():
+        raise _ConfigNotReady("could_not_authenticate")
+
     _LOGGER.debug("Creating entities")
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _LOGGER.debug("Setup done")
-    entry.async_on_unload(entry.add_update_listener(update_listener))
+    entry.async_on_unload(entry.add_update_listener(_update_listener))
 
     return True
 
@@ -70,10 +95,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> b
     """Unload a config entry."""
     device = entry.runtime_data
     await device.disconnect()
-    device.with_logging_options(LogOptions(0))
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    return unload_ok
+    device.with_logging_options(LogOptions.no_options())
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 def device_info(entry: ConfigEntry) -> DeviceInfo:
@@ -86,7 +109,7 @@ def device_info(entry: ConfigEntry) -> DeviceInfo:
     )
 
 
-async def update_listener(hass: HomeAssistant, entry: DeviceConfigEntry):
+async def _update_listener(hass: HomeAssistant, entry: DeviceConfigEntry):
     device = entry.runtime_data
     merged_options = entry.data | entry.options
     update_period = merged_options.get(CONF_UPDATE_PERIOD, 0)

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -62,7 +62,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._user_id: str = ""
         self._email: str = ""
         self._user_id_validated: bool = False
-        self._log_options = LogOptions(0)
+        self._log_options = LogOptions.no_options()
         self._collapsed = True
 
     async def async_step_bluetooth(
@@ -260,8 +260,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         device.with_logging_options(ConfLogOptions.from_config(user_input))
 
         await device.connect(self._user_id, max_attempts=4)
-        await device.waitConnected(timeout=20)
-        conn_state = device.connection_state
+        conn_state = await device.wait_until_connected_or_error(timeout=20)
         await device.disconnect()
 
         error = None
@@ -282,7 +281,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             case _:
                 error = "error_try_refresh"
 
-        await device.waitDisconnected()
+        await device.wait_disconnected()
 
         if error is not None:
             return {"base": error}
@@ -311,7 +310,13 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                 "Content-Type": "application/json",
             },
         ) as response:
-            response.raise_for_status()
+            if not response.ok:
+                return {
+                    "login": (
+                        f"Login failed with status code {response.status}: "
+                        f"{response.reason}"
+                    )
+                }
 
             result_json = await response.json()
             if result_json["code"] != "0":
@@ -370,7 +375,7 @@ class ConfLogOptions:
     @classmethod
     def from_config(cls, config_entry: Mapping[str, Any]):
         config_entry = config_entry.get(cls.CONF_KEY, config_entry)
-        log_options = LogOptions(0)
+        log_options = LogOptions.no_options()
         for conf_option, log_option in cls._CONF_OPTION_TO_LOG_OPTION.items():
             if config_entry.get(conf_option, False):
                 log_options |= log_option

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 from collections.abc import Mapping
@@ -28,6 +29,7 @@ from homeassistant.helpers.storage import Store
 
 from . import eflib
 from .const import (
+    CONF_CONNECTION_TIMEOUT,
     CONF_LOG_BLEAK,
     CONF_LOG_CONNECTION,
     CONF_LOG_ENCRYPTED_PAYLOADS,
@@ -37,6 +39,8 @@ from .const import (
     CONF_LOG_PAYLOADS,
     CONF_UPDATE_PERIOD,
     CONF_USER_ID,
+    DEFAULT_CONNECTION_TIMEOUT,
+    DEFAULT_UPDATE_PERIOD,
     DOMAIN,
 )
 from .eflib.connection import ConnectionState
@@ -117,6 +121,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                     **self._login_option(),
                     vol.Required(CONF_ADDRESS): vol.In([f"{title} ({device.address})"]),
                     **_update_period_option(),
+                    **_timeout_option(),
                     **ConfLogOptions.schema(
                         ConfLogOptions.to_config(self._log_options)
                     ),
@@ -176,6 +181,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                     **self._login_option(),
                     vol.Required(CONF_ADDRESS): vol.In(self._discovered_devices.keys()),
                     **_update_period_option(),
+                    **_timeout_option(),
                     **ConfLogOptions.schema(
                         ConfLogOptions.to_config(self._log_options)
                     ),
@@ -242,6 +248,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._email = user_input.get("login", {}).get(CONF_EMAIL, "")
         password = user_input.get("login", {}).get(CONF_PASSWORD, "")
         user_id = user_input.get(CONF_USER_ID, "")
+        timeout = user_input.get(CONF_CONNECTION_TIMEOUT, 20)
 
         self._collapsed = False
 
@@ -259,8 +266,10 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         device.with_logging_options(ConfLogOptions.from_config(user_input))
 
-        await device.connect(self._user_id, max_attempts=4)
-        conn_state = await device.wait_until_connected_or_error(timeout=20)
+        await device.connect(self._user_id)
+        conn_state = await asyncio.wait_for(
+            device.wait_until_authenticated_or_error(), timeout
+        )
         await device.disconnect()
 
         error = None
@@ -335,7 +344,9 @@ class OptionsFlowHandler(OptionsFlow):
 
         merged_entry = self.config_entry.data | self.config_entry.options
         options = {
-            CONF_UPDATE_PERIOD: merged_entry.get(CONF_UPDATE_PERIOD, 0),
+            CONF_UPDATE_PERIOD: merged_entry.get(
+                CONF_UPDATE_PERIOD, DEFAULT_UPDATE_PERIOD
+            ),
         }
 
         device: eflib.DeviceBase | None = getattr(
@@ -412,9 +423,17 @@ class ConfLogOptions:
         }
 
 
-def _update_period_option(default: int = 0):
+def _update_period_option(default: int = DEFAULT_UPDATE_PERIOD):
     return {
         vol.Optional(CONF_UPDATE_PERIOD, default=default): vol.All(
+            int, vol.Range(min=0)
+        )
+    }
+
+
+def _timeout_option(default: int = DEFAULT_CONNECTION_TIMEOUT):
+    return {
+        vol.Optional(CONF_CONNECTION_TIMEOUT, default=default): vol.All(
             int, vol.Range(min=0)
         )
     }

--- a/custom_components/ef_ble/const.py
+++ b/custom_components/ef_ble/const.py
@@ -5,6 +5,7 @@ MANUFACTURER = "EcoFlow"
 
 CONF_USER_ID = "user_id"
 CONF_UPDATE_PERIOD = "update_period"
+CONF_CONNECTION_TIMEOUT = "connection_timeout"
 
 CONF_LOG_MASKED = "log_masked"
 CONF_LOG_PACKETS = "log_packets"
@@ -13,3 +14,7 @@ CONF_LOG_PAYLOADS = "log_payloads"
 CONF_LOG_MESSAGES = "log_messages"
 CONF_LOG_CONNECTION = "log_connection"
 CONF_LOG_BLEAK = "log_bleak"
+
+
+DEFAULT_UPDATE_PERIOD = 10
+DEFAULT_CONNECTION_TIMEOUT = 20

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -3,17 +3,17 @@ import hashlib
 import logging
 import struct
 import traceback
-from collections.abc import Awaitable, Callable
-from enum import Enum, auto
-from typing import Any, Coroutine
+from collections import deque
+from collections.abc import Awaitable, Callable, Coroutine
+from enum import StrEnum, auto
 
 import ecdsa
+from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 from bleak_retry_connector import (
     MAX_CONNECT_ATTEMPTS,
-    BleakClientWithServiceCache,
     BleakNotFoundError,
     establish_connection,
 )
@@ -43,8 +43,21 @@ class AuthFailedError(Exception):
     """Error during authentificating"""
 
 
-class ConnectionState(Enum):
-    INIT = auto()
+class ConnectionState(StrEnum):
+    NOT_CONNECTED = auto()
+
+    CREATED = auto()
+    ESTABLISHING_CONNECTION = auto()
+    CONNECTED = auto()
+    PUBLIC_KEY_EXCHANGE = auto()
+    PUBLIC_KEY_RECEIVED = auto()
+    REQUESTING_SESSION_KEY = auto()
+    SESSION_KEY_RECEIVED = auto()
+    REQUESTING_AUTH_STATUS = auto()
+    AUTH_STATUS_RECEIVED = auto()
+    AUTHENTICATING = auto()
+    AUTHENTICATED = auto()
+
     ERROR_TIMEOUT = auto()
     ERROR_NOT_FOUND = auto()
     ERROR_BLEAK = auto()
@@ -52,7 +65,40 @@ class ConnectionState(Enum):
     ERROR_SEND_REQUEST = auto()
     ERROR_UNKNOWN = auto()
     ERROR_AUTH_FAILED = auto()
-    AUTHENTICATED = auto()
+
+    RECONNECTING = auto()
+    DISCONNECTED = auto()
+
+    def connection_error(self):
+        return self in [
+            ConnectionState.ERROR_TIMEOUT,
+            ConnectionState.ERROR_NOT_FOUND,
+            ConnectionState.ERROR_BLEAK,
+        ]
+
+    def is_error(self):
+        return (
+            self
+            in [
+                ConnectionState.ERROR_AUTH_FAILED,
+                ConnectionState.ERROR_UNKNOWN,
+            ]
+            or self.connection_error()
+        )
+
+    def authenticated(self):
+        return self is ConnectionState.AUTHENTICATED
+
+    def is_terminal(self):
+        return (
+            self
+            in [
+                ConnectionState.AUTHENTICATED,
+                ConnectionState.DISCONNECTED,
+                ConnectionState.NOT_CONNECTED,
+            ]
+            or self.is_error()
+        )
 
 
 class Connection:
@@ -71,6 +117,8 @@ class Connection:
         user_id: str,
         data_parse: Callable[[Packet], Awaitable[bool]],
         packet_parse: Callable[[bytes], Awaitable[Packet]],
+        on_state_change: Callable[[ConnectionState], None] = lambda _: None,
+        on_disconnected: Callable[[], None] = lambda: None,
     ) -> None:
         self._ble_dev = ble_dev
         self._address = ble_dev.address
@@ -81,22 +129,23 @@ class Connection:
         self._authenticated = False
 
         self._errors = 0
-        self._last_error_msg = ""
+        self._last_errors = deque(maxlen=10)
         self._client = None
         self._connected = asyncio.Event()
         self._disconnected = asyncio.Event()
         self._retry_on_disconnect = False
         self._retry_on_disconnect_delay = 10
-        self._state = ConnectionState.INIT
-        self._cancel_lock = asyncio.Lock()
+        self._connection_state = ConnectionState.CREATED
 
         self._enc_packet_buffer = b""
 
         self._tasks: set[asyncio.Task] = set()
-        self._cancelling = False
         self._debug_mode = False
 
         self._logger = ConnectionLogger(self)
+        self._on_state_change = on_state_change
+        self._on_disconnected = on_disconnected
+        self._state_changed = asyncio.Event()
 
     @property
     def is_connected(self) -> bool:
@@ -105,33 +154,45 @@ class Connection:
     def ble_dev(self) -> BLEDevice:
         return self._ble_dev
 
+    @property
+    def _state(self) -> ConnectionState:
+        return self._connection_state
+
+    @_state.setter
+    def _state(self, value: ConnectionState):
+        self._connection_state = value
+        self._state_changed.set()
+        self._state_changed.clear()
+        self._on_state_change(value)
+
     def with_logging_options(self, options: LogOptions):
         self._logger.set_options(options)
         return self
 
-    async def connect(self, max_attempts: int = MAX_CONNECT_ATTEMPTS):
+    async def connect(
+        self, max_attempts: int = MAX_CONNECT_ATTEMPTS, timeout: int = 20
+    ):
         self._connected.clear()
         self._disconnected.clear()
 
         error = None
         try:
-            if self._client != None:
-                if self._client.is_connected:
-                    self._logger.warning("Device is already connected")
-                    return
-                self._logger.info("Reconnecting to device")
-                await self._client.connect()
-            else:
-                self._logger.info("Connecting to device")
-                self._client = await establish_connection(
-                    BleakClientWithServiceCache,
-                    self.ble_dev(),
-                    self._ble_dev.name,
-                    disconnected_callback=self.disconnected,
-                    ble_device_callback=self.ble_dev,
-                    max_attempts=max_attempts,
-                )
-        except asyncio.TimeoutError as err:
+            if self._client is not None and not self._client.is_connected:
+                self._logger.warning("Device is already connected")
+                return
+
+            self._state = ConnectionState.ESTABLISHING_CONNECTION
+            self._logger.info("Connecting to device")
+            self._client = await establish_connection(
+                BleakClient,
+                self.ble_dev(),
+                self._ble_dev.name,
+                disconnected_callback=self.disconnected,
+                ble_device_callback=self.ble_dev,
+                max_attempts=max_attempts,
+                timeout=timeout,
+            )
+        except TimeoutError as err:
             error = err
             self._state = ConnectionState.ERROR_TIMEOUT
         except BleakNotFoundError as err:
@@ -142,8 +203,8 @@ class Connection:
             self._state = ConnectionState.ERROR_BLEAK
 
         if error is not None:
-            self._last_error_msg = str(error)
             self._logger.error("Failed to connect to the device: %s", error)
+            self._last_errors.append(f"Failed to connect to the device: {error}")
             self.disconnected()
             return
 
@@ -158,18 +219,22 @@ class Connection:
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "MTU: %d", self._client.mtu_size
         )
-
         self._logger.info("Init completed, starting auth routine...")
 
         await self.initBleSessionKey()
 
     def disconnected(self, *args, **kwargs) -> None:
         self._logger.warning("Disconnected from device")
+        self._client = None
+
         if self._retry_on_disconnect:
+            self._state = ConnectionState.RECONNECTING
             self._add_task(self.reconnect(), asyncio.get_event_loop())
-        else:
-            self._connected.set()
-            self._disconnected.set()
+            return
+
+        self._connected.set()
+        self._disconnected.set()
+        self._on_disconnected()
 
     async def reconnect(self) -> None:
         # Wait before reconnect
@@ -190,15 +255,23 @@ class Connection:
         if self._client is not None and self._client.is_connected:
             self._cancel_tasks()
             await self._client.disconnect()
+            self._on_disconnected()
 
-    async def waitConnected(self, timeout: int = 20):
+        self._client = None
+
+    async def wait_connected(self, timeout: int = 20):
         """Will release when connection is happened and authenticated"""
         try:
             await asyncio.wait_for(self._connected.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             self._state = ConnectionState.ERROR_TIMEOUT
 
-    async def waitDisconnected(self):
+    async def wait_until_connected_or_error(self, timeout: int = 20):
+        while not self._state.is_terminal():
+            await asyncio.wait_for(self._state_changed.wait(), timeout=timeout)
+        return self._state
+
+    async def wait_disconnected(self):
         """Will release when client got disconnected from the device"""
         await self._disconnected.wait()
 
@@ -276,15 +349,17 @@ class Connection:
 
         # Check the payload CRC16
         if crc16(header + payload_data) != struct.unpack("<H", payload_crc)[0]:
-            self._logger.error(
-                "parseSimple: Unable to parse simple packet - incorrect CRC16: %r",
-                bytearray(payload_data).hex(),
+            error_msg = (
+                "parseSimple: Unable to parse simple packet - incorrect CRC16: %r"
             )
+            payload_hex = bytearray(payload_data).hex()
+            self._logger.error(error_msg, payload_hex)
+            self._last_errors.append(error_msg % payload_hex)
             raise PacketParseError
 
         return payload_data
 
-    async def parseEncPackets(self, data: str):
+    async def parseEncPackets(self, data: str) -> list[Packet]:
         """Deserializes bytes stream into a list of Packets"""
         # In case there are leftovers from previous processing - adding them to current data
         if self._enc_packet_buffer:
@@ -297,20 +372,23 @@ class Connection:
             bytearray(data).hex(),
         )
         if len(data) < 8:
-            self._logger.error(
-                "parseEncPackets: Unable to parse encrypted packet - too small: %r",
-                bytearray(data).hex(),
+            error_msg = (
+                "parseEncPackets: Unable to parse encrypted packet - too small: %r"
             )
+            self._logger.error(error_msg, bytearray(data).hex())
+            self._last_errors.append(error_msg % bytearray(data).hex())
             raise EncPacketParseError
 
         # Data can contain multiple EncPackets and even incomplete ones, so walking through
         packets = []
         while data:
             if not data.startswith(EncPacket.PREFIX):
-                self._logger.error(
-                    "parseEncPackets: Unable to parse encrypted packet - prefix is incorrect: %r",
-                    bytearray(data).hex(),
+                error_msg = (
+                    "parseEncPackets: Unable to parse encrypted packet - prefix is "
+                    "incorrect: %r"
                 )
+                self._logger.error(error_msg, bytearray(data).hex())
+                self._last_errors.append(error_msg % bytearray(data).hex())
                 return packets
 
             header = data[0:6]
@@ -328,11 +406,10 @@ class Connection:
             try:
                 # Check the packet CRC16
                 if crc16(header + payload_data) != struct.unpack("<H", payload_crc)[0]:
-                    self._logger.error(
-                        "Unable to parse encrypted packet - incorrect CRC16: %r",
-                        bytearray(payload_data).hex(),
-                    )
-                    raise PacketParseError
+                    error_msg = "Unable to parse encrypted packet - incorrect CRC16: %r"
+                    self._logger.error(error_msg, bytearray(payload_data).hex())
+                    self._last_errors.append(error_msg % bytearray(payload_data).hex())
+                    raise PacketParseError  # noqa: TRY301
 
                 # Decrypt the payload packet
                 payload = await self.decryptSession(payload_data)
@@ -389,13 +466,14 @@ class Connection:
 
     async def _sendRequest(self, send_data: bytes, response_handler=None):
         # Make sure the connection is here, otherwise just skipping
-        if not self._client.is_connected:
+        if self._client is None or not self._client.is_connected:
             self._logger.log_filtered(
                 LogOptions.CONNECTION_DEBUG,
                 "Skip sending: disconnected: %r",
                 bytearray(send_data).hex(),
             )
             return
+
         if response_handler:
             await self._client.start_notify(
                 Connection.NOTIFY_CHARACTERISTIC, response_handler
@@ -441,6 +519,7 @@ class Connection:
         self._add_task(self.sendPacket(reply_packet))
 
     async def initBleSessionKey(self):
+        self._state = ConnectionState.PUBLIC_KEY_EXCHANGE
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "initBleSessionKey: Pub key exchange"
         )
@@ -460,6 +539,7 @@ class Connection:
     async def initBleSessionKeyHandler(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
     ):
+        self._state = ConnectionState.PUBLIC_KEY_RECEIVED
         await self._client.stop_notify(Connection.NOTIFY_CHARACTERISTIC)
 
         data = await self.parseSimple(bytes(recv_data))
@@ -488,6 +568,7 @@ class Connection:
         await self.getKeyInfoReq()
 
     async def getKeyInfoReq(self):
+        self._state = ConnectionState.REQUESTING_SESSION_KEY
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "getKeyInfoReq: Receiving session key"
         )
@@ -502,6 +583,7 @@ class Connection:
     async def getKeyInfoReqHandler(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
     ):
+        self._state = ConnectionState.SESSION_KEY_RECEIVED
         await self._client.stop_notify(Connection.NOTIFY_CHARACTERISTIC)
         encrypted_data = await self.parseSimple(bytes(recv_data))
 
@@ -520,6 +602,7 @@ class Connection:
         await self.getAuthStatus()
 
     async def getAuthStatus(self):
+        self._state = ConnectionState.REQUESTING_AUTH_STATUS
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "getKeyInfoReq: Receiving auth status"
         )
@@ -532,6 +615,7 @@ class Connection:
     async def getAuthStatusHandler(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
     ):
+        self._state = ConnectionState.AUTH_STATUS_RECEIVED
         await self._client.stop_notify(Connection.NOTIFY_CHARACTERISTIC)
         packets = await self.parseEncPackets(bytes(recv_data))
         if len(packets) < 1:
@@ -546,6 +630,7 @@ class Connection:
         await self.autoAuthentication()
 
     async def autoAuthentication(self):
+        self._state = ConnectionState.AUTHENTICATING
         self._logger.info(
             "autoAuthentication: Sending secretKey consists of user id and device "
             "serial number",
@@ -581,6 +666,7 @@ class Connection:
                     # TODO: Most probably we need to follow some other way for auth, but
                     # happens rarely
                     self._logger.error("Auth failed with response: %r", packet)
+                    self._last_errors.append(f"Auth failed with response: {packet!r}")
                     self._state = ConnectionState.ERROR_AUTH_FAILED
                     self._connected.set()
                     raise AuthFailedError
@@ -600,6 +686,7 @@ class Connection:
     def _cancel_tasks(self):
         for task in self._tasks:
             task.cancel()
+        self._tasks.clear()
 
     def _add_task(
         self, coro: Coroutine, event_loop: asyncio.AbstractEventLoop | None = None
@@ -610,7 +697,7 @@ class Connection:
 
 
 def getEcdhTypeSize(curve_num: int):
-    """Returns size of ecdh based on type"""
+    """Return size of ecdh based on type"""
     match curve_num:
         case 1:
             return 52

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -1,9 +1,9 @@
 import asyncio
+import contextlib
 import hashlib
 import logging
 import struct
 import traceback
-from collections import deque
 from collections.abc import Awaitable, Callable, Coroutine
 from enum import StrEnum, auto
 
@@ -23,24 +23,23 @@ from Crypto.Util.Padding import pad, unpad
 from . import keydata
 from .crc import crc16
 from .encpacket import EncPacket
+from .exceptions import (
+    AuthFailedError,
+    ConnectionTimeout,
+    EncPacketParseError,
+    FailedToAuthenticate,
+    MaxConnectionAttemptsReached,
+    MaxReconnectAttemptsReached,
+    PacketParseError,
+    PacketReceiveError,
+)
 from .logging_util import ConnectionLogger, LogOptions
 from .packet import Packet
 
+MAX_RECONNECT_ATTEMPTS = 2
+MAX_CONNECTION_ATTEMPTS = 10
 
-class PacketParseError(Exception):
-    """Error during parsing Packet"""
-
-
-class EncPacketParseError(Exception):
-    """Error during parsing EncPacket"""
-
-
-class PacketReceiveError(Exception):
-    """Error during receiving packet"""
-
-
-class AuthFailedError(Exception):
-    """Error during authentificating"""
+type DisconnectListener = Callable[[Exception | type[Exception] | None], None]
 
 
 class ConnectionState(StrEnum):
@@ -65,8 +64,12 @@ class ConnectionState(StrEnum):
     ERROR_SEND_REQUEST = auto()
     ERROR_UNKNOWN = auto()
     ERROR_AUTH_FAILED = auto()
+    ERROR_TOO_MANY_ERRORS = auto()
 
     RECONNECTING = auto()
+    ERROR_MAX_RECONNECT_ATTEMPTS_REACHED = auto()
+
+    DISCONNECTING = auto()
     DISCONNECTED = auto()
 
     def connection_error(self):
@@ -76,11 +79,25 @@ class ConnectionState(StrEnum):
             ConnectionState.ERROR_BLEAK,
         ]
 
+    def is_connecting(self):
+        return self in [
+            ConnectionState.ESTABLISHING_CONNECTION,
+            ConnectionState.CONNECTED,
+            ConnectionState.PUBLIC_KEY_EXCHANGE,
+            ConnectionState.PUBLIC_KEY_RECEIVED,
+            ConnectionState.SESSION_KEY_RECEIVED,
+            ConnectionState.REQUESTING_AUTH_STATUS,
+            ConnectionState.AUTH_STATUS_RECEIVED,
+            ConnectionState.AUTHENTICATING,
+        ]
+
     def is_error(self):
         return (
             self
             in [
+                ConnectionState.ERROR_MAX_RECONNECT_ATTEMPTS_REACHED,
                 ConnectionState.ERROR_AUTH_FAILED,
+                ConnectionState.ERROR_TOO_MANY_ERRORS,
                 ConnectionState.ERROR_UNKNOWN,
             ]
             or self.connection_error()
@@ -118,7 +135,6 @@ class Connection:
         data_parse: Callable[[Packet], Awaitable[bool]],
         packet_parse: Callable[[bytes], Awaitable[Packet]],
         on_state_change: Callable[[ConnectionState], None] = lambda _: None,
-        on_disconnected: Callable[[], None] = lambda: None,
     ) -> None:
         self._ble_dev = ble_dev
         self._address = ble_dev.address
@@ -129,59 +145,101 @@ class Connection:
         self._authenticated = False
 
         self._errors = 0
-        self._last_errors = deque(maxlen=10)
         self._client = None
         self._connected = asyncio.Event()
         self._disconnected = asyncio.Event()
         self._retry_on_disconnect = False
         self._retry_on_disconnect_delay = 10
-        self._connection_state = ConnectionState.CREATED
-
         self._enc_packet_buffer = b""
 
         self._tasks: set[asyncio.Task] = set()
         self._debug_mode = False
 
         self._logger = ConnectionLogger(self)
+
+        self._state_exception: Exception | type[Exception] | None = None
+        self._last_exception: Exception | type[Exception] | None = None
         self._on_state_change = on_state_change
-        self._on_disconnected = on_disconnected
         self._state_changed = asyncio.Event()
+        self._reconnect_task: asyncio.Task | None = None
+        self._connection_attempt: int = 0
+        self._reconnect_attempt: int = 0
+        self._reconnect = True
+
+        self._disconnect_listeners: list[DisconnectListener] = []
+        self._connection_state = None
+        self._set_state(ConnectionState.CREATED)
 
     @property
     def is_connected(self) -> bool:
         return self._client is not None and self._client.is_connected
 
+    def on_disconnect(self, listener: DisconnectListener):
+        """
+        Add disconnect listener
+
+        Parameters
+        ----------
+        listener
+            Listener that will be called on disconnect that receives exception as a
+            param if one occured before device disconnected
+
+        Return
+        -------
+        Function to remove this listener
+        """
+        self._disconnect_listeners.append(listener)
+
+        def _unlisten():
+            self._disconnect_listeners.remove(listener)
+
+        return _unlisten
+
+    def _notify_disconnect(self, exception: Exception | type[Exception] | None = None):
+        if exception is None:
+            exception = self._last_exception
+
+        for listener in self._disconnect_listeners:
+            listener(exception)
+
     def ble_dev(self) -> BLEDevice:
         return self._ble_dev
-
-    @property
-    def _state(self) -> ConnectionState:
-        return self._connection_state
-
-    @_state.setter
-    def _state(self, value: ConnectionState):
-        self._connection_state = value
-        self._state_changed.set()
-        self._state_changed.clear()
-        self._on_state_change(value)
 
     def with_logging_options(self, options: LogOptions):
         self._logger.set_options(options)
         return self
 
+    def with_disabled_reconnect(self, is_disabled: bool = True):
+        self._reconnect = not is_disabled
+        return self
+
     async def connect(
-        self, max_attempts: int = MAX_CONNECT_ATTEMPTS, timeout: int = 20
+        self,
+        max_attempts: int = MAX_CONNECT_ATTEMPTS,
+        timeout: int = 20,
     ):
+        if self._state.is_connecting():
+            return
+
+        self._connection_attempt += 1
+        if self._connection_attempt > MAX_CONNECTION_ATTEMPTS:
+            self._connection_attempt = 0
+            self._notify_disconnect(self._last_exception)
+            raise MaxConnectionAttemptsReached(
+                last_error=self._last_exception,
+                attempts=MAX_CONNECTION_ATTEMPTS,
+            )
+
         self._connected.clear()
         self._disconnected.clear()
 
         error = None
         try:
-            if self._client is not None and not self._client.is_connected:
+            if self.is_connected:
                 self._logger.warning("Device is already connected")
                 return
 
-            self._state = ConnectionState.ESTABLISHING_CONNECTION
+            self._set_state(ConnectionState.ESTABLISHING_CONNECTION)
             self._logger.info("Connecting to device")
             self._client = await establish_connection(
                 BleakClient,
@@ -192,26 +250,30 @@ class Connection:
                 max_attempts=max_attempts,
                 timeout=timeout,
             )
-        except TimeoutError as err:
-            error = err
-            self._state = ConnectionState.ERROR_TIMEOUT
-        except BleakNotFoundError as err:
-            error = err
-            self._state = ConnectionState.ERROR_NOT_FOUND
-        except BleakError as err:
-            error = err
-            self._state = ConnectionState.ERROR_BLEAK
+        except TimeoutError as e:
+            error = e
+            self._set_state(
+                ConnectionState.ERROR_TIMEOUT,
+                ConnectionTimeout().with_traceback(e.__traceback__),
+            )
+        except BleakNotFoundError as e:
+            error = e
+            self._set_state(ConnectionState.ERROR_NOT_FOUND, e)
+        except BleakError as e:
+            error = e
+            self._set_state(ConnectionState.ERROR_BLEAK, e)
 
         if error is not None:
+            if self._client is not None and self._client.is_connected:
+                await self._client.disconnect()
+
             self._logger.error("Failed to connect to the device: %s", error)
-            self._last_errors.append(f"Failed to connect to the device: {error}")
             self.disconnected()
             return
 
         self._logger.info("Connected")
         self._errors = 0
-        self._retry_on_disconnect = True
-        self._retry_on_disconnect_delay = 10
+        self._retry_on_disconnect = self._reconnect
 
         if self._client._backend.__class__.__name__ == "BleakClientBlueZDBus":
             await self._client._backend._acquire_mtu()
@@ -227,64 +289,161 @@ class Connection:
         self._logger.warning("Disconnected from device")
         self._client = None
 
-        if self._retry_on_disconnect:
-            self._state = ConnectionState.RECONNECTING
-            self._add_task(self.reconnect(), asyncio.get_event_loop())
+        if not self._retry_on_disconnect:
+            if self._reconnect_task:
+                self._reconnect_task.cancel()
+
+            self._connected.set()
+            self._disconnected.set()
+            if self._state is not ConnectionState.DISCONNECTING:
+                self._notify_disconnect()
+            self._set_state(ConnectionState.DISCONNECTED)
             return
 
-        self._connected.set()
-        self._disconnected.set()
-        self._on_disconnected()
+        if self._reconnect_task is not None:
+            return
+
+        loop = asyncio.get_event_loop()
+        self._reconnect_task = self._add_task(self.reconnect(), loop)
+
+        def _reconnect_done(task: asyncio.Task[None]):
+            self._reconnect_task = None
+            with contextlib.suppress(asyncio.CancelledError):
+                if exc := task.exception():
+                    raise exc
+
+        self._reconnect_task.add_done_callback(_reconnect_done)
 
     async def reconnect(self) -> None:
         # Wait before reconnect
+        if self._reconnect_attempt == 0:
+            self._retry_on_disconnect_delay = 10
+
+        self._reconnect_attempt += 1
+        if self._reconnect_attempt > MAX_RECONNECT_ATTEMPTS:
+            self._logger.error(
+                "Could not reconnect after %d attempts", MAX_RECONNECT_ATTEMPTS
+            )
+            self._set_state(
+                ConnectionState.ERROR_MAX_RECONNECT_ATTEMPTS_REACHED,
+                MaxReconnectAttemptsReached(
+                    attempts=MAX_RECONNECT_ATTEMPTS,
+                    last_error=self._last_exception,
+                ),
+            )
+            self._notify_disconnect(self._last_exception)
+
+            self._reconnect_attempt = 0
+            return
+
         self._logger.warning(
-            "Reconnecting to the device in %d seconds...",
+            "Reconnecting to the device in %d seconds, attempt: %d/%d...",
             self._retry_on_disconnect_delay,
+            self._reconnect_attempt,
+            MAX_RECONNECT_ATTEMPTS,
         )
         await asyncio.sleep(self._retry_on_disconnect_delay)
         if not self._retry_on_disconnect:
             self._logger.warning("Reconnect is aborted")
             return
+
         self._retry_on_disconnect_delay += 10
+        self._set_state(ConnectionState.RECONNECTING)
         await self.connect()
 
     async def disconnect(self) -> None:
-        self._logger.info("Disconnecting from device")
+        self._logger.info(msg="Disconnecting from device")
         self._retry_on_disconnect = False
+
+        self._reconnect_attempt = 0
+        self._cancel_tasks()
+
         if self._client is not None and self._client.is_connected:
-            self._cancel_tasks()
+            self._set_state(ConnectionState.DISCONNECTING)
             await self._client.disconnect()
-            self._on_disconnected()
 
         self._client = None
 
     async def wait_connected(self, timeout: int = 20):
         """Will release when connection is happened and authenticated"""
+        last_state = self._state
         try:
             await asyncio.wait_for(self._connected.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            self._state = ConnectionState.ERROR_TIMEOUT
+        except TimeoutError as e:
+            last_state = self._state
+            self._set_state(ConnectionState.ERROR_TIMEOUT, e)
 
-    async def wait_until_connected_or_error(self, timeout: int = 20):
+        if self._state is not ConnectionState.AUTHENTICATED:
+            self._set_state(
+                self._state,
+                FailedToAuthenticate(
+                    f"Could not connect to device, state: {last_state}"
+                ),
+            )
+
+    async def wait_until_authenticated_or_error(self, raise_on_error: bool = False):
         while not self._state.is_terminal():
-            await asyncio.wait_for(self._state_changed.wait(), timeout=timeout)
+            await self._state_changed.wait()
+
+            if (
+                self._state is ConnectionState.ERROR_MAX_RECONNECT_ATTEMPTS_REACHED
+                and raise_on_error
+            ):
+                assert isinstance(self._state_exception, MaxReconnectAttemptsReached)
+                raise (
+                    self._state_exception.last_error
+                    if self._state_exception.last_error is not None
+                    else self._state_exception
+                )
+
+        if self._state_exception is not None and raise_on_error:
+            raise self._state_exception
+
+        if self._state is ConnectionState.DISCONNECTED:
+            return self._last_state
+
         return self._state
 
     async def wait_disconnected(self):
         """Will release when client got disconnected from the device"""
         await self._disconnected.wait()
 
-    async def errorsAdd(self, exception: Exception):
+    async def add_error(self, exception: Exception):
         tb = traceback.format_tb(exception.__traceback__)
         self._logger.error("Captured exception: %s:\n%s", exception, "".join(tb))
         self._errors += 1
+        self._last_exception = exception
         if self._errors > 5:
             # Too many errors happened - let's reconnect
             self._errors = 0
+            self._set_state(ConnectionState.ERROR_TOO_MANY_ERRORS, exception)
             if self._client is not None and self._client.is_connected:
                 self._logger.warning("Client disconnected after encountering 5 errors")
                 await self._client.disconnect()
+
+    @property
+    def _state(self) -> ConnectionState:
+        return self._connection_state
+
+    @_state.setter
+    def _state(self, value: ConnectionState):
+        self._connection_state = value
+        self._state_changed.set()
+        self._state_changed.clear()
+        self._on_state_change(value)
+
+    def _set_state(
+        self, state: ConnectionState, exc: Exception | type[Exception] | None = None
+    ):
+        self._state_exception = exc
+        if exc is not None:
+            self._last_exception = exc
+
+        self._last_state = self._state
+        self._state = state
+
+        if state.is_error():
+            self._notify_disconnect(exc)
 
     # En/Decrypt functions must create AES object every time, because
     # it saves the internal state after encryption and become useless
@@ -354,7 +513,6 @@ class Connection:
             )
             payload_hex = bytearray(payload_data).hex()
             self._logger.error(error_msg, payload_hex)
-            self._last_errors.append(error_msg % payload_hex)
             raise PacketParseError
 
         return payload_data
@@ -376,7 +534,6 @@ class Connection:
                 "parseEncPackets: Unable to parse encrypted packet - too small: %r"
             )
             self._logger.error(error_msg, bytearray(data).hex())
-            self._last_errors.append(error_msg % bytearray(data).hex())
             raise EncPacketParseError
 
         # Data can contain multiple EncPackets and even incomplete ones, so walking through
@@ -388,7 +545,6 @@ class Connection:
                     "incorrect: %r"
                 )
                 self._logger.error(error_msg, bytearray(data).hex())
-                self._last_errors.append(error_msg % bytearray(data).hex())
                 return packets
 
             header = data[0:6]
@@ -408,7 +564,6 @@ class Connection:
                 if crc16(header + payload_data) != struct.unpack("<H", payload_crc)[0]:
                     error_msg = "Unable to parse encrypted packet - incorrect CRC16: %r"
                     self._logger.error(error_msg, bytearray(payload_data).hex())
-                    self._last_errors.append(error_msg % bytearray(payload_data).hex())
                     raise PacketParseError  # noqa: TRY301
 
                 # Decrypt the payload packet
@@ -428,9 +583,8 @@ class Connection:
                 )
                 if packet is not None:
                     packets.append(packet)
-            except Exception as e:
-                self._state = ConnectionState.ERROR_PACKET_PARSE
-                await self.errorsAdd(e)
+            except Exception as e:  # noqa: BLE001
+                await self.add_error(e)
 
         return packets
 
@@ -462,7 +616,7 @@ class Connection:
             else:
                 return
 
-        await self.errorsAdd(err)
+        await self.add_error(err)
 
     async def _sendRequest(self, send_data: bytes, response_handler=None):
         # Make sure the connection is here, otherwise just skipping
@@ -519,7 +673,7 @@ class Connection:
         self._add_task(self.sendPacket(reply_packet))
 
     async def initBleSessionKey(self):
-        self._state = ConnectionState.PUBLIC_KEY_EXCHANGE
+        self._set_state(ConnectionState.PUBLIC_KEY_EXCHANGE)
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "initBleSessionKey: Pub key exchange"
         )
@@ -539,7 +693,10 @@ class Connection:
     async def initBleSessionKeyHandler(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
     ):
-        self._state = ConnectionState.PUBLIC_KEY_RECEIVED
+        if self._client is None or not self._client.is_connected:
+            return
+
+        self._set_state(ConnectionState.PUBLIC_KEY_RECEIVED)
         await self._client.stop_notify(Connection.NOTIFY_CHARACTERISTIC)
 
         data = await self.parseSimple(bytes(recv_data))
@@ -568,7 +725,7 @@ class Connection:
         await self.getKeyInfoReq()
 
     async def getKeyInfoReq(self):
-        self._state = ConnectionState.REQUESTING_SESSION_KEY
+        self._set_state(ConnectionState.REQUESTING_SESSION_KEY)
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "getKeyInfoReq: Receiving session key"
         )
@@ -583,7 +740,10 @@ class Connection:
     async def getKeyInfoReqHandler(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
     ):
-        self._state = ConnectionState.SESSION_KEY_RECEIVED
+        if self._client is None or not self._client.is_connected:
+            return
+
+        self._set_state(ConnectionState.SESSION_KEY_RECEIVED)
         await self._client.stop_notify(Connection.NOTIFY_CHARACTERISTIC)
         encrypted_data = await self.parseSimple(bytes(recv_data))
 
@@ -602,7 +762,7 @@ class Connection:
         await self.getAuthStatus()
 
     async def getAuthStatus(self):
-        self._state = ConnectionState.REQUESTING_AUTH_STATUS
+        self._set_state(ConnectionState.REQUESTING_AUTH_STATUS)
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "getKeyInfoReq: Receiving auth status"
         )
@@ -615,7 +775,10 @@ class Connection:
     async def getAuthStatusHandler(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
     ):
-        self._state = ConnectionState.AUTH_STATUS_RECEIVED
+        if self._client is None or not self._client.is_connected:
+            return
+
+        self._set_state(ConnectionState.AUTH_STATUS_RECEIVED)
         await self._client.stop_notify(Connection.NOTIFY_CHARACTERISTIC)
         packets = await self.parseEncPackets(bytes(recv_data))
         if len(packets) < 1:
@@ -630,7 +793,7 @@ class Connection:
         await self.autoAuthentication()
 
     async def autoAuthentication(self):
-        self._state = ConnectionState.AUTHENTICATING
+        self._set_state(ConnectionState.AUTHENTICATING)
         self._logger.info(
             "autoAuthentication: Sending secretKey consists of user id and device "
             "serial number",
@@ -652,9 +815,8 @@ class Connection:
     ):
         try:
             packets = await self.parseEncPackets(bytes(recv_data))
-        except Exception as e:
-            self._state = ConnectionState.ERROR_PACKET_PARSE
-            await self.errorsAdd(e)
+        except Exception as e:  # noqa: BLE001
+            await self.add_error(e)
             return
 
         for packet in packets:
@@ -665,18 +827,29 @@ class Connection:
                 if packet.payload != b"\x00":
                     # TODO: Most probably we need to follow some other way for auth, but
                     # happens rarely
-                    self._logger.error("Auth failed with response: %r", packet)
-                    self._last_errors.append(f"Auth failed with response: {packet!r}")
-                    self._state = ConnectionState.ERROR_AUTH_FAILED
-                    self._connected.set()
-                    raise AuthFailedError
+                    error_msg = "Auth failed with response: %r"
+                    self._logger.error(error_msg, packet)
+                    exc = AuthFailedError(error_msg % packet)
+                    self._set_state(ConnectionState.ERROR_AUTH_FAILED, exc)
+
+                    if self._client is not None and self._client.is_connected:
+                        await self._client.disconnect()
+
+                    raise exc
+
+                self._connection_attempt = 0
+                self._reconnect_attempt = 0
                 processed = True
                 self._logger.info("Auth completed, everything is fine")
-                self._state = ConnectionState.AUTHENTICATED
+                self._set_state(ConnectionState.AUTHENTICATED)
                 self._connected.set()
             else:
-                # Processing the packet with specific device
-                processed = await self._data_parse(packet)
+                try:
+                    # Processing the packet with specific device
+                    processed = await self._data_parse(packet)
+                except Exception as e:  # noqa: BLE001
+                    await self.add_error(e)
+                    continue
 
             if not processed:
                 self._logger.log_filtered(
@@ -689,11 +862,14 @@ class Connection:
         self._tasks.clear()
 
     def _add_task(
-        self, coro: Coroutine, event_loop: asyncio.AbstractEventLoop | None = None
+        self,
+        coro: Coroutine,
+        event_loop: asyncio.AbstractEventLoop | None = None,
     ):
         task = event_loop.create_task(coro) if event_loop else asyncio.create_task(coro)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
+        return task
 
 
 def getEcdhTypeSize(curve_num: int):

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -8,7 +8,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak_retry_connector import MAX_CONNECT_ATTEMPTS
 
-from .connection import Connection, ConnectionState
+from .connection import Connection, ConnectionState, DisconnectListener
 from .logging_util import DeviceLogger, LogOptions
 from .packet import Packet
 
@@ -48,6 +48,9 @@ class DeviceBase:
         self._props_to_update = set()
         self._wait_until_throttle = 0
 
+        self._reconnect_disabled = False
+        self._disconnect_listeners: list[DisconnectListener] = []
+
     @property
     def device(self):
         return self.__doc__ if self.__doc__ else ""
@@ -85,6 +88,12 @@ class DeviceBase:
             self._conn.with_logging_options(options)
         return self
 
+    def with_disabled_reconnect(self, is_disabled: bool = True):
+        self._reconnect_disabled = is_disabled
+        if self._conn is not None:
+            self._conn.with_disabled_reconnect(is_disabled)
+        return self
+
     async def data_parse(self, packet: Packet) -> bool:
         """Function to parse incoming data and trigger sensors update"""
         return False
@@ -94,21 +103,34 @@ class DeviceBase:
         return Packet.fromBytes(data)
 
     async def connect(
-        self, user_id: str | None = None, max_attempts: int = MAX_CONNECT_ATTEMPTS
+        self,
+        user_id: str | None = None,
+        max_attempts: int = MAX_CONNECT_ATTEMPTS,
+        timeout: int = 20,
     ):
         if self._conn is None:
-            self._conn = Connection(
-                self._ble_dev,
-                self._sn,
-                user_id,
-                self.data_parse,
-                self.packet_parse,
-            ).with_logging_options(self._logger.options)
+            self._conn = (
+                Connection(
+                    self._ble_dev,
+                    self._sn,
+                    user_id,
+                    self.data_parse,
+                    self.packet_parse,
+                )
+                .with_logging_options(self._logger.options)
+                .with_disabled_reconnect(self._reconnect_disabled)
+            )
             self._logger.info("Connecting to %s", self.device)
+
+            def _disconnect_callback(exc):
+                for callback in self._disconnect_listeners:
+                    callback(exc)
+
+            self._conn.on_disconnect(_disconnect_callback)
         elif self._conn._user_id != user_id:
             self._conn._user_id = user_id
 
-        await self._conn.connect(max_attempts=max_attempts)
+        await self._conn.connect(max_attempts=max_attempts, timeout=timeout)
 
     async def disconnect(self):
         if self._conn is None:
@@ -131,10 +153,34 @@ class DeviceBase:
         if self.is_connected:
             await self._conn.wait_disconnected()
 
-    async def wait_until_connected_or_error(self, timeout: int = 20):
+    async def wait_until_authenticated_or_error(self, raise_on_error: bool = False):
         if self._conn is None:
             return ConnectionState.NOT_CONNECTED
-        return await self._conn.wait_until_connected_or_error(timeout)
+
+        return await self._conn.wait_until_authenticated_or_error(
+            raise_on_error=raise_on_error
+        )
+
+    def on_disconnect(self, listener: DisconnectListener):
+        """
+        Add disconnect listener
+
+        Parameters
+        ----------
+        listener
+            Listener that will be called on disconnect that receives exception as a
+            param if one occured before device disconnected
+
+        Return
+        -------
+        Function to remove this listener
+        """
+        self._disconnect_listeners.append(listener)
+
+        def _unlisten():
+            self._disconnect_listeners.remove(listener)
+
+        return _unlisten
 
     def register_callback(
         self, callback: Callable[[], None], propname: str | None = None

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -8,7 +8,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak_retry_connector import MAX_CONNECT_ATTEMPTS
 
-from .connection import Connection
+from .connection import Connection, ConnectionState
 from .logging_util import DeviceLogger, LogOptions
 from .packet import Packet
 
@@ -29,7 +29,7 @@ class DeviceBase:
         self._address = ble_dev.address
 
         self._logger = DeviceLogger(self)
-        self._logging_options = LogOptions(0)
+        self._logging_options = LogOptions.no_options()
 
         self._logger.debug(
             "Creating new device: %s (%s)",
@@ -104,7 +104,7 @@ class DeviceBase:
                 self.data_parse,
                 self.packet_parse,
             ).with_logging_options(self._logger.options)
-            self._logger.info("Connecting to %s", self.__doc__)
+            self._logger.info("Connecting to %s", self.device)
         elif self._conn._user_id != user_id:
             self._conn._user_id = user_id
 
@@ -117,18 +117,24 @@ class DeviceBase:
 
         await self._conn.disconnect()
 
-    async def waitConnected(self, timeout: int = 20):
+    async def wait_connected(self, timeout: int = 20):
         if self._conn is None:
             self._logger.error("Device has no connection")
             return
-        await self._conn.waitConnected(timeout=timeout)
+        await self._conn.wait_connected(timeout=timeout)
 
-    async def waitDisconnected(self):
+    async def wait_disconnected(self):
         if self._conn is None:
             self._logger.error("Device has no connection")
             return
 
-        await self._conn.waitDisconnected()
+        if self.is_connected:
+            await self._conn.wait_disconnected()
+
+    async def wait_until_connected_or_error(self, timeout: int = 20):
+        if self._conn is None:
+            return ConnectionState.NOT_CONNECTED
+        return await self._conn.wait_until_connected_or_error(timeout)
 
     def register_callback(
         self, callback: Callable[[], None], propname: str | None = None

--- a/custom_components/ef_ble/eflib/exceptions.py
+++ b/custom_components/ef_ble/eflib/exceptions.py
@@ -1,0 +1,44 @@
+class PacketParseError(Exception):
+    """Error during parsing Packet"""
+
+
+class EncPacketParseError(Exception):
+    """Error during parsing EncPacket"""
+
+
+class PacketReceiveError(Exception):
+    """Error during receiving packet"""
+
+
+class AuthFailedError(Exception):
+    """Error during authentificating"""
+
+
+class FailedToAuthenticate(Exception):
+    """Failed to connect"""
+
+
+class ConnectionTimeout(TimeoutError):
+    """Connection timeout reached"""
+
+
+class MaxConnectionAttemptsReached(Exception):
+    """Device could not complete initial connection after maximum attempts"""
+
+    def __init__(
+        self, last_error: Exception | type[Exception] | None = None, attempts: int = 8
+    ):
+        super().__init__()
+        self.last_error = last_error
+        self.attempts = attempts
+
+
+class MaxReconnectAttemptsReached(Exception):
+    """Device could not reconnect after maximum attempts"""
+
+    def __init__(self, last_error: Exception | type[Exception], attempts: int = 2):
+        super().__init__(
+            f"Could not connect to device after {attempts} unsuccessful attempts"
+        )
+        self.last_error = last_error
+        self.attempts = attempts

--- a/custom_components/ef_ble/eflib/logging_util.py
+++ b/custom_components/ef_ble/eflib/logging_util.py
@@ -69,6 +69,10 @@ class LogOptions(Flag):
             | LogOptions.CONNECTION_DEBUG
         )
 
+    @staticmethod
+    def no_options():
+        return LogOptions(0)
+
 
 _BLEAK_LOGGER = logging.getLogger(bleak.__name__)
 _ORIGINAL_BLEAK_LOG_LEVEL = _BLEAK_LOGGER.level
@@ -80,7 +84,7 @@ class MaskingLogger(logging.Logger):
     ) -> None:
         self._logger = logger
         self._mask_funcs = mask_funcs
-        self._options = LogOptions(0)
+        self._options = LogOptions.no_options()
 
     @cached_property
     def _mask_filter(self):

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -1,21 +1,4 @@
 {
-  "exceptions": {
-    "unable_to_create_device": {
-      "message": "EcoFlow BLE Device unable to create"
-    },
-    "device_not_present": {
-      "message": "EcoFlow BLE device not present"
-    },
-    "could_not_connect": {
-      "message": "Could not connect to the device after {time} seconds, check the logs"
-    },
-    "error_after_connected": {
-      "message": "Error occured before device could authenticate"
-    },
-    "could_not_authenticate": {
-      "message": "Could not authenticate, check the logs"
-    }
-  },
   "config": {
     "abort": {
       "already_configured": "Device is already configured",
@@ -41,10 +24,12 @@
         "data": {
           "user_id": "EcoFlow User ID",
           "address": "BLE Device",
-          "update_period": "Update Period"
+          "update_period": "Update Period",
+          "connection_timeout": "Connection Timeout"
         },
         "data_description": {
-          "update_period": "Number of seconds to wait before processing the next device update. A default value of 0 means all updates are processed immediately (this may result in a high number of database writes)."
+          "update_period": "Number of seconds to wait before processing the next device update. Value of 0 means all updates are processed immediately (will result in a high number of database writes).",
+          "connection_timeout": "Number of seconds to wait for the device to connect and authenticate."
         },
         "sections": {
           "login": {
@@ -74,10 +59,12 @@
         "data": {
           "user_id": "EcoFlow User ID",
           "address": "BLE Device",
-          "update_period": "Update Period"
+          "update_period": "Update Period",
+          "connection_timeout": "Connection Timeout"
         },
         "data_description": {
-          "update_period": "Number of seconds to wait before processing the next device update. A default value of 0 means all updates are processed immediately (may result in a high number of DB writes)."
+          "update_period": "Number of seconds to wait before processing the next device update. Value of 0 means all updates are processed immediately (will result in a high number of DB writes).",
+          "connection_timeout": "Number of seconds to wait for the device to connect and authenticate."
         },
         "sections": {
           "login": {
@@ -117,7 +104,7 @@
           "update_period": "Update Period"
         },
         "data_description": {
-          "update_period": "Number of seconds to wait before processing the next device update. A default value of 0 means all updates are processed immediately (may result in a high number of DB writes)."
+          "update_period": "Number of seconds to wait before processing the next device update. Value of 0 means all updates are processed immediately (will result in a high number of DB writes)."
         },
         "sections": {
           "log_options": {
@@ -135,6 +122,41 @@
           }
         }
       }
+    }
+  },
+  "exceptions": {
+    "unknown_error": {
+      "message": "Unknown error: {error}"
+    },
+    "unable_to_create_device": {
+      "message": "EcoFlow BLE Device unable to create"
+    },
+    "device_not_present": {
+      "message": "EcoFlow BLE device not present"
+    },
+    "could_not_connect": {
+      "message": "Could not connect to the device after {time} seconds, check the logs"
+    },
+    "error_after_connected": {
+      "message": "Error occured before device could authenticate"
+    },
+    "authentication_failed": {
+      "message": "Authentication failed"
+    },
+    "could_not_reconnect_after_max_attempts": {
+      "message": "Could not reconnect after losing connection {attempts} times."
+    },
+    "could_not_connect_no_retry": {
+      "message": "Could not connect to device after {attempts} unsuccessful attempts"
+    },
+    "failed_after_successful_connection": {
+      "message": "Device connected but did not get to auth procedure, last state: {last_state}"
+    }
+  },
+  "issues": {
+    "max_connection_attempts_reached": {
+      "title": "Could not connect to {device_name} after {attempts} unsuccessful attempts",
+      "description": "Failed to connect to {device_name} after {attempts} unsuccessful attempts. Check the logs for more info.\n\nAutomatic retry was disabled to not spam logs, integration has to be reloaded manually. This error clears after successful connection."
     }
   },
   "entity": {

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -1,4 +1,21 @@
 {
+  "exceptions": {
+    "unable_to_create_device": {
+      "message": "EcoFlow BLE Device unable to create"
+    },
+    "device_not_present": {
+      "message": "EcoFlow BLE device not present"
+    },
+    "could_not_connect": {
+      "message": "Could not connect to the device after {time} seconds, check the logs"
+    },
+    "error_after_connected": {
+      "message": "Error occured before device could authenticate"
+    },
+    "could_not_authenticate": {
+      "message": "Could not authenticate, check the logs"
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "Device is already configured",


### PR DESCRIPTION
This PR adds multiple changes:
- **Reworked reconnection logic** - instead of handling reconnections ourselves, this PR switches control to home assistant config reloads. This is better because it displays errors and retries in integration UI so user does not need to look at logs to see if something failed.
- **Reconnect can now only create one task at a time** - there was possibility that `disconnected` was called more than once which caused multiple reconnect tasks to be spawned at once. If this repeats several times, requests would overlap and device received messages in wrong order causing it to immediately disconnect. This spawned yet more reconnect tasks and existing messages would still be received on the same characteristic but client would not be connected. This would explain what was was happening in #36.
- Added issues in case of connection failures - if the device can not connect more than 10 times in succession, setup fails until it is manually reloaded and creates HA issue that persists until the device is connected successfully
- **Changed update period default to 10 seconds** - it makes more sense to have it a bit higher by default as most of the users don't need it.
- Added observable states to connection for better error reporting
- Added connection timeout option