### PR TITLE
Add individual circuit control switches for EcoFlow SHP2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Python cache files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -12,8 +12,8 @@ from ..props import (
     proto_attr_mapper,
     repeated_pb_field_type,
 )
-from ..props.protobuf_field import TransformIfMissing
 from ..props.enums import IntFieldValue
+from ..props.protobuf_field import TransformIfMissing
 
 pb_time = proto_attr_mapper(pd303_pb2.ProtoTime)
 pb_push_set = proto_attr_mapper(pd303_pb2.ProtoPushAndSet)
@@ -21,8 +21,9 @@ pb_push_set = proto_attr_mapper(pd303_pb2.ProtoPushAndSet)
 
 class CircuitState(IntFieldValue):
     """Circuit state enum (0=OFF, 1=ON)"""
+
     UNKNOWN = -1
-    
+
     OFF = 0
     ON = 1
 
@@ -57,6 +58,13 @@ class ChannelPowerField(repeated_pb_field_type(list_field=pb_time.watt_info.ch_w
 
 def _errors(error_codes: pd303_pb2.ErrCode):
     return [e for e in error_codes.err_code if e != b"\x00\x00\x00\x00\x00\x00\x00\x00"]
+
+
+def _is_circuit_on(v):
+    return CircuitState.from_value(v) is CircuitState.ON
+
+
+_hall1_incre_info = pb_push_set.load_incre_info.hall1_incre_info
 
 
 class Device(DeviceBase, ProtobufProps):
@@ -97,21 +105,18 @@ class Device(DeviceBase, ProtobufProps):
     circuit_current_12 = CircuitCurrentField(11)
 
     # Circuit state properties (on/off control)
-    circuit_1 = pb_field(
-        pb_push_set.load_incre_info.hall1_incre_info.ch1_sta.load_sta, 
-        lambda v: CircuitState.from_value(v) is CircuitState.ON
-    )
-    circuit_2 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch2_sta.load_sta, CircuitState)
-    circuit_3 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch3_sta.load_sta, CircuitState)
-    circuit_4 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch4_sta.load_sta, CircuitState)
-    circuit_5 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch5_sta.load_sta, CircuitState)
-    circuit_6 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch6_sta.load_sta, CircuitState)
-    circuit_7 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch7_sta.load_sta, CircuitState)
-    circuit_8 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch8_sta.load_sta, CircuitState)
-    circuit_9 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch9_sta.load_sta, CircuitState)
-    circuit_10 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch10_sta.load_sta, CircuitState)
-    circuit_11 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch11_sta.load_sta, CircuitState)
-    circuit_12 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch12_sta.load_sta, CircuitState)
+    circuit_1 = pb_field(_hall1_incre_info.ch1_sta.load_sta, _is_circuit_on)
+    circuit_2 = pb_field(_hall1_incre_info.ch2_sta.load_sta, _is_circuit_on)
+    circuit_3 = pb_field(_hall1_incre_info.ch3_sta.load_sta, _is_circuit_on)
+    circuit_4 = pb_field(_hall1_incre_info.ch4_sta.load_sta, _is_circuit_on)
+    circuit_5 = pb_field(_hall1_incre_info.ch5_sta.load_sta, _is_circuit_on)
+    circuit_6 = pb_field(_hall1_incre_info.ch6_sta.load_sta, _is_circuit_on)
+    circuit_7 = pb_field(_hall1_incre_info.ch7_sta.load_sta, _is_circuit_on)
+    circuit_8 = pb_field(_hall1_incre_info.ch8_sta.load_sta, _is_circuit_on)
+    circuit_9 = pb_field(_hall1_incre_info.ch9_sta.load_sta, _is_circuit_on)
+    circuit_10 = pb_field(_hall1_incre_info.ch10_sta.load_sta, _is_circuit_on)
+    circuit_11 = pb_field(_hall1_incre_info.ch11_sta.load_sta, _is_circuit_on)
+    circuit_12 = pb_field(_hall1_incre_info.ch12_sta.load_sta, _is_circuit_on)
 
     channel_power_1 = ChannelPowerField(0)
     channel_power_2 = ChannelPowerField(1)
@@ -217,55 +222,6 @@ class Device(DeviceBase, ProtobufProps):
             self.update_state(field_name, getattr(self, field_name))
 
         return processed
-
-    # Circuit enable methods for Home Assistant switches
-    async def enable_circuit_1(self, enable: bool):
-        """Enable/disable circuit 1"""
-        await self.set_circuit_power(0, enable)
-
-    async def enable_circuit_2(self, enable: bool):
-        """Enable/disable circuit 2"""
-        await self.set_circuit_power(1, enable)
-
-    async def enable_circuit_3(self, enable: bool):
-        """Enable/disable circuit 3"""
-        await self.set_circuit_power(2, enable)
-
-    async def enable_circuit_4(self, enable: bool):
-        """Enable/disable circuit 4"""
-        await self.set_circuit_power(3, enable)
-
-    async def enable_circuit_5(self, enable: bool):
-        """Enable/disable circuit 5"""
-        await self.set_circuit_power(4, enable)
-
-    async def enable_circuit_6(self, enable: bool):
-        """Enable/disable circuit 6"""
-        await self.set_circuit_power(5, enable)
-
-    async def enable_circuit_7(self, enable: bool):
-        """Enable/disable circuit 7"""
-        await self.set_circuit_power(6, enable)
-
-    async def enable_circuit_8(self, enable: bool):
-        """Enable/disable circuit 8"""
-        await self.set_circuit_power(7, enable)
-
-    async def enable_circuit_9(self, enable: bool):
-        """Enable/disable circuit 9"""
-        await self.set_circuit_power(8, enable)
-
-    async def enable_circuit_10(self, enable: bool):
-        """Enable/disable circuit 10"""
-        await self.set_circuit_power(9, enable)
-
-    async def enable_circuit_11(self, enable: bool):
-        """Enable/disable circuit 11"""
-        await self.set_circuit_power(10, enable)
-
-    async def enable_circuit_12(self, enable: bool):
-        """Enable/disable circuit 12"""
-        await self.set_circuit_power(11, enable)
 
     async def set_config_flag(self, enable):
         """Send command to enable/disable sending config data from device to the host"""

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -95,7 +95,10 @@ class Device(DeviceBase, ProtobufProps):
     circuit_current_12 = CircuitCurrentField(11)
 
     # Circuit state properties (on/off control)
-    circuit_1 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch1_sta.load_sta, CircuitState)
+    circuit_1 = pb_field(
+        pb_push_set.load_incre_info.hall1_incre_info.ch1_sta.load_sta, 
+        lambda v: CircuitState.from_value(v) is CircuitState.ON
+    )
     circuit_2 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch2_sta.load_sta, CircuitState)
     circuit_3 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch3_sta.load_sta, CircuitState)
     circuit_4 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch4_sta.load_sta, CircuitState)

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -21,6 +21,8 @@ pb_push_set = proto_attr_mapper(pd303_pb2.ProtoPushAndSet)
 
 class CircuitState(IntFieldValue):
     """Circuit state enum (0=OFF, 1=ON)"""
+    UNKNOWN = -1
+    
     OFF = 0
     ON = 1
 

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -13,9 +13,16 @@ from ..props import (
     repeated_pb_field_type,
 )
 from ..props.protobuf_field import TransformIfMissing
+from ..props.enums import IntFieldValue
 
 pb_time = proto_attr_mapper(pd303_pb2.ProtoTime)
 pb_push_set = proto_attr_mapper(pd303_pb2.ProtoPushAndSet)
+
+
+class CircuitState(IntFieldValue):
+    """Circuit state enum (0=OFF, 1=ON)"""
+    OFF = 0
+    ON = 1
 
 
 @dataclass
@@ -86,6 +93,20 @@ class Device(DeviceBase, ProtobufProps):
     circuit_current_10 = CircuitCurrentField(9)
     circuit_current_11 = CircuitCurrentField(10)
     circuit_current_12 = CircuitCurrentField(11)
+
+    # Circuit state properties (on/off control)
+    circuit_1 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch1_sta.load_sta, CircuitState)
+    circuit_2 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch2_sta.load_sta, CircuitState)
+    circuit_3 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch3_sta.load_sta, CircuitState)
+    circuit_4 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch4_sta.load_sta, CircuitState)
+    circuit_5 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch5_sta.load_sta, CircuitState)
+    circuit_6 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch6_sta.load_sta, CircuitState)
+    circuit_7 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch7_sta.load_sta, CircuitState)
+    circuit_8 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch8_sta.load_sta, CircuitState)
+    circuit_9 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch9_sta.load_sta, CircuitState)
+    circuit_10 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch10_sta.load_sta, CircuitState)
+    circuit_11 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch11_sta.load_sta, CircuitState)
+    circuit_12 = pb_field(pb_push_set.load_incre_info.hall1_incre_info.ch12_sta.load_sta, CircuitState)
 
     channel_power_1 = ChannelPowerField(0)
     channel_power_2 = ChannelPowerField(1)
@@ -191,6 +212,55 @@ class Device(DeviceBase, ProtobufProps):
             self.update_state(field_name, getattr(self, field_name))
 
         return processed
+
+    # Circuit enable methods for Home Assistant switches
+    async def enable_circuit_1(self, enable: bool):
+        """Enable/disable circuit 1"""
+        await self.set_circuit_power(0, enable)
+
+    async def enable_circuit_2(self, enable: bool):
+        """Enable/disable circuit 2"""
+        await self.set_circuit_power(1, enable)
+
+    async def enable_circuit_3(self, enable: bool):
+        """Enable/disable circuit 3"""
+        await self.set_circuit_power(2, enable)
+
+    async def enable_circuit_4(self, enable: bool):
+        """Enable/disable circuit 4"""
+        await self.set_circuit_power(3, enable)
+
+    async def enable_circuit_5(self, enable: bool):
+        """Enable/disable circuit 5"""
+        await self.set_circuit_power(4, enable)
+
+    async def enable_circuit_6(self, enable: bool):
+        """Enable/disable circuit 6"""
+        await self.set_circuit_power(5, enable)
+
+    async def enable_circuit_7(self, enable: bool):
+        """Enable/disable circuit 7"""
+        await self.set_circuit_power(6, enable)
+
+    async def enable_circuit_8(self, enable: bool):
+        """Enable/disable circuit 8"""
+        await self.set_circuit_power(7, enable)
+
+    async def enable_circuit_9(self, enable: bool):
+        """Enable/disable circuit 9"""
+        await self.set_circuit_power(8, enable)
+
+    async def enable_circuit_10(self, enable: bool):
+        """Enable/disable circuit 10"""
+        await self.set_circuit_power(9, enable)
+
+    async def enable_circuit_11(self, enable: bool):
+        """Enable/disable circuit 11"""
+        await self.set_circuit_power(10, enable)
+
+    async def enable_circuit_12(self, enable: bool):
+        """Enable/disable circuit 12"""
+        await self.set_circuit_power(11, enable)
 
     async def set_config_flag(self, enable):
         """Send command to enable/disable sending config data from device to the host"""

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -61,8 +61,10 @@ def _errors(error_codes: pd303_pb2.ErrCode):
 
 
 def _is_circuit_on(v):
-    return CircuitState.from_value(v) is CircuitState.ON
+    return CircuitState.from_value(v) is CircuitState.ON if v is not None else False
 
+
+_is_circuit_on_missing = TransformIfMissing(_is_circuit_on)
 
 _hall1_incre_info = pb_push_set.load_incre_info.hall1_incre_info
 
@@ -105,18 +107,18 @@ class Device(DeviceBase, ProtobufProps):
     circuit_current_12 = CircuitCurrentField(11)
 
     # Circuit state properties (on/off control)
-    circuit_1 = pb_field(_hall1_incre_info.ch1_sta.load_sta, _is_circuit_on)
-    circuit_2 = pb_field(_hall1_incre_info.ch2_sta.load_sta, _is_circuit_on)
-    circuit_3 = pb_field(_hall1_incre_info.ch3_sta.load_sta, _is_circuit_on)
-    circuit_4 = pb_field(_hall1_incre_info.ch4_sta.load_sta, _is_circuit_on)
-    circuit_5 = pb_field(_hall1_incre_info.ch5_sta.load_sta, _is_circuit_on)
-    circuit_6 = pb_field(_hall1_incre_info.ch6_sta.load_sta, _is_circuit_on)
-    circuit_7 = pb_field(_hall1_incre_info.ch7_sta.load_sta, _is_circuit_on)
-    circuit_8 = pb_field(_hall1_incre_info.ch8_sta.load_sta, _is_circuit_on)
-    circuit_9 = pb_field(_hall1_incre_info.ch9_sta.load_sta, _is_circuit_on)
-    circuit_10 = pb_field(_hall1_incre_info.ch10_sta.load_sta, _is_circuit_on)
-    circuit_11 = pb_field(_hall1_incre_info.ch11_sta.load_sta, _is_circuit_on)
-    circuit_12 = pb_field(_hall1_incre_info.ch12_sta.load_sta, _is_circuit_on)
+    circuit_1 = pb_field(_hall1_incre_info.ch1_sta.load_sta, _is_circuit_on_missing)
+    circuit_2 = pb_field(_hall1_incre_info.ch2_sta.load_sta, _is_circuit_on_missing)
+    circuit_3 = pb_field(_hall1_incre_info.ch3_sta.load_sta, _is_circuit_on_missing)
+    circuit_4 = pb_field(_hall1_incre_info.ch4_sta.load_sta, _is_circuit_on_missing)
+    circuit_5 = pb_field(_hall1_incre_info.ch5_sta.load_sta, _is_circuit_on_missing)
+    circuit_6 = pb_field(_hall1_incre_info.ch6_sta.load_sta, _is_circuit_on_missing)
+    circuit_7 = pb_field(_hall1_incre_info.ch7_sta.load_sta, _is_circuit_on_missing)
+    circuit_8 = pb_field(_hall1_incre_info.ch8_sta.load_sta, _is_circuit_on_missing)
+    circuit_9 = pb_field(_hall1_incre_info.ch9_sta.load_sta, _is_circuit_on_missing)
+    circuit_10 = pb_field(_hall1_incre_info.ch10_sta.load_sta, _is_circuit_on_missing)
+    circuit_11 = pb_field(_hall1_incre_info.ch11_sta.load_sta, _is_circuit_on_missing)
+    circuit_12 = pb_field(_hall1_incre_info.ch12_sta.load_sta, _is_circuit_on_missing)
 
     channel_power_1 = ChannelPowerField(0)
     channel_power_2 = ChannelPowerField(1)

--- a/custom_components/ef_ble/eflib/props/protobuf_field.py
+++ b/custom_components/ef_ble/eflib/props/protobuf_field.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from google.protobuf.message import Message
 
@@ -10,13 +11,15 @@ if TYPE_CHECKING:
 
 
 class _ProtoAttr:
-    def __init__(self, message_type: type[Message], name: str):
-        self.attrs = [name]
+    def __init__(self, message_type: type[Message], names: str | list[str]):
+        if isinstance(names, list):
+            self.attrs = names.copy()
+        else:
+            self.attrs = [names]
         self.message_type = message_type
 
     def __getattr__(self, name: str):
-        self.attrs.append(name)
-        return self
+        return _ProtoAttr(self.message_type, [*self.attrs, name])
 
     def __repr__(self):
         return f"proto_attr({self.attrs})"

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -45,78 +45,15 @@ SWITCH_TYPES = [
         icon="mdi:usb",
     ),
     # SHP2 Circuit switches
-    SwitchEntityDescription(
-        key="circuit_1",
-        name="Circuit 1",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_2",
-        name="Circuit 2",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_3",
-        name="Circuit 3",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_4",
-        name="Circuit 4",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_5",
-        name="Circuit 5",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_6",
-        name="Circuit 6",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_7",
-        name="Circuit 7",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_8",
-        name="Circuit 8",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_9",
-        name="Circuit 9",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_10",
-        name="Circuit 10",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_11",
-        name="Circuit 11",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
-    SwitchEntityDescription(
-        key="circuit_12",
-        name="Circuit 12",
-        device_class=SwitchDeviceClass.OUTLET,
-        icon="mdi:power-socket-us",
-    ),
+    *[
+        EcoflowSwitchEntityDescription[shp2.Device](
+           key="circuit_{i}",
+            name=f"Circuit {i:02}",
+            device_class=SwitchDeviceClass.OUTLET,
+            icon="mdi:power-socket-us",
+            enable=lambda device, enabled: device.set_circuit_power(i, enabled),
+        ) for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
+    ],
 ]
 
 

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -44,6 +44,79 @@ SWITCH_TYPES = [
         name="USB Ports",
         icon="mdi:usb",
     ),
+    # SHP2 Circuit switches
+    SwitchEntityDescription(
+        key="circuit_1",
+        name="Circuit 1",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_2",
+        name="Circuit 2",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_3",
+        name="Circuit 3",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_4",
+        name="Circuit 4",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_5",
+        name="Circuit 5",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_6",
+        name="Circuit 6",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_7",
+        name="Circuit 7",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_8",
+        name="Circuit 8",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_9",
+        name="Circuit 9",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_10",
+        name="Circuit 10",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_11",
+        name="Circuit 11",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
+    SwitchEntityDescription(
+        key="circuit_12",
+        name="Circuit 12",
+        device_class=SwitchDeviceClass.OUTLET,
+        icon="mdi:power-socket-us",
+    ),
 ]
 
 
@@ -89,7 +162,11 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
 
     @callback
     def state_updated(self, state: bool | None):
-        self._on_off_state = state
+        # Handle protobuf enum values (0=OFF, 1=ON) for circuit switches
+        if isinstance(state, int):
+            self._on_off_state = state == 1
+        else:
+            self._on_off_state = state
         self.async_write_ha_state()
 
     @property

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -1,4 +1,7 @@
-from typing import Any
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Callable
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -10,7 +13,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DeviceConfigEntry
 from .eflib import DeviceBase
+from .eflib.devices import shp2
 from .entity import EcoflowEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class EcoflowSwitchEntityDescription[Device: DeviceBase](SwitchEntityDescription):
+    enable: Callable[[Device, bool], Awaitable[None]] | None = None
+
 
 SWITCH_TYPES = [
     SwitchEntityDescription(
@@ -47,12 +57,13 @@ SWITCH_TYPES = [
     # SHP2 Circuit switches
     *[
         EcoflowSwitchEntityDescription[shp2.Device](
-           key="circuit_{i}",
+            key=f"circuit_{i}",
             name=f"Circuit {i:02}",
             device_class=SwitchDeviceClass.OUTLET,
             icon="mdi:power-socket-us",
-            enable=lambda device, enabled: device.set_circuit_power(i, enabled),
-        ) for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
+            enable=lambda device, enabled, i=i: device.set_circuit_power(i, enabled),
+        )
+        for i in range(1, shp2.Device.NUM_OF_CIRCUITS + 1)
     ],
 ]
 
@@ -68,7 +79,10 @@ async def async_setup_entry(
         EcoflowSwitchEntity(device, switch_desc)
         for switch_desc in SWITCH_TYPES
         if hasattr(device, switch_desc.key)
-        and hasattr(device, f"enable_{switch_desc.key}")
+        and (
+            hasattr(device, f"enable_{switch_desc.key}")
+            or isinstance(switch_desc, EcoflowSwitchEntityDescription)
+        )
     ]
 
     if switches:
@@ -83,15 +97,25 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
 
         self._attr_unique_id = f"{device.name}_{entity_description.key}"
         self._prop_name = entity_description.key
-        self._method_name = f"enable_{self._prop_name}"
         self.entity_description = entity_description
         self._on_off_state = False
 
+        if (
+            isinstance(entity_description, EcoflowSwitchEntityDescription)
+            and entity_description.enable is not None
+        ):
+            self._update_state_func = partial(entity_description.enable, device)
+        else:
+            self._update_state_func = getattr(self._device, f"enable_{self._prop_name}")
+
+        if entity_description.translation_key is None:
+            self._attr_translation_key = self.entity_description.key
+
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await getattr(self._device, self._method_name)(True)
+        await self._update_state_func(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await getattr(self._device, self._method_name)(False)
+        await self._update_state_func(False)
 
     async def async_added_to_hass(self) -> None:
         self._device.register_state_update_callback(self.state_updated, self._prop_name)
@@ -99,11 +123,7 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
 
     @callback
     def state_updated(self, state: bool | None):
-        # Handle protobuf enum values (0=OFF, 1=ON) for circuit switches
-        if isinstance(state, int):
-            self._on_off_state = state == 1
-        else:
-            self._on_off_state = state
+        self._on_off_state = state
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
- Add circuit state properties (circuit_1 - circuit_12) to track on/off status
- Add enable methods (enable_circuit_1 - enable_circuit_12) for Home Assistant integration
- Add 12 circuit switch entities with proper outlet device class and icons
- Enhance switch state handling for protobuf enum values (0=OFF, 1=ON)
- Uses existing set_circuit_power() method for reliable BLE communication

This enables individual control of all 12 SHP2 circuits through Home Assistant switches, supporting automation and manual control while maintaining compatibility with the EcoFlow app.

Original author @crogers2287, see #54 