### PR TITLE
Fix D3 solar power sensor not updating

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta3.py
+++ b/custom_components/ef_ble/eflib/devices/delta3.py
@@ -160,7 +160,7 @@ class Device(DeviceBase, ProtobufProps):
         self.solar_input_power = (
             round(self.dc_port_input_power, 2)
             if (
-                self.dc_port_state == DCPortState.SOLAR.state_name
+                self.dc_port_state is DCPortState.SOLAR
                 and self.dc_port_input_power is not None
             )
             else 0

--- a/custom_components/ef_ble/eflib/devices/delta3_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_plus.py
@@ -26,7 +26,7 @@ class Device(delta3.Device):
         self.solar_input_power_2 = (
             round(self.dc_port_2_input_power, 2)
             if (
-                self.dc_port_2_state == DCPortState.SOLAR.state_name
+                self.dc_port_2_state is DCPortState.SOLAR
                 and self.dc_port_2_input_power is not None
             )
             else 0

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -57,12 +57,8 @@ class Device(DeviceBase, ProtobufProps):
 
     dc_lv_input_power = pb_field(pb.pow_get_pv_l)
     dc_hv_input_power = pb_field(pb.pow_get_pv_h)
-    dc_lv_input_state = pb_field(
-        pb.plug_in_info_pv_l_type, lambda v: DCPortState.from_value(v).state_name
-    )
-    dc_hv_input_state = pb_field(
-        pb.plug_in_info_pv_h_type, lambda v: DCPortState.from_value(v).state_name
-    )
+    dc_lv_input_state = pb_field(pb.plug_in_info_pv_l_type, DCPortState.from_value)
+    dc_hv_input_state = pb_field(pb.plug_in_info_pv_h_type, DCPortState.from_value)
 
     usbc_output_power = pb_field(pb.pow_get_typec1, _out_power)
     usbc2_output_power = pb_field(pb.pow_get_typec2, _out_power)
@@ -132,11 +128,9 @@ class Device(DeviceBase, ProtobufProps):
 
         return processed
 
-    def _get_solar_power(self, power: float | None, state: str | None):
+    def _get_solar_power(self, power: float | None, state: DCPortState | None):
         return (
-            round(power, 2)
-            if state == DCPortState.SOLAR.state_name and power is not None
-            else 0
+            round(power, 2) if state == DCPortState.SOLAR and power is not None else 0
         )
 
     async def _send_config_packet(self, message: Message):


### PR DESCRIPTION
#64 changed dc port state enum handling causing check for D3(+) solar power sensor to fail causing it to always be 0.

Resolves #65