### PR TITLE
Add AC port control for SG

### DIFF
--- a/custom_components/ef_ble/eflib/devices/smart_generator.py
+++ b/custom_components/ef_ble/eflib/devices/smart_generator.py
@@ -110,7 +110,7 @@ class Device(DeviceBase, ProtobufProps):
         pb.generator_sub_battery_state, SubBatteryState.from_value
     )
 
-    ac_ports = pb_field(pb.ac_out_open)
+    ac_port = pb_field(pb.ac_out_open)
 
     def __init__(
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str


### PR DESCRIPTION
It seems that I pluralized field name but left the action method `enable_ac_port` unpluralized causing it to not register as switch.

Fixes #70 