### PR TITLE
Fix DP3 crash caused by incorrectly renamed field name

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -58,8 +58,8 @@ class Device(DeviceBase, ProtobufProps):
     dc_lv_input_power = pb_field(pb.pow_get_pv_l)
     dc_hv_input_power = pb_field(pb.pow_get_pv_h)
 
-    dc_lv_state = pb_field(pb.plug_in_info_pv_l_type, DCPortState.from_value)
-    dc_hv_state = pb_field(pb.plug_in_info_pv_h_type, DCPortState.from_value)
+    dc_lv_input_state = pb_field(pb.plug_in_info_pv_l_type, DCPortState.from_value)
+    dc_hv_input_state = pb_field(pb.plug_in_info_pv_h_type, DCPortState.from_value)
 
     usbc_output_power = pb_field(pb.pow_get_typec1, _out_power)
     usbc2_output_power = pb_field(pb.pow_get_typec2, _out_power)

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -389,13 +389,13 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_display_precision=2,
     ),
-    "dc_lv_state": SensorEntityDescription(
-        key="dc_lv_state",
+    "dc_lv_input_state": SensorEntityDescription(
+        key="dc_lv_input_state",
         device_class=SensorDeviceClass.ENUM,
         options=delta_pro_3.DCPortState.options(),
     ),
-    "dc_hv_state": SensorEntityDescription(
-        key="dc_hv_state",
+    "dc_hv_input_state": SensorEntityDescription(
+        key="dc_hv_input_state",
         device_class=SensorDeviceClass.ENUM,
         options=delta_pro_3.DCPortState.options(),
     ),

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -299,10 +299,10 @@
       "dc_hv_input_power": {
         "name": "LV DC Port Input Power"
       },
-      "dc_lv_state": {
+      "dc_lv_input_state": {
         "name": "LV DC Input Port State"
       },
-      "dc_hv_state": {
+      "dc_hv_input_state": {
         "name": "HV DC Input Port State"
       },
       "engine_state": {


### PR DESCRIPTION
I renamed field in previous PR but forgot that it was used in packet parse code which is causing DP3 to crash. This PR does revert this change and fixes sensor name which was the reason for why I renamed it in the first place.

Fixes #74 