### PR TITLE
Added a bunch of SHP2 channel fields

### DIFF
--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -38,46 +38,49 @@ def _create_shp2_binary_sensors():
     # Energy binary sensors
     for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
         sensors.update({
-            f"energy{i}_is_enable": BinarySensorEntityDescription(
-                key=f"energy{i}_is_enable",
-                name=f"Energy {i} Enabled",
+            f"channel{i}_is_enabled": BinarySensorEntityDescription(
+                key=f"channel{i}_is_enabled",
+                name=f"Channel {i} Enabled",
                 device_class=BinarySensorDeviceClass.POWER,
             ),
-            f"energy{i}_is_connect": BinarySensorEntityDescription(
-                key=f"energy{i}_is_connect",
-                name=f"Energy {i} Connected",
+            f"channel{i}_is_connected": BinarySensorEntityDescription(
+                key=f"channel{i}_is_connected",
+                name=f"Channel {i} Connected",
                 device_class=BinarySensorDeviceClass.CONNECTIVITY,
             ),
-            f"energy{i}_is_ac_open": BinarySensorEntityDescription(
-                key=f"energy{i}_is_ac_open",
-                name=f"Energy {i} AC Output",
+            f"channel{i}_is_ac_open": BinarySensorEntityDescription(
+                key=f"channel{i}_is_ac_open",
+                name=f"Channel {i} AC Output",
                 device_class=BinarySensorDeviceClass.POWER,
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_is_power_output": BinarySensorEntityDescription(
-                key=f"energy{i}_is_power_output",
-                name=f"Energy {i} Power Output",
-                device_class=BinarySensorDeviceClass.POWER,
-            ),
-            f"energy{i}_is_grid_charge": BinarySensorEntityDescription(
-                key=f"energy{i}_is_grid_charge",
-                name=f"Energy {i} Grid Charging",
-                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-            ),
-            f"energy{i}_is_mppt_charge": BinarySensorEntityDescription(
-                key=f"energy{i}_is_mppt_charge",
-                name=f"Energy {i} Solar Charging",
-                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-            ),
-            f"energy{i}_ems_chg_flag": BinarySensorEntityDescription(
-                key=f"energy{i}_ems_chg_flag",
-                name=f"Energy {i} EMS Charge Flag",
+            f"channel{i}_is_power_output": BinarySensorEntityDescription(
+                key=f"channel{i}_is_power_output",
+                name=f"Channel {i} Power Output",
                 device_class=BinarySensorDeviceClass.POWER,
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_hw_connect": BinarySensorEntityDescription(
-                key=f"energy{i}_hw_connect",
-                name=f"Energy {i} Hardware Connected",
+            f"channel{i}_is_grid_charge": BinarySensorEntityDescription(
+                key=f"channel{i}_is_grid_charge",
+                name=f"Channel {i} Grid Charging",
+                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+                entity_registry_enabled_default=False,
+            ),
+            f"channel{i}_is_mppt_charge": BinarySensorEntityDescription(
+                key=f"channel{i}_is_mppt_charge",
+                name=f"Channel {i} Solar Charging",
+                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+                entity_registry_enabled_default=False,
+            ),
+            f"channel{i}_ems_charging": BinarySensorEntityDescription(
+                key=f"channel{i}_ems_charging",
+                name=f"Channel {i} EMS Charging Flag",
+                device_class=BinarySensorDeviceClass.POWER,
+                entity_registry_enabled_default=False,
+            ),
+            f"channel{i}_hw_connected": BinarySensorEntityDescription(
+                key=f"channel{i}_hw_connected",
+                name=f"Channel {i} Hardware Connected",
                 device_class=BinarySensorDeviceClass.CONNECTIVITY,
                 entity_registry_enabled_default=False,
             ),

--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -14,11 +14,76 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.ef_ble.eflib import DeviceBase
+from custom_components.ef_ble.eflib.devices import shp2
 
 from . import DeviceConfigEntry
 from .entity import EcoflowEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _create_shp2_binary_sensors():
+    """Create binary sensor descriptions for SHP2 backup channel and energy info"""
+    sensors = {}
+
+    # Backup channel binary sensors
+    for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
+        sensors[f"ch{i}_backup_is_ready"] = BinarySensorEntityDescription(
+            key=f"ch{i}_backup_is_ready",
+            name=f"Channel {i} Backup Ready",
+            device_class=BinarySensorDeviceClass.BATTERY,
+            entity_registry_enabled_default=False,
+        )
+
+    # Energy binary sensors
+    for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
+        sensors.update({
+            f"energy{i}_is_enable": BinarySensorEntityDescription(
+                key=f"energy{i}_is_enable",
+                name=f"Energy {i} Enabled",
+                device_class=BinarySensorDeviceClass.POWER,
+            ),
+            f"energy{i}_is_connect": BinarySensorEntityDescription(
+                key=f"energy{i}_is_connect",
+                name=f"Energy {i} Connected",
+                device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            ),
+            f"energy{i}_is_ac_open": BinarySensorEntityDescription(
+                key=f"energy{i}_is_ac_open",
+                name=f"Energy {i} AC Output",
+                device_class=BinarySensorDeviceClass.POWER,
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_is_power_output": BinarySensorEntityDescription(
+                key=f"energy{i}_is_power_output",
+                name=f"Energy {i} Power Output",
+                device_class=BinarySensorDeviceClass.POWER,
+            ),
+            f"energy{i}_is_grid_charge": BinarySensorEntityDescription(
+                key=f"energy{i}_is_grid_charge",
+                name=f"Energy {i} Grid Charging",
+                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+            ),
+            f"energy{i}_is_mppt_charge": BinarySensorEntityDescription(
+                key=f"energy{i}_is_mppt_charge",
+                name=f"Energy {i} Solar Charging",
+                device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+            ),
+            f"energy{i}_ems_chg_flag": BinarySensorEntityDescription(
+                key=f"energy{i}_ems_chg_flag",
+                name=f"Energy {i} EMS Charge Flag",
+                device_class=BinarySensorDeviceClass.POWER,
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_hw_connect": BinarySensorEntityDescription(
+                key=f"energy{i}_hw_connect",
+                name=f"Energy {i} Hardware Connected",
+                device_class=BinarySensorDeviceClass.CONNECTIVITY,
+                entity_registry_enabled_default=False,
+            ),
+        })
+
+    return sensors
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -38,6 +103,8 @@ BINARY_SENSOR_TYPES = {
         name="AC Plugged In",
         device_class=BinarySensorDeviceClass.PLUG,
     ),
+    # SHP2 Binary Sensors - dynamically generated
+    **_create_shp2_binary_sensors(),
 }
 
 

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -13,10 +13,25 @@ from ..props import (
     repeated_pb_field_type,
 )
 from ..props.protobuf_field import TransformIfMissing
+from ..props.enums import IntFieldValue
 
 pb_time = proto_attr_mapper(pd303_pb2.ProtoTime)
 pb_push_set = proto_attr_mapper(pd303_pb2.ProtoPushAndSet)
 
+class ControlStatus(IntFieldValue):
+    UNKNOWN = -1
+
+    OFF = 0
+    DISCHARGE = 1
+    CHARGE = 2
+    EMERGENCY_STOP = 3
+    STANDBY = 4
+
+class ForceChargeStatus(IntFieldValue):
+    UNKNOWN = -1
+
+    OFF = 0;
+    ON = 1;
 
 @dataclass
 class CircuitPowerField(
@@ -91,94 +106,94 @@ class Device(DeviceBase, ProtobufProps):
     channel_power_3 = ChannelPowerField(2)
 
     # Input 1
-    energy1_sn = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.model_info.sn)
-    energy1_type = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.type)
-    energy1_capacity = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.full_cap)
-    energy1_rate_power = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.rate_power)
-    energy1_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_enable)
-    energy1_is_connected = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_connect)
-    energy1_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_ac_open)
-    energy1_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_power_output)
-    energy1_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_grid_charge)
-    energy1_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_mppt_charge)
-    energy1_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy1_info.battery_percentage)
-    energy1_output_power = pb_field(pb_push_set.backup_incre_info.Energy1_info.output_power)
-    energy1_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy1_info.ems_chg_flag)
-    energy1_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy1_info.hw_connect)
-    energy1_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy1_info.ems_bat_temp)
-    energy1_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.lcd_input_watts)
-    energy1_pv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_charge_watts)
-    energy1_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_low_charge_watts)
-    energy1_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_height_charge_watts)
-    energy1_error_code = pb_field(pb_push_set.backup_incre_info.Energy1_info.error_code_num)
+    channel1_sn = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.model_info.sn)
+    channel1_type = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.type)
+    channel1_capacity = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.full_cap)
+    channel1_rate_power = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.rate_power)
+    channel1_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_enable)
+    channel1_is_connected = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_connect)
+    channel1_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_ac_open)
+    channel1_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_power_output)
+    channel1_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_grid_charge)
+    channel1_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_mppt_charge)
+    channel1_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy1_info.battery_percentage)
+    channel1_output_power = pb_field(pb_push_set.backup_incre_info.Energy1_info.output_power)
+    channel1_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy1_info.ems_chg_flag)
+    channel1_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy1_info.hw_connect)
+    channel1_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy1_info.ems_bat_temp)
+    channel1_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.lcd_input_watts)
+    channel1_pv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_charge_watts)
+    channel1_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_low_charge_watts)
+    channel1_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_height_charge_watts)
+    channel1_error_code = pb_field(pb_push_set.backup_incre_info.Energy1_info.error_code_num)
 
     ch1_backup_is_ready = pb_field(pb_push_set.backup_incre_info.ch1_info.backup_is_ready)
-    ch1_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch1_info.ctrl_sta)
-    ch1_force_charge = pb_field(pb_push_set.backup_incre_info.ch1_info.force_charge_sta)
+    ch1_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch1_info.ctrl_sta, ControlStatus.from_value)
+    ch1_force_charge = pb_field(pb_push_set.backup_incre_info.ch1_info.force_charge_sta, ForceChargeStatus.from_value)
     ch1_backup_rly1_cnt = pb_field(pb_push_set.backup_incre_info.ch1_info.backup_rly1_cnt)
     ch1_backup_rly2_cnt = pb_field(pb_push_set.backup_incre_info.ch1_info.backup_rly2_cnt)
     ch1_wake_up_charge_status = pb_field(pb_push_set.backup_incre_info.ch1_info.wake_up_charge_sta)
-    ch1_energy_5p8_type = pb_field(pb_push_set.backup_incre_info.ch1_info.energy_5p8_type)
+    ch1_channel_5p8_type = pb_field(pb_push_set.backup_incre_info.ch1_info.energy_5p8_type)
 
     # Input 2
-    energy2_sn = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.model_info.sn)
-    energy2_type = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.type)
-    energy2_capacity = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.full_cap)
-    energy2_rate_power = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.rate_power)
-    energy2_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_enable)
-    energy2_is_connected = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_connect)
-    energy2_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_ac_open)
-    energy2_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_power_output)
-    energy2_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_grid_charge)
-    energy2_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_mppt_charge)
-    energy2_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy2_info.battery_percentage)
-    energy2_output_power = pb_field(pb_push_set.backup_incre_info.Energy2_info.output_power)
-    energy2_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy2_info.ems_chg_flag)
-    energy2_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy2_info.hw_connect)
-    energy2_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy2_info.ems_bat_temp)
-    energy2_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.lcd_input_watts)
-    energy2_pv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_charge_watts)
-    energy2_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_low_charge_watts)
-    energy2_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_height_charge_watts)
-    energy2_error_code = pb_field(pb_push_set.backup_incre_info.Energy2_info.error_code_num)
+    channel2_sn = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.model_info.sn)
+    channel2_type = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.type)
+    channel2_capacity = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.full_cap)
+    channel2_rate_power = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.rate_power)
+    channel2_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_enable)
+    channel2_is_connected = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_connect)
+    channel2_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_ac_open)
+    channel2_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_power_output)
+    channel2_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_grid_charge)
+    channel2_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_mppt_charge)
+    channel2_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy2_info.battery_percentage)
+    channel2_output_power = pb_field(pb_push_set.backup_incre_info.Energy2_info.output_power)
+    channel2_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy2_info.ems_chg_flag)
+    channel2_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy2_info.hw_connect)
+    channel2_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy2_info.ems_bat_temp)
+    channel2_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.lcd_input_watts)
+    channel2_pv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_charge_watts)
+    channel2_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_low_charge_watts)
+    channel2_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_height_charge_watts)
+    channel2_error_code = pb_field(pb_push_set.backup_incre_info.Energy2_info.error_code_num)
 
     ch2_backup_is_ready = pb_field(pb_push_set.backup_incre_info.ch2_info.backup_is_ready)
-    ch2_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch2_info.ctrl_sta)
-    ch2_force_charge = pb_field(pb_push_set.backup_incre_info.ch2_info.force_charge_sta)
+    ch2_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch2_info.ctrl_sta, ControlStatus.from_value)
+    ch2_force_charge = pb_field(pb_push_set.backup_incre_info.ch2_info.force_charge_sta, ForceChargeStatus.from_value)
     ch2_backup_rly1_cnt = pb_field(pb_push_set.backup_incre_info.ch2_info.backup_rly1_cnt)
     ch2_backup_rly2_cnt = pb_field(pb_push_set.backup_incre_info.ch2_info.backup_rly2_cnt)
     ch2_wake_up_charge_status = pb_field(pb_push_set.backup_incre_info.ch2_info.wake_up_charge_sta)
-    ch2_energy_5p8_type = pb_field(pb_push_set.backup_incre_info.ch2_info.energy_5p8_type)
+    ch2_channel_5p8_type = pb_field(pb_push_set.backup_incre_info.ch2_info.energy_5p8_type)
 
     # Input 3
-    energy3_sn = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.model_info.sn)
-    energy3_type = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.type)
-    energy3_capacity = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.full_cap)
-    energy3_rate_power = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.rate_power)
-    energy3_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_enable)
-    energy3_is_connected = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_connect)
-    energy3_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_ac_open)
-    energy3_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_power_output)
-    energy3_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_grid_charge)
-    energy3_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_mppt_charge)
-    energy3_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy3_info.battery_percentage)
-    energy3_output_power = pb_field(pb_push_set.backup_incre_info.Energy3_info.output_power)
-    energy3_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy3_info.ems_chg_flag)
-    energy3_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy3_info.hw_connect)
-    energy3_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy3_info.ems_bat_temp)
-    energy3_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.lcd_input_watts)
-    energy3_pv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_charge_watts)
-    energy3_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_low_charge_watts)
-    energy3_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_height_charge_watts)
-    energy3_error_code = pb_field(pb_push_set.backup_incre_info.Energy3_info.error_code_num)
+    channel3_sn = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.model_info.sn)
+    channel3_type = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.type)
+    channel3_capacity = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.full_cap)
+    channel3_rate_power = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.rate_power)
+    channel3_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_enable)
+    channel3_is_connected = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_connect)
+    channel3_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_ac_open)
+    channel3_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_power_output)
+    channel3_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_grid_charge)
+    channel3_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_mppt_charge)
+    channel3_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy3_info.battery_percentage)
+    channel3_output_power = pb_field(pb_push_set.backup_incre_info.Energy3_info.output_power)
+    channel3_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy3_info.ems_chg_flag)
+    channel3_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy3_info.hw_connect)
+    channel3_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy3_info.ems_bat_temp)
+    channel3_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.lcd_input_watts)
+    channel3_pv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_charge_watts)
+    channel3_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_low_charge_watts)
+    channel3_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_height_charge_watts)
+    channel3_error_code = pb_field(pb_push_set.backup_incre_info.Energy3_info.error_code_num)
 
     ch3_backup_is_ready = pb_field(pb_push_set.backup_incre_info.ch3_info.backup_is_ready)
-    ch3_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch3_info.ctrl_sta)
-    ch3_force_charge = pb_field(pb_push_set.backup_incre_info.ch3_info.force_charge_sta)
+    ch3_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch3_info.ctrl_sta, ControlStatus.from_value)
+    ch3_force_charge = pb_field(pb_push_set.backup_incre_info.ch3_info.force_charge_sta, ForceChargeStatus.from_value)
     ch3_backup_rly1_cnt = pb_field(pb_push_set.backup_incre_info.ch3_info.backup_rly1_cnt)
     ch3_backup_rly2_cnt = pb_field(pb_push_set.backup_incre_info.ch3_info.backup_rly2_cnt)
     ch3_wake_up_charge_status = pb_field(pb_push_set.backup_incre_info.ch3_info.wake_up_charge_sta)
-    ch3_energy_5p8_type = pb_field(pb_push_set.backup_incre_info.ch3_info.energy_5p8_type)
+    ch3_5p8_type = pb_field(pb_push_set.backup_incre_info.ch3_info.energy_5p8_type)
 
     in_use_power = pb_field(pb_time.watt_info.all_hall_watt)
     grid_power = pb_field(
@@ -274,8 +289,17 @@ class Device(DeviceBase, ProtobufProps):
             )
 
         for field_name in self.updated_fields:
-            self.update_callback(field_name)
-            self.update_state(field_name, getattr(self, field_name))
+            try:
+                self.update_callback(field_name)
+                self.update_state(field_name, getattr(self, field_name))
+            except Exception as e:
+                self._logger.warning(
+                    "%s: %s: Error happened while updating field %s: %s",
+                    self.address,
+                    self.name,
+                    field_name,
+                    e,
+                )
 
         return processed
 

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -50,6 +50,63 @@ def _errors(error_codes: pd303_pb2.ErrCode):
     return [e for e in error_codes.err_code if e != b"\x00\x00\x00\x00\x00\x00\x00\x00"]
 
 
+def _create_backup_channel_fields(cls):
+    """Dynamically create backup channel fields for all channels"""
+    for i in range(1, cls.NUM_OF_CHANNELS + 1):
+        ch_info = getattr(pb_push_set.backup_incre_info, f"ch{i}_info")
+
+        setattr(cls, f"ch{i}_backup_is_ready", pb_field(ch_info.backup_is_ready))
+        setattr(cls, f"ch{i}_ctrl_status", pb_field(ch_info.ctrl_sta))
+        setattr(cls, f"ch{i}_force_charge", pb_field(ch_info.force_charge_sta))
+        setattr(cls, f"ch{i}_backup_rly1_cnt", pb_field(ch_info.backup_rly1_cnt))
+        setattr(cls, f"ch{i}_backup_rly2_cnt", pb_field(ch_info.backup_rly2_cnt))
+        setattr(cls, f"ch{i}_wake_up_charge_status", pb_field(ch_info.wake_up_charge_sta))
+        setattr(cls, f"ch{i}_energy_5p8_type", pb_field(ch_info.energy_5p8_type))
+
+
+def _create_energy_fields(cls):
+    """Dynamically create energy fields for all energy units"""
+    for i in range(1, cls.NUM_OF_CHANNELS + 1):
+        energy_info = getattr(pb_push_set.backup_incre_info, f"Energy{i}_info")
+
+        # Device info fields
+        setattr(cls, f"energy{i}_sn", pb_field(energy_info.dev_info.model_info.sn))
+        setattr(cls, f"energy{i}_type", pb_field(energy_info.dev_info.type))
+        setattr(cls, f"energy{i}_capacity", pb_field(energy_info.dev_info.full_cap))
+        setattr(cls, f"energy{i}_rate_power", pb_field(energy_info.dev_info.rate_power))
+
+        # Status fields
+        setattr(cls, f"energy{i}_is_enabled", pb_field(energy_info.is_enable))
+        setattr(cls, f"energy{i}_is_connected", pb_field(energy_info.is_connect))
+        setattr(cls, f"energy{i}_is_ac_open", pb_field(energy_info.is_ac_open))
+        setattr(cls, f"energy{i}_is_power_output", pb_field(energy_info.is_power_output))
+        setattr(cls, f"energy{i}_is_grid_charge", pb_field(energy_info.is_grid_charge))
+        setattr(cls, f"energy{i}_is_mppt_charge", pb_field(energy_info.is_mppt_charge))
+
+        # Power and battery fields
+        setattr(cls, f"energy{i}_battery_percentage", pb_field(energy_info.battery_percentage))
+        setattr(cls, f"energy{i}_output_power", pb_field(energy_info.output_power))
+        setattr(cls, f"energy{i}_ems_charging", pb_field(energy_info.ems_chg_flag))
+        setattr(cls, f"energy{i}_hw_connect", pb_field(energy_info.hw_connect))
+        setattr(cls, f"energy{i}_battery_temp", pb_field(energy_info.ems_bat_temp))
+        setattr(cls, f"energy{i}_lcd_input", pb_field(energy_info.lcd_input_watts))
+        setattr(cls, f"energy{i}_pv_input", pb_field(energy_info.pv_charge_watts))
+        setattr(cls, f"energy{i}_pv_lv_input", pb_field(energy_info.pv_low_charge_watts))
+        setattr(cls, f"energy{i}_pv_hv_input", pb_field(energy_info.pv_height_charge_watts))
+        setattr(cls, f"energy{i}_error_code", pb_field(energy_info.error_code_num))
+
+        setattr(cls, f"channel_power_{i}", ChannelPowerField(i-1))
+
+def _create_circuit_fields(cls):
+    """Dynamically create circuit fields for all available circuits"""
+    for i in range(1, cls.NUM_OF_CIRCUITS + 1):
+        # Circuit power
+        setattr(cls, f"circuit_power_{i}", CircuitPowerField(i-1))
+
+        # Circuit current
+        setattr(cls, f"circuit_current_{i}", CircuitCurrentField(i-1))
+
+
 class Device(DeviceBase, ProtobufProps):
     """Smart Home Panel 2"""
 
@@ -61,35 +118,7 @@ class Device(DeviceBase, ProtobufProps):
 
     battery_level = pb_field(pb_push_set.backup_incre_info.backup_bat_per)
 
-    circuit_power_1 = CircuitPowerField(0)
-    circuit_power_2 = CircuitPowerField(1)
-    circuit_power_3 = CircuitPowerField(2)
-    circuit_power_4 = CircuitPowerField(3)
-    circuit_power_5 = CircuitPowerField(4)
-    circuit_power_6 = CircuitPowerField(5)
-    circuit_power_7 = CircuitPowerField(6)
-    circuit_power_8 = CircuitPowerField(7)
-    circuit_power_9 = CircuitPowerField(8)
-    circuit_power_10 = CircuitPowerField(9)
-    circuit_power_11 = CircuitPowerField(10)
-    circuit_power_12 = CircuitPowerField(11)
-
-    circuit_current_1 = CircuitCurrentField(0)
-    circuit_current_2 = CircuitCurrentField(1)
-    circuit_current_3 = CircuitCurrentField(2)
-    circuit_current_4 = CircuitCurrentField(3)
-    circuit_current_5 = CircuitCurrentField(4)
-    circuit_current_6 = CircuitCurrentField(5)
-    circuit_current_7 = CircuitCurrentField(6)
-    circuit_current_8 = CircuitCurrentField(7)
-    circuit_current_9 = CircuitCurrentField(8)
-    circuit_current_10 = CircuitCurrentField(9)
-    circuit_current_11 = CircuitCurrentField(10)
-    circuit_current_12 = CircuitCurrentField(11)
-
-    channel_power_1 = ChannelPowerField(0)
-    channel_power_2 = ChannelPowerField(1)
-    channel_power_3 = ChannelPowerField(2)
+    # Additional attributes are created dynamically after class definition
 
     in_use_power = pb_field(pb_time.watt_info.all_hall_watt)
     grid_power = pb_field(
@@ -109,6 +138,12 @@ class Device(DeviceBase, ProtobufProps):
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
+
+        # Creating dynamic fields
+        _create_backup_channel_fields(self)
+        _create_energy_fields(self)
+        _create_circuit_fields(self)
+
         self._time_commands = TimeCommands(self)
 
     async def data_parse(self, packet: Packet) -> bool:
@@ -136,9 +171,6 @@ class Device(DeviceBase, ProtobufProps):
 
                 await self._conn.replyPacket(packet)
                 self.update_from_bytes(pd303_pb2.ProtoPushAndSet, packet.payload)
-
-                # TODO: Energy2_info.pv_height_charge_watts
-                # TODO: Energy2_info.pv_low_charge_watts
 
                 processed = True
 

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -49,64 +49,6 @@ class ChannelPowerField(repeated_pb_field_type(list_field=pb_time.watt_info.ch_w
 def _errors(error_codes: pd303_pb2.ErrCode):
     return [e for e in error_codes.err_code if e != b"\x00\x00\x00\x00\x00\x00\x00\x00"]
 
-
-def _create_backup_channel_fields(cls):
-    """Dynamically create backup channel fields for all channels"""
-    for i in range(1, cls.NUM_OF_CHANNELS + 1):
-        ch_info = getattr(pb_push_set.backup_incre_info, f"ch{i}_info")
-
-        setattr(cls, f"ch{i}_backup_is_ready", pb_field(ch_info.backup_is_ready))
-        setattr(cls, f"ch{i}_ctrl_status", pb_field(ch_info.ctrl_sta))
-        setattr(cls, f"ch{i}_force_charge", pb_field(ch_info.force_charge_sta))
-        setattr(cls, f"ch{i}_backup_rly1_cnt", pb_field(ch_info.backup_rly1_cnt))
-        setattr(cls, f"ch{i}_backup_rly2_cnt", pb_field(ch_info.backup_rly2_cnt))
-        setattr(cls, f"ch{i}_wake_up_charge_status", pb_field(ch_info.wake_up_charge_sta))
-        setattr(cls, f"ch{i}_energy_5p8_type", pb_field(ch_info.energy_5p8_type))
-
-
-def _create_energy_fields(cls):
-    """Dynamically create energy fields for all energy units"""
-    for i in range(1, cls.NUM_OF_CHANNELS + 1):
-        energy_info = getattr(pb_push_set.backup_incre_info, f"Energy{i}_info")
-
-        # Device info fields
-        setattr(cls, f"energy{i}_sn", pb_field(energy_info.dev_info.model_info.sn))
-        setattr(cls, f"energy{i}_type", pb_field(energy_info.dev_info.type))
-        setattr(cls, f"energy{i}_capacity", pb_field(energy_info.dev_info.full_cap))
-        setattr(cls, f"energy{i}_rate_power", pb_field(energy_info.dev_info.rate_power))
-
-        # Status fields
-        setattr(cls, f"energy{i}_is_enabled", pb_field(energy_info.is_enable))
-        setattr(cls, f"energy{i}_is_connected", pb_field(energy_info.is_connect))
-        setattr(cls, f"energy{i}_is_ac_open", pb_field(energy_info.is_ac_open))
-        setattr(cls, f"energy{i}_is_power_output", pb_field(energy_info.is_power_output))
-        setattr(cls, f"energy{i}_is_grid_charge", pb_field(energy_info.is_grid_charge))
-        setattr(cls, f"energy{i}_is_mppt_charge", pb_field(energy_info.is_mppt_charge))
-
-        # Power and battery fields
-        setattr(cls, f"energy{i}_battery_percentage", pb_field(energy_info.battery_percentage))
-        setattr(cls, f"energy{i}_output_power", pb_field(energy_info.output_power))
-        setattr(cls, f"energy{i}_ems_charging", pb_field(energy_info.ems_chg_flag))
-        setattr(cls, f"energy{i}_hw_connect", pb_field(energy_info.hw_connect))
-        setattr(cls, f"energy{i}_battery_temp", pb_field(energy_info.ems_bat_temp))
-        setattr(cls, f"energy{i}_lcd_input", pb_field(energy_info.lcd_input_watts))
-        setattr(cls, f"energy{i}_pv_input", pb_field(energy_info.pv_charge_watts))
-        setattr(cls, f"energy{i}_pv_lv_input", pb_field(energy_info.pv_low_charge_watts))
-        setattr(cls, f"energy{i}_pv_hv_input", pb_field(energy_info.pv_height_charge_watts))
-        setattr(cls, f"energy{i}_error_code", pb_field(energy_info.error_code_num))
-
-        setattr(cls, f"channel_power_{i}", ChannelPowerField(i-1))
-
-def _create_circuit_fields(cls):
-    """Dynamically create circuit fields for all available circuits"""
-    for i in range(1, cls.NUM_OF_CIRCUITS + 1):
-        # Circuit power
-        setattr(cls, f"circuit_power_{i}", CircuitPowerField(i-1))
-
-        # Circuit current
-        setattr(cls, f"circuit_current_{i}", CircuitCurrentField(i-1))
-
-
 class Device(DeviceBase, ProtobufProps):
     """Smart Home Panel 2"""
 
@@ -118,7 +60,125 @@ class Device(DeviceBase, ProtobufProps):
 
     battery_level = pb_field(pb_push_set.backup_incre_info.backup_bat_per)
 
-    # Additional attributes are created dynamically after class definition
+    circuit_power_1 = CircuitPowerField(0)
+    circuit_power_2 = CircuitPowerField(1)
+    circuit_power_3 = CircuitPowerField(2)
+    circuit_power_4 = CircuitPowerField(3)
+    circuit_power_5 = CircuitPowerField(4)
+    circuit_power_6 = CircuitPowerField(5)
+    circuit_power_7 = CircuitPowerField(6)
+    circuit_power_8 = CircuitPowerField(7)
+    circuit_power_9 = CircuitPowerField(8)
+    circuit_power_10 = CircuitPowerField(9)
+    circuit_power_11 = CircuitPowerField(10)
+    circuit_power_12 = CircuitPowerField(11)
+
+    circuit_current_1 = CircuitCurrentField(0)
+    circuit_current_2 = CircuitCurrentField(1)
+    circuit_current_3 = CircuitCurrentField(2)
+    circuit_current_4 = CircuitCurrentField(3)
+    circuit_current_5 = CircuitCurrentField(4)
+    circuit_current_6 = CircuitCurrentField(5)
+    circuit_current_7 = CircuitCurrentField(6)
+    circuit_current_8 = CircuitCurrentField(7)
+    circuit_current_9 = CircuitCurrentField(8)
+    circuit_current_10 = CircuitCurrentField(9)
+    circuit_current_11 = CircuitCurrentField(10)
+    circuit_current_12 = CircuitCurrentField(11)
+
+    channel_power_1 = ChannelPowerField(0)
+    channel_power_2 = ChannelPowerField(1)
+    channel_power_3 = ChannelPowerField(2)
+
+    # Input 1
+    energy1_sn = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.model_info.sn)
+    energy1_type = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.type)
+    energy1_capacity = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.full_cap)
+    energy1_rate_power = pb_field(pb_push_set.backup_incre_info.Energy1_info.dev_info.rate_power)
+    energy1_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_enable)
+    energy1_is_connected = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_connect)
+    energy1_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_ac_open)
+    energy1_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_power_output)
+    energy1_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_grid_charge)
+    energy1_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy1_info.is_mppt_charge)
+    energy1_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy1_info.battery_percentage)
+    energy1_output_power = pb_field(pb_push_set.backup_incre_info.Energy1_info.output_power)
+    energy1_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy1_info.ems_chg_flag)
+    energy1_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy1_info.hw_connect)
+    energy1_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy1_info.ems_bat_temp)
+    energy1_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.lcd_input_watts)
+    energy1_pv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_charge_watts)
+    energy1_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_low_charge_watts)
+    energy1_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy1_info.pv_height_charge_watts)
+    energy1_error_code = pb_field(pb_push_set.backup_incre_info.Energy1_info.error_code_num)
+
+    ch1_backup_is_ready = pb_field(pb_push_set.backup_incre_info.ch1_info.backup_is_ready)
+    ch1_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch1_info.ctrl_sta)
+    ch1_force_charge = pb_field(pb_push_set.backup_incre_info.ch1_info.force_charge_sta)
+    ch1_backup_rly1_cnt = pb_field(pb_push_set.backup_incre_info.ch1_info.backup_rly1_cnt)
+    ch1_backup_rly2_cnt = pb_field(pb_push_set.backup_incre_info.ch1_info.backup_rly2_cnt)
+    ch1_wake_up_charge_status = pb_field(pb_push_set.backup_incre_info.ch1_info.wake_up_charge_sta)
+    ch1_energy_5p8_type = pb_field(pb_push_set.backup_incre_info.ch1_info.energy_5p8_type)
+
+    # Input 2
+    energy2_sn = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.model_info.sn)
+    energy2_type = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.type)
+    energy2_capacity = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.full_cap)
+    energy2_rate_power = pb_field(pb_push_set.backup_incre_info.Energy2_info.dev_info.rate_power)
+    energy2_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_enable)
+    energy2_is_connected = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_connect)
+    energy2_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_ac_open)
+    energy2_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_power_output)
+    energy2_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_grid_charge)
+    energy2_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy2_info.is_mppt_charge)
+    energy2_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy2_info.battery_percentage)
+    energy2_output_power = pb_field(pb_push_set.backup_incre_info.Energy2_info.output_power)
+    energy2_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy2_info.ems_chg_flag)
+    energy2_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy2_info.hw_connect)
+    energy2_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy2_info.ems_bat_temp)
+    energy2_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.lcd_input_watts)
+    energy2_pv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_charge_watts)
+    energy2_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_low_charge_watts)
+    energy2_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy2_info.pv_height_charge_watts)
+    energy2_error_code = pb_field(pb_push_set.backup_incre_info.Energy2_info.error_code_num)
+
+    ch2_backup_is_ready = pb_field(pb_push_set.backup_incre_info.ch2_info.backup_is_ready)
+    ch2_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch2_info.ctrl_sta)
+    ch2_force_charge = pb_field(pb_push_set.backup_incre_info.ch2_info.force_charge_sta)
+    ch2_backup_rly1_cnt = pb_field(pb_push_set.backup_incre_info.ch2_info.backup_rly1_cnt)
+    ch2_backup_rly2_cnt = pb_field(pb_push_set.backup_incre_info.ch2_info.backup_rly2_cnt)
+    ch2_wake_up_charge_status = pb_field(pb_push_set.backup_incre_info.ch2_info.wake_up_charge_sta)
+    ch2_energy_5p8_type = pb_field(pb_push_set.backup_incre_info.ch2_info.energy_5p8_type)
+
+    # Input 3
+    energy3_sn = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.model_info.sn)
+    energy3_type = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.type)
+    energy3_capacity = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.full_cap)
+    energy3_rate_power = pb_field(pb_push_set.backup_incre_info.Energy3_info.dev_info.rate_power)
+    energy3_is_enabled = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_enable)
+    energy3_is_connected = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_connect)
+    energy3_is_ac_open = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_ac_open)
+    energy3_is_power_output = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_power_output)
+    energy3_is_grid_charge = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_grid_charge)
+    energy3_is_mppt_charge = pb_field(pb_push_set.backup_incre_info.Energy3_info.is_mppt_charge)
+    energy3_battery_percentage = pb_field(pb_push_set.backup_incre_info.Energy3_info.battery_percentage)
+    energy3_output_power = pb_field(pb_push_set.backup_incre_info.Energy3_info.output_power)
+    energy3_ems_charging = pb_field(pb_push_set.backup_incre_info.Energy3_info.ems_chg_flag)
+    energy3_hw_connect = pb_field(pb_push_set.backup_incre_info.Energy3_info.hw_connect)
+    energy3_battery_temp = pb_field(pb_push_set.backup_incre_info.Energy3_info.ems_bat_temp)
+    energy3_lcd_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.lcd_input_watts)
+    energy3_pv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_charge_watts)
+    energy3_pv_lv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_low_charge_watts)
+    energy3_pv_hv_input = pb_field(pb_push_set.backup_incre_info.Energy3_info.pv_height_charge_watts)
+    energy3_error_code = pb_field(pb_push_set.backup_incre_info.Energy3_info.error_code_num)
+
+    ch3_backup_is_ready = pb_field(pb_push_set.backup_incre_info.ch3_info.backup_is_ready)
+    ch3_ctrl_status = pb_field(pb_push_set.backup_incre_info.ch3_info.ctrl_sta)
+    ch3_force_charge = pb_field(pb_push_set.backup_incre_info.ch3_info.force_charge_sta)
+    ch3_backup_rly1_cnt = pb_field(pb_push_set.backup_incre_info.ch3_info.backup_rly1_cnt)
+    ch3_backup_rly2_cnt = pb_field(pb_push_set.backup_incre_info.ch3_info.backup_rly2_cnt)
+    ch3_wake_up_charge_status = pb_field(pb_push_set.backup_incre_info.ch3_info.wake_up_charge_sta)
+    ch3_energy_5p8_type = pb_field(pb_push_set.backup_incre_info.ch3_info.energy_5p8_type)
 
     in_use_power = pb_field(pb_time.watt_info.all_hall_watt)
     grid_power = pb_field(
@@ -138,11 +198,6 @@ class Device(DeviceBase, ProtobufProps):
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
-
-        # Creating dynamic fields
-        _create_backup_channel_fields(self)
-        _create_energy_fields(self)
-        _create_circuit_fields(self)
 
         self._time_commands = TimeCommands(self)
 

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -123,6 +123,33 @@
             },
             "grid_frequency": {
                 "default": "mdi:cosine-wave"
+            },
+            "channel1_pv_input": {
+                "default": "mdi:solar-power"
+            },
+            "channel2_pv_input": {
+                "default": "mdi:solar-power"
+            },
+            "channel3_pv_input": {
+                "default": "mdi:solar-power"
+            },
+            "channel1_pv_lv_input": {
+                "default": "mdi:solar-panel"
+            },
+            "channel2_pv_lv_input": {
+                "default": "mdi:solar-panel"
+            },
+            "channel3_pv_lv_input": {
+                "default": "mdi:solar-panel"
+            },
+            "channel1_pv_hv_input": {
+                "default": "mdi:solar-panel-large"
+            },
+            "channel2_pv_hv_input": {
+                "default": "mdi:solar-panel-large"
+            },
+            "channel3_pv_hv_input": {
+                "default": "mdi:solar-panel-large"
             }
         },
         "switch": {

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -42,6 +42,241 @@ def _auto_name_from_key(key: str):
     )
 
 
+def _create_shp2_backup_channel_sensors():
+    """Create sensor descriptions for SHP2 backup channel info"""
+    sensors = {}
+
+    for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
+        sensors.update({
+            f"ch{i}_backup_is_ready": SensorEntityDescription(
+                key=f"ch{i}_backup_is_ready",
+                device_class=SensorDeviceClass.ENUM,
+                options=["false", "true"],
+                translation_key="backup_is_ready",
+                translation_placeholders={"channel": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"ch{i}_ctrl_status": SensorEntityDescription(
+                key=f"ch{i}_ctrl_status",
+                device_class=SensorDeviceClass.ENUM,
+                options=["backup_ch_off", "backup_ch_discharge", "backup_ch_charge", "backup_ch_em_stop", "backup_ch_standby"],
+                translation_key="backup_ctrl_status",
+                translation_placeholders={"channel": f"{i}"},
+            ),
+            f"ch{i}_force_charge": SensorEntityDescription(
+                key=f"ch{i}_force_charge",
+                device_class=SensorDeviceClass.ENUM,
+                options=["force_charge_off", "force_charge_on"],
+                translation_key="backup_force_charge",
+                translation_placeholders={"channel": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"ch{i}_backup_rly1_cnt": SensorEntityDescription(
+                key=f"ch{i}_backup_rly1_cnt",
+                state_class=SensorStateClass.TOTAL,
+                translation_key="backup_relay1_count",
+                translation_placeholders={"channel": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"ch{i}_backup_rly2_cnt": SensorEntityDescription(
+                key=f"ch{i}_backup_rly2_cnt",
+                state_class=SensorStateClass.TOTAL,
+                translation_key="backup_relay2_count",
+                translation_placeholders={"channel": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"ch{i}_wake_up_charge_status": SensorEntityDescription(
+                key=f"ch{i}_wake_up_charge_status",
+                native_unit_of_measurement=PERCENTAGE,
+                device_class=SensorDeviceClass.BATTERY,
+                state_class=SensorStateClass.MEASUREMENT,
+                translation_key="backup_wakeup_charge",
+                translation_placeholders={"channel": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"ch{i}_energy_5p8_type": SensorEntityDescription(
+                key=f"ch{i}_energy_5p8_type",
+                translation_key="backup_connector_type",
+                translation_placeholders={"channel": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+        })
+
+    return sensors
+
+
+def _create_shp2_energy_sensors():
+    """Create sensor descriptions for SHP2 energy info"""
+    sensors = {}
+
+    for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
+        sensors.update({
+            f"energy{i}_sn": SensorEntityDescription(
+                key=f"energy{i}_sn",
+                translation_key="energy_serial_number",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_type": SensorEntityDescription(
+                key=f"energy{i}_type",
+                translation_key="energy_device_type",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_capacity": SensorEntityDescription(
+                key=f"energy{i}_capacity",
+                native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+                device_class=SensorDeviceClass.ENERGY_STORAGE,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                translation_key="energy_full_capacity",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_rate_power": SensorEntityDescription(
+                key=f"energy{i}_rate_power",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                translation_key="energy_rated_power",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_is_enabled": SensorEntityDescription(
+                key=f"energy{i}_is_enabled",
+                device_class=SensorDeviceClass.ENUM,
+                options=["disabled", "enabled"],
+                translation_key="energy_enabled",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_is_connected": SensorEntityDescription(
+                key=f"energy{i}_is_connected",
+                device_class=SensorDeviceClass.ENUM,
+                options=["disconnected", "connected"],
+                translation_key="energy_connected",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_is_ac_open": SensorEntityDescription(
+                key=f"energy{i}_is_ac_open",
+                device_class=SensorDeviceClass.ENUM,
+                options=["closed", "open"],
+                translation_key="energy_ac_output",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_is_power_output": SensorEntityDescription(
+                key=f"energy{i}_is_power_output",
+                device_class=SensorDeviceClass.ENUM,
+                options=["off", "on"],
+                translation_key="energy_power_output",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_is_grid_charge": SensorEntityDescription(
+                key=f"energy{i}_is_grid_charge",
+                device_class=SensorDeviceClass.ENUM,
+                options=["off", "on"],
+                translation_key="energy_grid_charging",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_is_mppt_charge": SensorEntityDescription(
+                key=f"energy{i}_is_mppt_charge",
+                device_class=SensorDeviceClass.ENUM,
+                options=["off", "on"],
+                translation_key="energy_solar_charging",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_battery_percentage": SensorEntityDescription(
+                key=f"energy{i}_battery_percentage",
+                native_unit_of_measurement=PERCENTAGE,
+                device_class=SensorDeviceClass.BATTERY,
+                state_class=SensorStateClass.MEASUREMENT,
+                translation_key="energy_battery_level",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_output_power": SensorEntityDescription(
+                key=f"energy{i}_output_power",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=1,
+                translation_key="energy_output_power",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_ems_charging": SensorEntityDescription(
+                key=f"energy{i}_ems_charging",
+                device_class=SensorDeviceClass.ENUM,
+                options=["off", "on"],
+                translation_key="energy_ems_charge_flag",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_hw_connect": SensorEntityDescription(
+                key=f"energy{i}_hw_connect",
+                device_class=SensorDeviceClass.ENUM,
+                options=["disconnected", "connected"],
+                translation_key="energy_hw_connected",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_ems_battery_temp": SensorEntityDescription(
+                key=f"energy{i}_ems_battery_temp",
+                native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+                device_class=SensorDeviceClass.TEMPERATURE,
+                state_class=SensorStateClass.MEASUREMENT,
+                translation_key="energy_battery_temperature",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_lcd_input": SensorEntityDescription(
+                key=f"energy{i}_lcd_input",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                translation_key="energy_lcd_input_power",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+            f"energy{i}_pv_input": SensorEntityDescription(
+                key=f"energy{i}_pv_input",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                translation_key="energy_pv_input_power",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_pv_lv_input": SensorEntityDescription(
+                key=f"energy{i}_pv_lv_input",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                translation_key="energy_pv_lv_input_power",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_pv_hv_input": SensorEntityDescription(
+                key=f"energy{i}_pv_hv_input",
+                native_unit_of_measurement=UnitOfPower.WATT,
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                translation_key="energy_pv_hv_input_power",
+                translation_placeholders={"energy": f"{i}"},
+            ),
+            f"energy{i}_error_code": SensorEntityDescription(
+                key=f"energy{i}_error_code",
+                state_class=SensorStateClass.MEASUREMENT,
+                translation_key="energy_error_count",
+                translation_placeholders={"energy": f"{i}"},
+                entity_registry_enabled_default=False,
+            ),
+        })
+
+    return sensors
+
+
 @dataclass(frozen=True, kw_only=True)
 class EcoflowSensorEntityDescription[Device: DeviceBase](SensorEntityDescription):
     state_attribute_fields: list[str] = field(default_factory=list)
@@ -125,6 +360,10 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         )
         for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1)
     },
+    # SHP2 Backup Channel Info - dynamically generated
+    **_create_shp2_backup_channel_sensors(),
+    # SHP2 Energy Info - dynamically generated
+    **_create_shp2_energy_sensors(),
     # DPU
     **{
         f"{sensor}_{measurement}": SensorEntityDescription(

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    EntityCategory,
     PERCENTAGE,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -48,25 +49,17 @@ def _create_shp2_backup_channel_sensors():
 
     for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
         sensors.update({
-            f"ch{i}_backup_is_ready": SensorEntityDescription(
-                key=f"ch{i}_backup_is_ready",
-                device_class=SensorDeviceClass.ENUM,
-                options=["false", "true"],
-                translation_key="backup_is_ready",
-                translation_placeholders={"channel": f"{i}"},
-                entity_registry_enabled_default=False,
-            ),
             f"ch{i}_ctrl_status": SensorEntityDescription(
                 key=f"ch{i}_ctrl_status",
                 device_class=SensorDeviceClass.ENUM,
-                options=["backup_ch_off", "backup_ch_discharge", "backup_ch_charge", "backup_ch_em_stop", "backup_ch_standby"],
+                options=shp2.ControlStatus.options(include_unknown=False),
                 translation_key="backup_ctrl_status",
                 translation_placeholders={"channel": f"{i}"},
             ),
             f"ch{i}_force_charge": SensorEntityDescription(
                 key=f"ch{i}_force_charge",
                 device_class=SensorDeviceClass.ENUM,
-                options=["force_charge_off", "force_charge_on"],
+                options=shp2.ForceChargeStatus.options(include_unknown=False),
                 translation_key="backup_force_charge",
                 translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
@@ -94,8 +87,8 @@ def _create_shp2_backup_channel_sensors():
                 translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
             ),
-            f"ch{i}_energy_5p8_type": SensorEntityDescription(
-                key=f"ch{i}_energy_5p8_type",
+            f"ch{i}_5p8_type": SensorEntityDescription(
+                key=f"ch{i}_5p8_type",
                 translation_key="backup_connector_type",
                 translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
@@ -105,172 +98,114 @@ def _create_shp2_backup_channel_sensors():
     return sensors
 
 
-def _create_shp2_energy_sensors():
-    """Create sensor descriptions for SHP2 energy info"""
+def _create_shp2_channel_sensors():
+    """Create sensor descriptions for SHP2 channel info"""
     sensors = {}
 
     for i in range(1, shp2.Device.NUM_OF_CHANNELS + 1):
         sensors.update({
-            f"energy{i}_sn": SensorEntityDescription(
-                key=f"energy{i}_sn",
-                translation_key="energy_serial_number",
-                translation_placeholders={"energy": f"{i}"},
+            f"channel{i}_sn": SensorEntityDescription(
+                key=f"channel{i}_sn",
+                translation_key="channel_serial_number",
+                translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_type": SensorEntityDescription(
-                key=f"energy{i}_type",
-                translation_key="energy_device_type",
-                translation_placeholders={"energy": f"{i}"},
+            f"channel{i}_type": SensorEntityDescription(
+                key=f"channel{i}_type",
+                translation_key="channel_device_type",
+                translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_capacity": SensorEntityDescription(
-                key=f"energy{i}_capacity",
+            f"channel{i}_capacity": SensorEntityDescription(
+                key=f"channel{i}_capacity",
                 native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
                 device_class=SensorDeviceClass.ENERGY_STORAGE,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
                 suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-                translation_key="energy_full_capacity",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_full_capacity",
+                translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_rate_power": SensorEntityDescription(
-                key=f"energy{i}_rate_power",
+            f"channel{i}_rate_power": SensorEntityDescription(
+                key=f"channel{i}_rate_power",
                 native_unit_of_measurement=UnitOfPower.WATT,
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
-                translation_key="energy_rated_power",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_rated_power",
+                translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_is_enabled": SensorEntityDescription(
-                key=f"energy{i}_is_enabled",
-                device_class=SensorDeviceClass.ENUM,
-                options=["disabled", "enabled"],
-                translation_key="energy_enabled",
-                translation_placeholders={"energy": f"{i}"},
-            ),
-            f"energy{i}_is_connected": SensorEntityDescription(
-                key=f"energy{i}_is_connected",
-                device_class=SensorDeviceClass.ENUM,
-                options=["disconnected", "connected"],
-                translation_key="energy_connected",
-                translation_placeholders={"energy": f"{i}"},
-            ),
-            f"energy{i}_is_ac_open": SensorEntityDescription(
-                key=f"energy{i}_is_ac_open",
-                device_class=SensorDeviceClass.ENUM,
-                options=["closed", "open"],
-                translation_key="energy_ac_output",
-                translation_placeholders={"energy": f"{i}"},
-                entity_registry_enabled_default=False,
-            ),
-            f"energy{i}_is_power_output": SensorEntityDescription(
-                key=f"energy{i}_is_power_output",
-                device_class=SensorDeviceClass.ENUM,
-                options=["off", "on"],
-                translation_key="energy_power_output",
-                translation_placeholders={"energy": f"{i}"},
-            ),
-            f"energy{i}_is_grid_charge": SensorEntityDescription(
-                key=f"energy{i}_is_grid_charge",
-                device_class=SensorDeviceClass.ENUM,
-                options=["off", "on"],
-                translation_key="energy_grid_charging",
-                translation_placeholders={"energy": f"{i}"},
-            ),
-            f"energy{i}_is_mppt_charge": SensorEntityDescription(
-                key=f"energy{i}_is_mppt_charge",
-                device_class=SensorDeviceClass.ENUM,
-                options=["off", "on"],
-                translation_key="energy_solar_charging",
-                translation_placeholders={"energy": f"{i}"},
-            ),
-            f"energy{i}_battery_percentage": SensorEntityDescription(
-                key=f"energy{i}_battery_percentage",
+            f"channel{i}_battery_percentage": SensorEntityDescription(
+                key=f"channel{i}_battery_percentage",
                 native_unit_of_measurement=PERCENTAGE,
                 device_class=SensorDeviceClass.BATTERY,
                 state_class=SensorStateClass.MEASUREMENT,
-                translation_key="energy_battery_level",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_battery_level",
+                translation_placeholders={"channel": f"{i}"},
             ),
-            f"energy{i}_output_power": SensorEntityDescription(
-                key=f"energy{i}_output_power",
+            f"channel{i}_output_power": SensorEntityDescription(
+                key=f"channel{i}_output_power",
                 native_unit_of_measurement=UnitOfPower.WATT,
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=1,
-                translation_key="energy_output_power",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_output_power",
+                translation_placeholders={"channel": f"{i}"},
             ),
-            f"energy{i}_ems_charging": SensorEntityDescription(
-                key=f"energy{i}_ems_charging",
-                device_class=SensorDeviceClass.ENUM,
-                options=["off", "on"],
-                translation_key="energy_ems_charge_flag",
-                translation_placeholders={"energy": f"{i}"},
-                entity_registry_enabled_default=False,
-            ),
-            f"energy{i}_hw_connect": SensorEntityDescription(
-                key=f"energy{i}_hw_connect",
-                device_class=SensorDeviceClass.ENUM,
-                options=["disconnected", "connected"],
-                translation_key="energy_hw_connected",
-                translation_placeholders={"energy": f"{i}"},
-                entity_registry_enabled_default=False,
-            ),
-            f"energy{i}_ems_battery_temp": SensorEntityDescription(
-                key=f"energy{i}_ems_battery_temp",
+            f"channel{i}_battery_temp": SensorEntityDescription(
+                key=f"channel{i}_battery_temp",
                 native_unit_of_measurement=UnitOfTemperature.CELSIUS,
                 device_class=SensorDeviceClass.TEMPERATURE,
                 state_class=SensorStateClass.MEASUREMENT,
-                translation_key="energy_battery_temperature",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_battery_temperature",
+                translation_placeholders={"channel": f"{i}"},
             ),
-            f"energy{i}_lcd_input": SensorEntityDescription(
-                key=f"energy{i}_lcd_input",
+            f"channel{i}_lcd_input": SensorEntityDescription(
+                key=f"channel{i}_lcd_input",
                 native_unit_of_measurement=UnitOfPower.WATT,
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
-                translation_key="energy_lcd_input_power",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_lcd_input_power",
+                translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
             ),
-            f"energy{i}_pv_input": SensorEntityDescription(
-                key=f"energy{i}_pv_input",
+            f"channel{i}_pv_input": SensorEntityDescription(
+                key=f"channel{i}_pv_input",
                 native_unit_of_measurement=UnitOfPower.WATT,
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
-                translation_key="energy_pv_input_power",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_pv_input_power",
+                translation_placeholders={"channel": f"{i}"},
             ),
-            f"energy{i}_pv_lv_input": SensorEntityDescription(
-                key=f"energy{i}_pv_lv_input",
+            f"channel{i}_pv_lv_input": SensorEntityDescription(
+                key=f"channel{i}_pv_lv_input",
                 native_unit_of_measurement=UnitOfPower.WATT,
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
-                translation_key="energy_pv_lv_input_power",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_pv_lv_input_power",
+                translation_placeholders={"channel": f"{i}"},
             ),
-            f"energy{i}_pv_hv_input": SensorEntityDescription(
-                key=f"energy{i}_pv_hv_input",
+            f"channel{i}_pv_hv_input": SensorEntityDescription(
+                key=f"channel{i}_pv_hv_input",
                 native_unit_of_measurement=UnitOfPower.WATT,
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
-                translation_key="energy_pv_hv_input_power",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_pv_hv_input_power",
+                translation_placeholders={"channel": f"{i}"},
             ),
-            f"energy{i}_error_code": SensorEntityDescription(
-                key=f"energy{i}_error_code",
+            f"channel{i}_error_code": SensorEntityDescription(
+                key=f"channel{i}_error_code",
                 state_class=SensorStateClass.MEASUREMENT,
-                translation_key="energy_error_count",
-                translation_placeholders={"energy": f"{i}"},
+                translation_key="channel_error_count",
+                translation_placeholders={"channel": f"{i}"},
                 entity_registry_enabled_default=False,
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
         })
 
@@ -363,7 +298,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
     # SHP2 Backup Channel Info - dynamically generated
     **_create_shp2_backup_channel_sensors(),
     # SHP2 Energy Info - dynamically generated
-    **_create_shp2_energy_sensors(),
+    **_create_shp2_channel_sensors(),
     # DPU
     **{
         f"{sensor}_{measurement}": SensorEntityDescription(

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -381,6 +381,130 @@
       },
       "grid_frequency": {
         "name": "Grid Frequency"
+      },
+      "backup_is_ready": {
+        "name": "Channel {channel} Backup Ready"
+      },
+      "backup_ctrl_status": {
+        "name": "Channel {channel} Control Status",
+        "state": {
+          "backup_ch_off": "Off",
+          "backup_ch_discharge": "Discharging",
+          "backup_ch_charge": "Charging",
+          "backup_ch_em_stop": "Emergency Stop",
+          "backup_ch_standby": "Standby"
+        }
+      },
+      "backup_force_charge": {
+        "name": "Channel {channel} Force Charge",
+        "state": {
+          "force_charge_off": "Off",
+          "force_charge_on": "On"
+        }
+      },
+      "backup_relay1_count": {
+        "name": "Channel {channel} Relay 1 Count"
+      },
+      "backup_relay2_count": {
+        "name": "Channel {channel} Relay 2 Count"
+      },
+      "backup_wakeup_charge": {
+        "name": "Channel {channel} Wakeup Charge Level"
+      },
+      "backup_connector_type": {
+        "name": "Channel {channel} Connector Type"
+      },
+      "energy_serial_number": {
+        "name": "Energy {energy} Serial Number"
+      },
+      "energy_device_type": {
+        "name": "Energy {energy} Device Type"
+      },
+      "energy_full_capacity": {
+        "name": "Energy {energy} Full Capacity"
+      },
+      "energy_rated_power": {
+        "name": "Energy {energy} Rated Power"
+      },
+      "energy_enabled": {
+        "name": "Energy {energy} Enabled",
+        "state": {
+          "disabled": "Disabled",
+          "enabled": "Enabled"
+        }
+      },
+      "energy_connected": {
+        "name": "Energy {energy} Connected",
+        "state": {
+          "disconnected": "Disconnected",
+          "connected": "Connected"
+        }
+      },
+      "energy_ac_output": {
+        "name": "Energy {energy} AC Output",
+        "state": {
+          "closed": "Closed",
+          "open": "Open"
+        }
+      },
+      "energy_power_output": {
+        "name": "Energy {energy} Power Output",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "energy_grid_charging": {
+        "name": "Energy {energy} Grid Charging",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "energy_solar_charging": {
+        "name": "Energy {energy} Solar Charging",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "energy_battery_level": {
+        "name": "Energy {energy} Battery Level"
+      },
+      "energy_output_power": {
+        "name": "Energy {energy} Output Power"
+      },
+      "energy_ems_charge_flag": {
+        "name": "Energy {energy} EMS Charge Flag",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "energy_hw_connected": {
+        "name": "Energy {energy} Hardware Connected",
+        "state": {
+          "disconnected": "Disconnected",
+          "connected": "Connected"
+        }
+      },
+      "energy_battery_temperature": {
+        "name": "Energy {energy} Battery Temperature"
+      },
+      "energy_lcd_input_power": {
+        "name": "Energy {energy} LCD Input Power"
+      },
+      "energy_pv_input_power": {
+        "name": "Energy {energy} PV Input Power"
+      },
+      "energy_pv_lv_input_power": {
+        "name": "Energy {energy} PV LV Input Power"
+      },
+      "energy_pv_hv_input_power": {
+        "name": "Energy {energy} PV HV Input Power"
+      },
+      "energy_error_count": {
+        "name": "Energy {energy} Error Count"
       }
     },
     "select": {

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -388,18 +388,18 @@
       "backup_ctrl_status": {
         "name": "Channel {channel} Control Status",
         "state": {
-          "backup_ch_off": "Off",
-          "backup_ch_discharge": "Discharging",
-          "backup_ch_charge": "Charging",
-          "backup_ch_em_stop": "Emergency Stop",
-          "backup_ch_standby": "Standby"
+          "off": "Off",
+          "discharge": "Discharging",
+          "charge": "Charging",
+          "emergency_stop": "Emergency Stop",
+          "standby": "Standby"
         }
       },
       "backup_force_charge": {
         "name": "Channel {channel} Force Charge",
         "state": {
-          "force_charge_off": "Off",
-          "force_charge_on": "On"
+          "off": "Off",
+          "on": "On"
         }
       },
       "backup_relay1_count": {
@@ -414,97 +414,41 @@
       "backup_connector_type": {
         "name": "Channel {channel} Connector Type"
       },
-      "energy_serial_number": {
-        "name": "Energy {energy} Serial Number"
+      "channel_serial_number": {
+        "name": "Channel {channel} Serial Number"
       },
-      "energy_device_type": {
-        "name": "Energy {energy} Device Type"
+      "channel_device_type": {
+        "name": "Channel {channel} Device Type"
       },
-      "energy_full_capacity": {
-        "name": "Energy {energy} Full Capacity"
+      "channel_full_capacity": {
+        "name": "Channel {channel} Full Capacity"
       },
-      "energy_rated_power": {
-        "name": "Energy {energy} Rated Power"
+      "channel_rated_power": {
+        "name": "Channel {channel} Rated Power"
       },
-      "energy_enabled": {
-        "name": "Energy {energy} Enabled",
-        "state": {
-          "disabled": "Disabled",
-          "enabled": "Enabled"
-        }
+      "channel_battery_level": {
+        "name": "Channel {channel} Battery Level"
       },
-      "energy_connected": {
-        "name": "Energy {energy} Connected",
-        "state": {
-          "disconnected": "Disconnected",
-          "connected": "Connected"
-        }
+      "channel_output_power": {
+        "name": "Channel {channel} Output Power"
       },
-      "energy_ac_output": {
-        "name": "Energy {energy} AC Output",
-        "state": {
-          "closed": "Closed",
-          "open": "Open"
-        }
+      "channel_battery_temperature": {
+        "name": "Channel {channel} Battery Temperature"
       },
-      "energy_power_output": {
-        "name": "Energy {energy} Power Output",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
+      "channel_lcd_input_power": {
+        "name": "Channel {channel} LCD Input Power"
       },
-      "energy_grid_charging": {
-        "name": "Energy {energy} Grid Charging",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
+      "channel_pv_input_power": {
+        "name": "Channel {channel} PV Input Power"
       },
-      "energy_solar_charging": {
-        "name": "Energy {energy} Solar Charging",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
+      "channel_pv_lv_input_power": {
+        "name": "Channel {channel} PV LV Input Power"
       },
-      "energy_battery_level": {
-        "name": "Energy {energy} Battery Level"
+      "channel_pv_hv_input_power": {
+        "name": "Channel {channel} PV HV Input Power"
       },
-      "energy_output_power": {
-        "name": "Energy {energy} Output Power"
-      },
-      "energy_ems_charge_flag": {
-        "name": "Energy {energy} EMS Charge Flag",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
-      },
-      "energy_hw_connected": {
-        "name": "Energy {energy} Hardware Connected",
-        "state": {
-          "disconnected": "Disconnected",
-          "connected": "Connected"
-        }
-      },
-      "energy_battery_temperature": {
-        "name": "Energy {energy} Battery Temperature"
-      },
-      "energy_lcd_input_power": {
-        "name": "Energy {energy} LCD Input Power"
-      },
-      "energy_pv_input_power": {
-        "name": "Energy {energy} PV Input Power"
-      },
-      "energy_pv_lv_input_power": {
-        "name": "Energy {energy} PV LV Input Power"
-      },
-      "energy_pv_hv_input_power": {
-        "name": "Energy {energy} PV HV Input Power"
-      },
-      "energy_error_count": {
-        "name": "Energy {energy} Error Count"
+      "channel_error_count": {
+        "name": "Channel {channel} Error Count"
       }
     },
     "select": {


### PR DESCRIPTION
Finally found a way to add some additional sensors into SHP2.

Had a few issues implementing - thought to use NUM_OF_CHANNELS / NUM_OF_CIRCUITS to unify identical fields but it did not work (HA did not liked those dynamic fields very much and always had issues with type of the field data), so moved static way.

Basically those are working, but still TODO:
* Check PV data input when sun will be back
* Ensure only necessary fields are enabled by default