### PR TITLE
Add STREAM Ultra X to supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ you have to create it yourself, see this section from the official
 </details>
 
 <details><summary>
-<b>STREAM (AC, AC Pro, Max, Pro, Ultra)</b>
+<b>STREAM (AC, AC Pro, Max, Pro, Ultra, Ultra X)</b>
 </summary>
 
 | *Sensors*                   | *Switches*  | *Sliders*             | *Selects*       |
@@ -216,7 +216,7 @@ you have to create it yourself, see this section from the official
 ᴬ Only available on AC Pro variant  
 ᴹ Only available on Max variant  
 ᴾ Only available on Pro variant  
-ᵁ Only available on Ultra variant  
+ᵁ Only available on Ultra and Ultra X variants
 ¹ Not available when there's no base load timeframe or more than 1 timeframe configured.
 </details>
 

--- a/custom_components/ef_ble/eflib/devices/stream_max.py
+++ b/custom_components/ef_ble/eflib/devices/stream_max.py
@@ -1,10 +1,10 @@
-from ..props import ProtobufProps, pb_field
+from ..props import pb_field
 from . import stream_ac
 
 pb = stream_ac.pb
 
 
-class Device(stream_ac.Device, ProtobufProps):
+class Device(stream_ac.Device):
     """STREAM Max"""
 
     SN_PREFIX = (b"BK41",)

--- a/custom_components/ef_ble/eflib/devices/stream_pro.py
+++ b/custom_components/ef_ble/eflib/devices/stream_pro.py
@@ -1,10 +1,10 @@
-from ..props import ProtobufProps, pb_field
+from ..props import pb_field
 from . import stream_ac, stream_max
 
 pb = stream_ac.pb
 
 
-class Device(stream_max.Device, ProtobufProps):
+class Device(stream_max.Device):
     """STREAM Pro"""
 
     SN_PREFIX = (b"BK12",)

--- a/custom_components/ef_ble/eflib/devices/stream_ultra.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ultra.py
@@ -1,12 +1,20 @@
-from ..props import ProtobufProps, pb_field
+from ..props import pb_field
 from . import stream_ac, stream_pro
 
 pb = stream_ac.pb
 
 
-class Device(stream_pro.Device, ProtobufProps):
+class Device(stream_pro.Device):
     """STREAM Ultra"""
 
-    SN_PREFIX = (b"BK11", b"ES11")
+    SN_PREFIX = (b"BK11", b"ES11", b"BK61")
 
     pv_power_4 = pb_field(pb.pow_get_pv4, lambda v: round(v, 2))
+
+    @property
+    def device(self):
+        model = ""
+        match self._sn[:4]:
+            case "BK61":
+                model = "X"
+        return f"STREAM Ultra {model}".strip()


### PR DESCRIPTION
Ultra X has the same I/O as a regular ultra, so this PR only adds serial number prefix to Ultra implementation.

Resolves #89 