### PR TITLE
Add region selector to login screen

### DIFF
--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -36,7 +36,8 @@
             "name": "EcoFlow Login (skip if you already know your user ID)",
             "data": {
               "email": "Email",
-              "password": "Password"
+              "password": "Password",
+              "region": "Region (try different region if you get 'Account does not exist' or 'user ID may be incorrect' error)"
             }
           },
           "log_options": {
@@ -71,7 +72,8 @@
             "name": "EcoFlow Login (skip if you already know your user ID)",
             "data": {
               "email": "Email",
-              "password": "Password"
+              "password": "Password",
+              "region": "Region (try different region if you get 'Account does not exist' or 'user ID may be incorrect' error)"
             }
           },
           "log_options": {


### PR DESCRIPTION
We are using `api.ecoflow.com` to get the user id, but it seems that this redirects to the region the user makes request from which should work for most of the users, however in #113 it was reported that the account was created for a different region so this PR adds a selector for region to login to.

It seems that the user id is also not the same depending on which region you choose - I do have accounts for both US and EU regions and it changes based on the endpoint.