### PR TITLE
Fix crc16 check for v19 packets

### DIFF
--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -104,7 +104,8 @@ class Packet:
 
         payload_length = struct.unpack("<H", data[2:4])[0]
 
-        if version >= 2:
+        # there are also version 19 packets that do not contain crc16 checksum
+        if version in [2, 3]:
             # Check whole packet CRC16
             if crc16(data[:-2]) != struct.unpack("<H", data[-2:])[0]:
                 _LOGGER.error(


### PR DESCRIPTION
In #109 we changed the crc16 check for packet version to >= 2 that enabled it for version 19 packets which do not contain checksums so crc checks for these packets fail.

Resolves #121 