### PR TITLE
Fix DP3, Wave3, SG and STREAM devices not resetting updated flag causing cpu increase over time

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -100,6 +100,7 @@ class Device(DeviceBase, ProtobufProps):
 
     async def data_parse(self, packet: Packet):
         processed = False
+        self.reset_updated()
 
         if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             self.update_from_bytes(mr521_pb2.DisplayPropertyUpload, packet.payload)

--- a/custom_components/ef_ble/eflib/devices/smart_generator.py
+++ b/custom_components/ef_ble/eflib/devices/smart_generator.py
@@ -127,6 +127,7 @@ class Device(DeviceBase, ProtobufProps):
 
     async def data_parse(self, packet: Packet):
         processed = False
+        self.reset_updated()
 
         if packet.src == 0x08 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             self.update_from_bytes(ge305_sys_pb2.DisplayPropertyUpload, packet.payload)

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -115,6 +115,8 @@ class Device(DeviceBase, ProtobufProps):
 
     async def data_parse(self, packet: Packet):
         processed = False
+        self.reset_updated()
+
         if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             self.update_from_bytes(bk_series_pb2.DisplayPropertyUpload, packet.payload)
             processed = True

--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -101,6 +101,7 @@ class Device(DeviceBase, ProtobufProps):
 
     async def data_parse(self, packet: Packet):
         processed = False
+        self.reset_updated()
 
         if packet.src == 0x42 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
             self.update_from_bytes(


### PR DESCRIPTION
This PR adds forgotten resets for updated flag causing linear increase in updated fields for each received packet and this is also causing cpu usage to increase in time as number of state updates is also increasing in time.

Should fix #42 