### PR TITLE
Add grid bypass switch to Delta 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,29 +96,29 @@ See more info in [this issue](https://github.com/rabits/ha-ef-ble/issues/78).
 <b>Delta 3 (Classic, Plus, Max, Max Plus, Ultra) (EF-D3####)</b>
 </summary>
 
-| *Sensors*                       | *Switches*     | *Sliders*                  |
-|---------------------------------|----------------|----------------------------|
-| Main Battery Level              | AC Ports       | Backup Reserve Level       |
-| Battery Level                   | DC Ports       | Max Charge Limit           |
-| AC Input Power                  | Backup Reserve | Min Discharge Limit        |
-| AC Output Power                 | USB Ports ¹    | AC Charging Speed          |
-| DC 12V Port Output Power        |                | DC Charging Max Amps       |
-| DC Port Input Power             |                | DC (2) Charging Max Amps ⁺ |
-| DC Port Input State             |                |                            |
-| DC Port (2) Input Power⁺        |                |                            |
-| DC Port (2) Input State⁺        |                |                            |
-| Solar Power                     |                |                            |
-| Solar Power (2) ⁺               |                |                            |
-| Input Power Total               |                |                            |
-| Output Power Total              |                |                            |
-| USB A Output Power              |                |                            |
-| USB A (2) Output Power          |                |                            |
-| USB C Output Power              |                |                            |
-| USB C (2) Output Power          |                |                            |
-| AC Plugged In                   |                |                            |
-| Battery Input Power (disabled)  |                |                            |
-| Battery Output Power (disabled) |                |                            |
-| Cell Temperature (disabled)     |                |                            |
+| *Sensors*                       | *Switches*                     | *Sliders*                  |
+|---------------------------------|--------------------------------|----------------------------|
+| Main Battery Level              | AC Ports                       | Backup Reserve Level       |
+| Battery Level                   | DC Ports                       | Max Charge Limit           |
+| AC Input Power                  | Backup Reserve                 | Min Discharge Limit        |
+| AC Output Power                 | USB Ports ¹                    | AC Charging Speed          |
+| DC 12V Port Output Power        | Disable Grid Bypass (disabled) | DC Charging Max Amps       |
+| DC Port Input Power             |                                | DC (2) Charging Max Amps ⁺ |
+| DC Port Input State             |                                |                            |
+| DC Port (2) Input Power⁺        |                                |                            |
+| DC Port (2) Input State⁺        |                                |                            |
+| Solar Power                     |                                |                            |
+| Solar Power (2) ⁺               |                                |                            |
+| Input Power Total               |                                |                            |
+| Output Power Total              |                                |                            |
+| USB A Output Power              |                                |                            |
+| USB A (2) Output Power          |                                |                            |
+| USB C Output Power              |                                |                            |
+| USB C (2) Output Power          |                                |                            |
+| AC Plugged In                   |                                |                            |
+| Battery Input Power (disabled)  |                                |                            |
+| Battery Output Power (disabled) |                                |                            |
+| Cell Temperature (disabled)     |                                |                            |
 
 ⁺ Only available on Plus variant  
 ¹ Not available on Classic

--- a/custom_components/ef_ble/eflib/devices/delta3_classic.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_classic.py
@@ -106,6 +106,7 @@ class Device(DeviceBase, ProtobufProps):
     cell_temperature = pb_field(pb.bms_max_cell_temp)
     dc_12v_port = pb_field(pb.flow_info_12v, _flow_is_on)
     ac_ports = pb_field(pb.flow_info_ac_out, _flow_is_on)
+    disable_grid_bypass = pb_field(pb.bypass_out_disable)
 
     solar_input_power = Field[float]()
 
@@ -253,3 +254,8 @@ class Device(DeviceBase, ProtobufProps):
 
         await self._send_config_packet(config)
         return True
+
+    async def enable_disable_grid_bypass(self, enabled: bool):
+        await self._send_config_packet(
+            pd335_sys_pb2.ConfigWrite(cfg_bypass_out_disable=enabled)
+        )

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -29,6 +29,11 @@ SWITCH_TYPES = [
         device_class=SwitchDeviceClass.OUTLET,
     ),
     SwitchEntityDescription(
+        key="disable_grid_bypass",
+        name="Disable Grid Bypass",
+        entity_registry_enabled_default=False,
+    ),
+    SwitchEntityDescription(
         key="self_start",
         name="Self Start",
     ),


### PR DESCRIPTION
This PR adds grid bypass switch to Delta 3 devices as requested [here](https://community.home-assistant.io/t/ecoflow-ble-unofficial/774794/199).