### PR TITLE
Fix PV 2 sensor for Stream Max

### DIFF
--- a/custom_components/ef_ble/eflib/devices/stream_max.py
+++ b/custom_components/ef_ble/eflib/devices/stream_max.py
@@ -13,6 +13,6 @@ class Device(stream_ac.Device):
     ac_1 = pb_field(pb.relay2_onoff)
 
     pv_power_1 = pb_field(pb.pow_get_pv, lambda v: round(v, 2))
-    pv_power_2 = pb_field(pb.pow_get_pv2, lambda v: round(v, 2))
+    pv_power_2 = pb_field(pb.pow_get_pv4, lambda v: round(v, 2))
 
     load_from_pv = pb_field(pb.pow_get_sys_load_from_pv, lambda v: round(v, 2))

--- a/custom_components/ef_ble/eflib/devices/stream_ultra.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ultra.py
@@ -9,7 +9,7 @@ class Device(stream_pro.Device):
 
     SN_PREFIX = (b"BK11", b"ES11", b"BK61")
 
-    pv_power_4 = pb_field(pb.pow_get_pv4, lambda v: round(v, 2))
+    pv_power_4 = pb_field(pb.pow_get_pv2, lambda v: round(v, 2))
 
     @property
     def device(self):


### PR DESCRIPTION
This PR fixes issue reported in #141 - PV ports seem to be indexed by their physical position.

Resolves #141 