### PR TITLE
Apply xor only for v19 packets

### DIFF
--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -219,9 +219,6 @@ class Delta2Base(DeviceBase, RawDataProps):
         packet = Packet(0x21, self.ac_commands_dst, 0x20, 0x42, payload, version=0x02)
         await self._conn.sendPacket(packet)
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def set_battery_charge_limit_max(self, limit: int):
         packet = Packet(0x21, 0x03, 0x20, 0x31, limit.to_bytes(), version=0x02)
         await self._conn.sendPacket(packet)

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -122,9 +122,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/alternator_charger.py
+++ b/custom_components/ef_ble/eflib/devices/alternator_charger.py
@@ -99,9 +99,6 @@ class Device(DeviceBase, ProtobufProps):
 
         return f"Alternator Charger {model}".strip()
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
 

--- a/custom_components/ef_ble/eflib/devices/delta2_max.py
+++ b/custom_components/ef_ble/eflib/devices/delta2_max.py
@@ -2,7 +2,6 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
 from ..model import Mr350MpptHeart, Mr350PdHeartbeatDelta2Max
-from ..packet import Packet
 from ..props import dataclass_attr_mapper, raw_field
 from ._delta2_base import Delta2Base, pb_inv
 
@@ -39,6 +38,3 @@ class Device(Delta2Base):
     @property
     def ac_commands_dst(self):
         return 0x04
-
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=False)

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -95,9 +95,6 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -65,12 +65,9 @@ class Device(DeviceBase, ProtobufProps):
         super().__init__(ble_dev, adv_data, sn)
         self._time_commands = TimeCommands(self)
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        """Need to override because packet payload is xor-encoded by the first byte of seq"""
-        return Packet.fromBytes(data, True)
-
     async def data_parse(self, packet: Packet) -> bool:
-        """Processing the incoming notifications from the device"""
+        """Process the incoming notifications from the device"""
+
         processed = False
         self.reset_updated()
 

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -126,9 +126,6 @@ class Device(DeviceBase, ProtobufProps):
                 model = "UPS (245Wh)"
         return f"River 3 {model}".strip()
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/smart_generator.py
+++ b/custom_components/ef_ble/eflib/devices/smart_generator.py
@@ -122,9 +122,6 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn.startswith(cls.SN_PREFIX)
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/smart_meter.py
+++ b/custom_components/ef_ble/eflib/devices/smart_meter.py
@@ -50,9 +50,6 @@ class Device(DeviceBase, ProtobufProps):
     l3_current = pb_field(pb.grid_connection_amp_L3, _round2)
     l3_voltage = pb_field(pb.grid_connection_vol_L3, _round2)
 
-    async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -151,9 +151,6 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/stream_microinverter.py
+++ b/custom_components/ef_ble/eflib/devices/stream_microinverter.py
@@ -41,9 +41,6 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -97,9 +97,6 @@ class Device(DeviceBase, RawDataProps):
     def check(cls, sn):
         return sn.startswith(cls.SN_PREFIX)
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet) -> bool:
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -96,9 +96,6 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
-    async def packet_parse(self, data: bytes) -> Packet:
-        return Packet.fromBytes(data, is_xor=True)
-
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -87,7 +87,7 @@ class Packet:
         return self._product_id
 
     @staticmethod
-    def fromBytes(data, is_xor=False):
+    def fromBytes(data: bytes):
         """Deserializes bytes stream into internal data"""
         if not data.startswith(Packet.PREFIX):
             error_msg = "Unable to parse packet - prefix is incorrect: %s"
@@ -137,12 +137,14 @@ class Packet:
         if payload_length > 0:
             payload = data[payload_start : payload_start + payload_length]
 
-            # If first byte of seq is set - we need to xor payload with it to get the real data
-            if is_xor is True and seq[0] != b"\x00":
-                payload = bytes([c ^ seq[0] for c in payload])
+            if version == 0x13:
+                # If first byte of seq is set - we need to xor payload with it to get
+                # the real data
+                if seq[0] != b"\x00":
+                    payload = bytes([c ^ seq[0] for c in payload])
 
-            if version == 19 and payload[-2:] == b"\xbb\xbb":
-                payload = payload[:-2]
+                if payload[-2:] == b"\xbb\xbb":
+                    payload = payload[:-2]
 
         return Packet(
             src=src,
@@ -182,7 +184,8 @@ class Packet:
         return data
 
     def productByte(self):
-        """Returns magics depends on product id"""
+        """Return magics depends on product id"""
+
         if self._product_id >= 0:
             return b"\x0d"
         return b"\x0c"


### PR DESCRIPTION
This PR removes option to provide `is_xor` to `Packet.fromBytes` as it's a property of version 19 packets.

I realized that we don't need to have packet_parse for each device - only version 19 packets are using xor. 

