### PR TITLE
Set max AC charging power to 1000W for Delta 3 2000 Air

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta3_air.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_air.py
@@ -14,16 +14,16 @@ class Device(Delta3Base):
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
-        self.max_ac_charging_power = 500
+        self.max_ac_charging_power = 1000 if sn[:4] == "PR21" else 500
 
     @property
     def device(self):
         model = "Air"
         match self._sn[:4]:
-            case b"PR11":
+            case "PR11":
                 model = "1000 Air"
-            case b"PR12":
+            case "PR12":
                 model = "1000 Air (10ms UPS)"
-            case b"PR21":
-                model = "Delta 3 2000 Air"
+            case "PR21":
+                model = "2000 Air"
         return f"Delta 3 {model}"


### PR DESCRIPTION
The Delta 3 2000 Air supports AC charging speeds of up to 1000W. This PR sets the max to match the spec for this model.

I also fixed the conditions in the device property so the device model shows up properly in HA.

Both fixes are tested using my own device and looks to be working properly.