### PR TITLE
Fix Delta 3 missing DC 12V port, fix Stream duplicated power grid slider

### DIFF
--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -166,27 +166,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self._conn.sendPacket(packet)
 
-    async def set_energy_backup_battery_level(self, value: int):
-        config = pd335_sys_pb2.ConfigWrite()
-        config.cfg_energy_backup.energy_backup_en = True
-        config.cfg_energy_backup.energy_backup_start_soc = value
-        await self._send_config_packet(config)
-        return True
-
-    async def enable_energy_backup(self, enabled: bool):
-        config = pd335_sys_pb2.ConfigWrite()
-        config.cfg_energy_backup.energy_backup_en = enabled
-        if enabled and self.energy_backup_battery_level is not None:
-            config.cfg_energy_backup.energy_backup_start_soc = (
-                self.energy_backup_battery_level
-            )
-        await self._send_config_packet(config)
-
-    async def enable_dc_12v_port(self, enabled: bool):
-        await self._send_config_packet(
-            pd335_sys_pb2.ConfigWrite(cfg_dc_12v_out_open=enabled)
-        )
-
     async def enable_ac_ports(self, enabled: bool):
         await self._send_config_packet(
             pd335_sys_pb2.ConfigWrite(cfg_ac_out_open=enabled)

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -160,18 +160,6 @@ NUMBER_TYPES: list[EcoflowNumberEntityDescription] = [
             lambda device, value: device.set_power_limit(int(value))
         ),
     ),
-    EcoflowNumberEntityDescription[stream_ac.Device](
-        key="feed_grid_pow_limit",
-        name="Feed Grid Power Limit",
-        device_class=NumberDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        native_step=1,
-        native_min_value=0,
-        max_value_prop="feed_grid_pow_max",
-        async_set_native_value=(
-            lambda device, value: device.set_feed_grid_pow_limit(int(value))
-        ),
-    ),
     EcoflowNumberEntityDescription[alternator_charger.Device](
         key="start_voltage",
         name="Start Voltage",


### PR DESCRIPTION
In #152 Delta 3 cleanup we also accidentally removed 12V DC port control, this PR brings it back. It also moves control methods to the proper Delta 3 class.
There is also duplicated number for Stream's that could cause crash, see #159 

Resolves #159 #161