### PR TITLE
Add energy sensors to Smart Meter, make phase sensors disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,18 +275,22 @@ you have to create it yourself, see this section from the official
 <b>Smart Meter</b>
 </summary>
 
-| *Sensors*  |
-|------------|
-| Grid Power |
-| L1 Power   |
-| L1 Current |
-| L1 Voltage |
-| L2 Power   |
-| L2 Current |
-| L2 Voltage |
-| L3 Power   |
-| L3 Current |
-| L3 Voltage |
+| *Sensors*             |
+|-----------------------|
+| Grid Power            |
+| Grid Energy           |
+| L1 Power (disabled)   |
+| L1 Current (disabled) |
+| L1 Voltage (disabled) |
+| L1 Energy (disabled)  |
+| L2 Power (disabled)   |
+| L2 Current (disabled) |
+| L2 Voltage (disabled) |
+| L2 Energy (disabled)  |
+| L3 Power (disabled)   |
+| L3 Current (disabled) |
+| L3 Voltage (disabled) |
+| L3 Energy (disabled)  |
 </details>
 
 <details><summary>

--- a/custom_components/ef_ble/eflib/devices/smart_meter.py
+++ b/custom_components/ef_ble/eflib/devices/smart_meter.py
@@ -34,25 +34,25 @@ class Device(DeviceBase, ProtobufProps):
 
     grid_power = pb_field(pb.pow_get_sys_grid)
     grid_state = pb_field(pb.grid_connection_sta, GridState.from_value)
-    grid_energy_today = pb_field(pb.grid_connection_data_record.today_active)
+    grid_energy = pb_field(pb.grid_connection_data_record.today_active)
 
     l1_active = pb_field(pb.grid_connection_flag_L1)
     l1_power = pb_field(pb.grid_connection_power_L1, _round2)
     l1_current = pb_field(pb.grid_connection_amp_L1, _round2)
     l1_voltage = pb_field(pb.grid_connection_vol_L1, _round2)
-    l1_grid_energy_today = pb_field(pb.grid_connection_data_record.today_active_L1)
+    l1_grid_energy = pb_field(pb.grid_connection_data_record.today_active_L1)
 
     l2_active = pb_field(pb.grid_connection_flag_L2)
     l2_power = pb_field(pb.grid_connection_power_L2, _round2)
     l2_current = pb_field(pb.grid_connection_amp_L2, _round2)
     l2_voltage = pb_field(pb.grid_connection_vol_L2, _round2)
-    l2_grid_energy_today = pb_field(pb.grid_connection_data_record.today_active_L2)
+    l2_grid_energy = pb_field(pb.grid_connection_data_record.today_active_L2)
 
     l3_active = pb_field(pb.grid_connection_flag_L3)
     l3_power = pb_field(pb.grid_connection_power_L3, _round2)
     l3_current = pb_field(pb.grid_connection_amp_L3, _round2)
     l3_voltage = pb_field(pb.grid_connection_vol_L3, _round2)
-    l3_grid_energy_today = pb_field(pb.grid_connection_data_record.today_active_L3)
+    l3_grid_energy = pb_field(pb.grid_connection_data_record.today_active_L3)
 
     async def data_parse(self, packet: Packet):
         processed = False

--- a/custom_components/ef_ble/eflib/devices/stream_ac_pro.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac_pro.py
@@ -1,5 +1,4 @@
-from custom_components.ef_ble.eflib.devices import stream_ac
-
+from ..devices import stream_ac
 from ..props import ProtobufProps, pb_field
 
 pb = stream_ac.pb

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -764,8 +764,8 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         for i in range(5)
     },
     # Smart Meter
-    "grid_energy_today": SensorEntityDescription(
-        key="grid_energy_today",
+    "grid_energy": SensorEntityDescription(
+        key="grid_energy",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -780,6 +780,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="port_power",
             translation_placeholders={"name": f"L{i}"},
+            entity_registry_enabled_default=False,
         )
         for i in range(4)
     },
@@ -791,6 +792,7 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="port_current",
             translation_placeholders={"name": f"L{i}"},
+            entity_registry_enabled_default=False,
         )
         for i in range(4)
     },
@@ -802,19 +804,21 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
             state_class=SensorStateClass.MEASUREMENT,
             translation_key="port_voltage",
             translation_placeholders={"name": f"L{i}"},
+            entity_registry_enabled_default=False,
         )
         for i in range(4)
     },
     **{
-        f"l{i}_energy_today": SensorEntityDescription(
-            key=f"l{i}_energy_today",
+        f"l{i}_energy": SensorEntityDescription(
+            key=f"l{i}_energy",
             native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
             suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             suggested_display_precision=3,
-            translation_key="port_energy_today",
+            translation_key="port_energy",
             translation_placeholders={"name": f"L{i}"},
+            entity_registry_enabled_default=False,
         )
         for i in range(4)
     },

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -309,8 +309,14 @@
       "port_energy_today": {
         "name": "{name} Energy Today"
       },
+      "port_energy": {
+        "name": "{name} Energy"
+      },
       "grid_energy_today": {
         "name": "Grid Energy Today"
+      },
+      "grid_energy": {
+        "name": "Grid Energy"
       },
       "circuit_power": {
         "name": "Circuit Power {index}"


### PR DESCRIPTION
This PR adds energy sensors to smart meter that we forgot to add earlier. Even though these sensors have `today` in their field name, they actually represent usage over lifetime - not sure if it's a bug, but this is how it is presented in the app.

PR also disables sensors for phases by default as it depends on installation. It is possible to determine number of phases using field active, but disabling them is the most straightforward solution.

Includes changes from #156, merge that one first.