### PR TITLE
Fix Delta 2 and Delta 3 1500 not applying xor for payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,12 @@ first charging task</sup>
 
 This integration is available in the default HACS repository.
 
+**Quick Install:** Click the badge below to open this repository directly in HACS:
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=rabits&repository=ha-ef-ble&category=integration)
+
+**Manual steps:**
+
 1. Open **HACS** in your Home Assistant instance
 2. Go to **Integrations**
 3. Click the **⋮** menu (three dots) in the top right

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -187,6 +187,7 @@ class DeviceBase(abc.ABC):
 
             self._conn.on_disconnect(self._on_disconnect)
             self._conn.on_packet_data_received(self._on_packet_received)
+            self._conn.on_packet_parsed(self._on_packet_parsed)
             self._conn.on_state_change(self._on_connection_state_change)
 
         elif self._conn._user_id != user_id:

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -2,6 +2,7 @@ from ..model import (
     Mr330MpptHeart,
     Mr330PdHeartDelta2,
 )
+from ..packet import Packet
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ._delta2_base import Delta2Base
 
@@ -20,6 +21,9 @@ class Device(Delta2Base):
     energy_backup_battery_level = raw_field(pb_pd.bp_power_soc)
     dc_output_power = raw_field(pb_pd.dc_pv_output_watts)
     ac_charging_speed = raw_field(pb_mppt.cfg_chg_watts)
+
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, use_xor=True)
 
     @property
     def pd_heart_type(self):

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -87,7 +87,7 @@ class Packet:
         return self._product_id
 
     @staticmethod
-    def fromBytes(data: bytes):
+    def fromBytes(data: bytes, use_xor: bool = False):
         """Deserializes bytes stream into internal data"""
         if not data.startswith(Packet.PREFIX):
             error_msg = "Unable to parse packet - prefix is incorrect: %s"
@@ -137,7 +137,7 @@ class Packet:
         if payload_length > 0:
             payload = data[payload_start : payload_start + payload_length]
 
-            if version == 0x13:
+            if version == 0x13 or use_xor:
                 # If first byte of seq is set - we need to xor payload with it to get
                 # the real data
                 if seq[0] != b"\x00":


### PR DESCRIPTION
Our previous assessment about v19 packets in #156 was wrong, it seems that v2 packets sometimes do need to xor as well. There's probably some different indicator on whether to xor on v2 devices - this PR brings that flag back for now.

PR also adds quick link for adding this repo to HACS.

Resolves #170 