### PR TITLE
Revert packet xor change due to inconsistency

### DIFF
--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -118,6 +118,9 @@ class Delta3Base(DeviceBase, ProtobufProps):
         self._time_commands = TimeCommands(self)
         self.max_ac_charging_power = 1500
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     @classmethod
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX

--- a/custom_components/ef_ble/eflib/devices/alternator_charger.py
+++ b/custom_components/ef_ble/eflib/devices/alternator_charger.py
@@ -99,6 +99,9 @@ class Device(DeviceBase, ProtobufProps):
 
         return f"Alternator Charger {model}".strip()
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet):
         processed = False
 

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -23,7 +23,7 @@ class Device(Delta2Base):
     ac_charging_speed = raw_field(pb_mppt.cfg_chg_watts)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, use_xor=True)
+        return Packet.fromBytes(data, xor_payload=True)
 
     @property
     def pd_heart_type(self):

--- a/custom_components/ef_ble/eflib/devices/delta3_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_plus.py
@@ -1,7 +1,6 @@
 from functools import partialmethod
 
-from custom_components.ef_ble.eflib.pb import pd335_sys_pb2
-
+from ..pb import pd335_sys_pb2
 from ..props import Field, pb_field
 from . import delta3
 from ._delta3_base import DCPortState, _DcAmpSettingField, _DcChargingMaxField, pb

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -95,6 +95,9 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -65,6 +65,9 @@ class Device(DeviceBase, ProtobufProps):
         super().__init__(ble_dev, adv_data, sn)
         self._time_commands = TimeCommands(self)
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet) -> bool:
         """Process the incoming notifications from the device"""
 

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -56,7 +56,7 @@ class Device(DeviceBase, ProtobufProps):
 
     battery_level = pb_field(pb.cms_batt_soc)
 
-    ac_input_power = pb_field(pb.pow_get_ac_in)
+    ac_input_power = pb_field(pb.pow_get_ac_in, lambda x: round(x, 2))
     ac_input_energy = _StatField(pr705_pb2.STATISTICS_OBJECT_AC_IN_ENERGY)
 
     ac_output_power = pb_field(pb.pow_get_ac_out, _out_power)
@@ -125,6 +125,9 @@ class Device(DeviceBase, ProtobufProps):
             case "R655":
                 model = "UPS (245Wh)"
         return f"River 3 {model}".strip()
+
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False

--- a/custom_components/ef_ble/eflib/devices/smart_generator.py
+++ b/custom_components/ef_ble/eflib/devices/smart_generator.py
@@ -122,6 +122,9 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn.startswith(cls.SN_PREFIX)
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/smart_meter.py
+++ b/custom_components/ef_ble/eflib/devices/smart_meter.py
@@ -54,6 +54,9 @@ class Device(DeviceBase, ProtobufProps):
     l3_voltage = pb_field(pb.grid_connection_vol_L3, _round2)
     l3_grid_energy = pb_field(pb.grid_connection_data_record.today_active_L3)
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -147,6 +147,9 @@ class Device(DeviceBase, ProtobufProps):
 
         return None
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     @classmethod
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX

--- a/custom_components/ef_ble/eflib/devices/stream_microinverter.py
+++ b/custom_components/ef_ble/eflib/devices/stream_microinverter.py
@@ -41,6 +41,9 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -97,6 +97,9 @@ class Device(DeviceBase, RawDataProps):
     def check(cls, sn):
         return sn.startswith(cls.SN_PREFIX)
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet) -> bool:
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -96,6 +96,9 @@ class Device(DeviceBase, ProtobufProps):
     def check(cls, sn):
         return sn[:4] in cls.SN_PREFIX
 
+    async def packet_parse(self, data: bytes):
+        return Packet.fromBytes(data, xor_payload=True)
+
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()

--- a/custom_components/ef_ble/eflib/model/kit_info.py
+++ b/custom_components/ef_ble/eflib/model/kit_info.py
@@ -13,7 +13,7 @@ class KitBaseInfo(RawData):
     app_version: Annotated[int, "I", "appVersion"]
     loader_version: Annotated[int, "I", "loaderVersion"]
     cur_real_power: Annotated[int, "I", "curRealPower"]
-    f32_soc: Annotated[int, "I", "f32Soc"]
+    f32_soc: Annotated[int, "f", "f32Soc"]
     soc: Annotated[int, "B", "soc"]
 
 

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -87,7 +87,7 @@ class Packet:
         return self._product_id
 
     @staticmethod
-    def fromBytes(data: bytes, use_xor: bool = False):
+    def fromBytes(data: bytes, xor_payload: bool = False):
         """Deserializes bytes stream into internal data"""
         if not data.startswith(Packet.PREFIX):
             error_msg = "Unable to parse packet - prefix is incorrect: %s"
@@ -137,14 +137,13 @@ class Packet:
         if payload_length > 0:
             payload = data[payload_start : payload_start + payload_length]
 
-            if version == 0x13 or use_xor:
-                # If first byte of seq is set - we need to xor payload with it to get
-                # the real data
-                if seq[0] != b"\x00":
-                    payload = bytes([c ^ seq[0] for c in payload])
+            # If first byte of seq is set - we need to xor payload with it to get the
+            # real data
+            if xor_payload and seq[0] != b"\x00":
+                payload = bytes([c ^ seq[0] for c in payload])
 
-                if payload[-2:] == b"\xbb\xbb":
-                    payload = payload[:-2]
+            if version == 0x13 and payload[-2:] == b"\xbb\xbb":
+                payload = payload[:-2]
 
         return Packet(
             src=src,


### PR DESCRIPTION
Unfortunately, I was wrong about gen 3 v19 packets as well, SHP2 is an exception that does not xor payloads which I completely missed. This PR reverts the xor change and goes back to per device configuration. I'll add some tests for this later so it does not happen in the future.

Resolves #172 