### PR TITLE
Add power for individual AC ports and usb C (3) power to D3M+

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,3 +1,4 @@
+name: "Python Tests"
 on:
   push:
     branches: [main]

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ Click on any device below to see available sensors, switches, and controls:
 | *Sensors*                       | *Switches*                      | *Sliders*                  |
 |---------------------------------|---------------------------------|----------------------------|
 | Main Battery Level              | AC Ports                        | Backup Reserve Level ²     |
-| Battery Level                   | DC Ports ²                      | Max Charge Limit           |
-| AC Input Power                  | Backup Reserve ²                | Min Discharge Limit        |
-| AC Output Power                 | USB Ports ¹²                    | AC Charging Speed          |
-| DC 12V Port Output Power ²      | Disable Grid Bypass ²(disabled) | DC Charging Max Amps       |
-| DC Port Input Power             |                                 | DC (2) Charging Max Amps ⁺ |
+| Battery Level                   | AC Ports (2) ³                  | Max Charge Limit           |
+| AC Input Power                  | DC Ports ²                      | Min Discharge Limit        |
+| AC Output Power                 | Backup Reserve ²                | AC Charging Speed          |
+| AC (1) Power ³                  | USB Ports ¹²                    | DC Charging Max Amps       |
+| AC (2) Power ³                  | Disable Grid Bypass ²(disabled) | DC (2) Charging Max Amps ⁺ |
+| DC 12V Port Output Power ²      |                                 |                            |
+| DC Port Input Power             |                                 |                            |
 | DC Port Input State             |                                 |                            |
 | DC Port (2) Input Power ⁺       |                                 |                            |
 | DC Port (2) Input State ⁺       |                                 |                            |
@@ -150,6 +152,7 @@ Click on any device below to see available sensors, switches, and controls:
 | USB A (2) Output Power          |                                 |                            |
 | USB C Output Power              |                                 |                            |
 | USB C (2) Output Power          |                                 |                            |
+| USB C (3) Output Power ³        |                                 |                            |
 | AC Plugged In                   |                                 |                            |
 | Battery Input Power (disabled)  |                                 |                            |
 | Battery Output Power (disabled) |                                 |                            |
@@ -157,7 +160,8 @@ Click on any device below to see available sensors, switches, and controls:
 
 <sup>⁺ Only available on Plus variant</sup><br>
 <sup>¹ Not available on Classic</sup><br>
-<sup>² Not available on Air</sup>
+<sup>² Not available on Air</sup><br>
+<sup>³ Only available on Max Plus</sup>
 
 > **📝 Note:** Delta 3 models do not expose energy sensors. To use with the Energy
 > dashboard, you must create them yourself. See the

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -508,6 +508,12 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    "usbc3_output_power": SensorEntityDescription(
+        key="usbc2_output_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
     "usba2_output_power": SensorEntityDescription(
         key="usba2_output_power",
         native_unit_of_measurement=UnitOfPower.WATT,

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -390,6 +390,9 @@
       "usbc2_output_power": {
         "name": "USB C (2) Output Power"
       },
+      "usbc3_output_power": {
+        "name": "USB C (3) Output Power"
+      },
       "usbc2_output_energy": {
         "name": "USB C (2) Output Energy"
       },


### PR DESCRIPTION
This PR adds new sensors that are only available for Delta 3 Max Plus - Power for AC Ports 1, 2 and a third USB C port.

Continuation of #176 