### PR TITLE
Use serial number for entity unique id instead of name due to possible conflicts

### DIFF
--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -146,7 +146,7 @@ class EcoflowBinarySensor(EcoflowEntity, BinarySensorEntity):
     ):
         super().__init__(device)
 
-        self._attr_unique_id = f"{self._device.name}_{sensor}"
+        self._attr_unique_id = f"ef_{self._device.serial_number}_{sensor}"
         if sensor in BINARY_SENSOR_TYPES:
             self.entity_description = BINARY_SENSOR_TYPES[sensor]
             self._prop_name = self.entity_description.key

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -82,7 +82,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
     """EcoFlow BLE ConfigFlow"""
 
     VERSION = 1
-    MINOR_VERSION = 0
+    MINOR_VERSION = 1
 
     CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
 

--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -29,7 +29,7 @@ class EcoflowEntity(Entity):
             name=self._device.name,
             manufacturer=MANUFACTURER,
             model=self._device.device,
-            serial_number=self._device._sn,
+            serial_number=self._device.serial_number,
         )
 
     @property

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -310,7 +310,7 @@ class EcoflowNumber(EcoflowEntity, NumberEntity):
         entity_description: EcoflowNumberEntityDescription[DeviceBase],
     ):
         super().__init__(device)
-        self._attr_unique_id = f"{device.name}_{entity_description.key}"
+        self._attr_unique_id = f"ef_{device.serial_number}_{entity_description.key}"
         self.entity_description = entity_description
         self._min_value_prop = entity_description.min_value_prop
         self._max_value_prop = entity_description.max_value_prop

--- a/custom_components/ef_ble/select.py
+++ b/custom_components/ef_ble/select.py
@@ -167,7 +167,7 @@ class EcoflowSelect(EcoflowEntity, SelectEntity):
     ):
         super().__init__(device)
 
-        self._attr_unique_id = f"{self._device.name}_{description.key}"
+        self._attr_unique_id = f"ef_{self._device.serial_number}_{description.key}"
         self.entity_description = description
         self._prop_name = self.entity_description.key
         self._set_state = description.set_state

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -1047,7 +1047,7 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
         super().__init__(device)
 
         self._sensor = sensor
-        self._attr_unique_id = f"{device.name}_{sensor}"
+        self._attr_unique_id = f"ef_{device.serial_number}_{sensor}"
 
         if sensor in SENSOR_TYPES:
             self.entity_description = SENSOR_TYPES[sensor]

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -151,7 +151,7 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
     ) -> None:
         super().__init__(device)
 
-        self._attr_unique_id = f"{device.name}_{entity_description.key}"
+        self._attr_unique_id = f"ef_{device.serial_number}_{entity_description.key}"
         self._prop_name = entity_description.key
         self._method_name = f"enable_{self._prop_name}"
         self.entity_description = entity_description


### PR DESCRIPTION
This PR changes the way we determine unique ids for all entities to serial numbers. Names are not greate because they can cause collisions as shown in #194. 

Resolves #194 