### PR TITLE
Add DC input sensors to Delta 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,9 @@ be manually reconfigured if battery is connected/disconnected.</sup>
 | DC Output Power                           |                |                     |
 | DC 12V Output Voltage (disabled)          |                |                     |
 | DC 12V Output Current (disabled)          |                |                     |
+| XT60 Input Power ¹                        |                |                     |
+| DC Input Voltage (disabled)               |                |                     |
+| DC Input Current (disabled)               |                |                     |
 | USB A (1) Output Power                    |                |                     |
 | USB A (2) Output Power                    |                |                     |
 | USB A QC (1) Output Power                 |                |                     |
@@ -454,6 +457,8 @@ be manually reconfigured if battery is connected/disconnected.</sup>
 
 > **📝 Note:** Extra batteries are only updated when you set up the device, but has to
 > be manually reconfigured if battery is connected/disconnected.
+
+<sup>¹ Only available on Delta 2 and Delta 2 1500</sup><br>
 
 </details>
 

--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -55,13 +55,6 @@ class Delta2Base(DeviceBase, RawDataProps):
 
     battery_level = raw_field(pb_ems.f32_lcd_show_soc, lambda x: round(x, 2))
 
-    master_design_cap = raw_field(pb_bms.design_cap)
-    master_remain_cap = raw_field(pb_bms.remain_cap)
-    master_full_cap = raw_field(pb_bms.full_cap)
-    slave_design_cap = raw_field(pb_bms_1.design_cap)
-    slave_remain_cap = raw_field(pb_bms_1.remain_cap)
-    slave_full_cap = raw_field(pb_bms_1.full_cap)
-
     input_power = raw_field(pb_pd.watts_in_sum)
     output_power = raw_field(pb_pd.watts_out_sum)
 
@@ -82,6 +75,9 @@ class Delta2Base(DeviceBase, RawDataProps):
     remaining_time_discharging = raw_field(pb_ems.dsg_remain_time)
 
     cell_temperature = raw_field(pb_bms.max_cell_temp)
+
+    dc_input_voltage = raw_field(pb_mppt.in_vol, lambda x: round(x / 1000, 2))
+    dc_input_current = raw_field(pb_mppt.in_amp, lambda x: round(x / 1000, 2))
 
     dc_12v_port = raw_field(pb_pd.car_state, lambda x: x == 1)
     dc12v_output_voltage = raw_field(pb_mppt.car_out_vol, lambda x: round(x / 1000, 2))

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -22,6 +22,8 @@ class Device(Delta2Base):
     dc_output_power = raw_field(pb_pd.dc_pv_output_watts)
     ac_charging_speed = raw_field(pb_mppt.cfg_chg_watts)
 
+    xt60_input_power = raw_field(pb_pd.dc_pv_input_watts)
+
     async def packet_parse(self, data: bytes):
         return Packet.fromBytes(data, xor_payload=True)
 

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -943,6 +943,28 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
     ),
+    "dc_input_voltage": SensorEntityDescription(
+        key="dc_input_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+    ),
+    "dc_input_current": SensorEntityDescription(
+        key="dc_input_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+    ),
+    "xt60_input_power": SensorEntityDescription(
+        key="xt60_input_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
     # Wave 2
     "outlet_temperature": SensorEntityDescription(
         key="outlet_temperature",

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -726,6 +726,15 @@
       },
       "pv_power_sum": {
         "name": "PV Power Total"
+      },
+      "xt60_input_power": {
+        "name": "XT60 Input Power"
+      },
+      "dc_input_voltage": {
+        "name": "DC Input Voltage"
+      },
+      "dc_input_current": {
+        "name": "DC Input Current"
       }
     },
     "select": {

--- a/tests/eflib/test_delta2_max.py
+++ b/tests/eflib/test_delta2_max.py
@@ -206,6 +206,8 @@ async def test_delta2_max_exact_values_from_known_packets(device, packet_sequenc
         Device.ac_charging_speed: 300,
         Device.remaining_time_charging: 5999,
         Device.remaining_time_discharging: 5601,
+        Device.dc_input_voltage: 0.0,
+        Device.dc_input_current: 0.0,
     }
 
     for field_name, expected_value in expected.items():

--- a/tests/eflib/test_delta2_plus.py
+++ b/tests/eflib/test_delta2_plus.py
@@ -233,6 +233,9 @@ async def test_delta2_plus_exact_values_from_known_packets(device, packet_sequen
         Device.max_ac_charging_power: 1500,
         Device.remaining_time_charging: 5939,
         Device.remaining_time_discharging: 5939,
+        Device.dc_input_voltage: 1.5,
+        Device.dc_input_current: 0.0,
+        Device.xt60_input_power: 0,
     }
 
     for field_name, expected_value in expected.items():


### PR DESCRIPTION
This PR adds XT60 input power sensor as requested in #213 and DC input voltage and current sensors to Delta 2.

Resolves #213 