### PR TITLE
Fix River 2 using incorrect message causing energy backup switch and slider to not work

### DIFF
--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -340,7 +340,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=(
                 schema_builder()
-                .user_id(reconfigure_entry.data.get(CONF_USER_ID))
+                .user_id(reconfigure_entry.data.get(CONF_USER_ID, ""))
                 .extra_battery(reconfigure_entry.data.get(CONF_EXTRA_BATTERY), device)
                 .build()
             ),
@@ -648,7 +648,11 @@ class _SchemaBuilder:
 
     def user_id(self, user_id: str, required: bool = False):
         marker = vol.Required if required else vol.Optional
-        user_id = cast("str", vol.UNDEFINED) if not user_id.strip() else user_id
+        user_id = (
+            cast("str", vol.UNDEFINED)
+            if user_id is None or not user_id.strip()
+            else user_id
+        )
 
         return self.update({marker(CONF_USER_ID, default=user_id): str})
 
@@ -712,7 +716,9 @@ class _SchemaBuilder:
 
         return self.update({vol.Optional(key, default=default): selector})
 
-    def extra_battery(self, extra_battery_conf: list[str], device: eflib.DeviceBase):
+    def extra_battery(
+        self, extra_battery_conf: list[str] | None, device: eflib.DeviceBase
+    ):
         available_battery_slots = (
             [i for i in range(1, 6) if hasattr(device, f"battery_{i}_battery_level")]
             if device is not None

--- a/custom_components/ef_ble/eflib/devices/delta_pro.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro.py
@@ -11,14 +11,14 @@ from ..model import (
     DirectEmsDeltaHeartbeatPack,
     DirectInvDeltaHeartbeatPack,
     DirectMpptHeartbeatPack,
-    DirectPdDeltaProHeartbeatPack,
+    DirectPdHeartbeatPack,
 )
 from ..packet import Packet
 from ..props import Field
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ..props.raw_data_props import RawDataProps
 
-rd_pd = dataclass_attr_mapper(DirectPdDeltaProHeartbeatPack)
+rd_pd = dataclass_attr_mapper(DirectPdHeartbeatPack)
 rd_bms = dataclass_attr_mapper(DirectBmsMDeltaHeartbeatPack)
 rd_ems = dataclass_attr_mapper(DirectEmsDeltaHeartbeatPack)
 rd_inv = dataclass_attr_mapper(DirectInvDeltaHeartbeatPack)
@@ -147,7 +147,7 @@ class Device(DeviceBase, RawDataProps):
                     async with self._lock:
                         self._dormant = False
             case 0x02, 0x20, 0x02:
-                self.update_from_bytes(DirectPdDeltaProHeartbeatPack, packet.payload)
+                self.update_from_bytes(DirectPdHeartbeatPack, packet.payload)
             case 0x03, 0x20, 0x32:
                 self.update_from_bytes(DirectBmsMDeltaHeartbeatPack, packet.payload)
             case 0x03, 0x20, 0x02:

--- a/custom_components/ef_ble/eflib/devices/river2.py
+++ b/custom_components/ef_ble/eflib/devices/river2.py
@@ -6,8 +6,8 @@ from ..model import (
     DirectBmsMDeltaHeartbeatPack,
     DirectEmsDeltaHeartbeatPack,
     DirectInvDeltaHeartbeatPack,
+    DirectPdHeartbeatPack,
     Mr330MpptHeart,
-    Mr330PdHeartRiver2,
 )
 from ..packet import Packet
 from ..props import Field
@@ -15,7 +15,7 @@ from ..props.enums import IntFieldValue
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ..props.raw_data_props import RawDataProps
 
-pb_pd = dataclass_attr_mapper(Mr330PdHeartRiver2)
+pb_pd = dataclass_attr_mapper(DirectPdHeartbeatPack)
 pb_mppt = dataclass_attr_mapper(Mr330MpptHeart)
 pb_ems = dataclass_attr_mapper(DirectEmsDeltaHeartbeatPack)
 pb_bms = dataclass_attr_mapper(DirectBmsMDeltaHeartbeatPack)
@@ -41,8 +41,8 @@ class Device(DeviceBase, RawDataProps):
     dc12v_output_power = raw_field(pb_pd.car_watts)
     ac_xboost = raw_field(pb_mppt.cfg_ac_xboost, lambda x: x == 1)
 
-    energy_backup = raw_field(pb_pd.watthis_config, lambda x: x == 1)
-    energy_backup_battery_level = raw_field(pb_pd.bp_power_soc)
+    energy_backup = raw_field(pb_pd.watth_is_config, lambda x: x == 1)
+    energy_backup_battery_level = raw_field(pb_pd.backup_soc)
 
     battery_charge_limit_min = raw_field(pb_ems.min_dsg_soc)
     battery_charge_limit_max = raw_field(pb_ems.max_charge_soc)
@@ -65,7 +65,7 @@ class Device(DeviceBase, RawDataProps):
     car_input_power = Field[int]()
 
     usbc_output_power = raw_field(pb_pd.typec1_watts)
-    usba_output_power = raw_field(pb_pd.usb1_watt)
+    usba_output_power = raw_field(pb_pd.usb1_watts)
 
     dc_charging_max_amps = raw_field(pb_mppt.cfg_dc_chg_current, lambda x: x / 1000)
     dc_charging_current_max = Field[int]()
@@ -107,7 +107,7 @@ class Device(DeviceBase, RawDataProps):
 
         match (packet.src, packet.cmdSet, packet.cmdId):
             case 0x02, 0x20, 0x02:
-                self.update_from_bytes(Mr330PdHeartRiver2, packet.payload)
+                self.update_from_bytes(DirectPdHeartbeatPack, packet.payload)
                 processed = True
 
             case 0x03, 0x20, 0x02:

--- a/custom_components/ef_ble/eflib/devices/river2_pro.py
+++ b/custom_components/ef_ble/eflib/devices/river2_pro.py
@@ -7,4 +7,4 @@ pb_mppt = river2.pb_mppt
 class Device(river2.Device):
     """River 2 Pro"""
 
-    SN_PREFIX = (b"R621", "R623")
+    SN_PREFIX = (b"R621", b"R623")

--- a/custom_components/ef_ble/eflib/model/__init__.py
+++ b/custom_components/ef_ble/eflib/model/__init__.py
@@ -10,7 +10,7 @@ from .direct_inv_heartbeat_pack import (
 )
 from .direct_mppt_heartbeat_pack import DirectMpptHeartbeatPack
 from .direct_pd_heartbeat_pack import (
-    DirectPdDeltaProHeartbeatPack,
+    DirectPdHeartbeatPack,
 )
 from .kit_info import AllKitDetailData
 from .mppt_heart import BaseMpptHeart, Mr330MpptHeart, Mr350MpptHeart
@@ -18,7 +18,6 @@ from .pd_heart import (
     BasePdHeart,
     Mr330PdHeart,
     Mr330PdHeartDelta2,
-    Mr330PdHeartRiver2,
     Mr350PdHeartbeatDelta2Max,
 )
 
@@ -34,11 +33,10 @@ __all__ = [
     "DirectInvRiverHeartbeatPack",
     "DirectInvRiverMiniHeartbeatPack",
     "DirectMpptHeartbeatPack",
-    "DirectPdDeltaProHeartbeatPack",
+    "DirectPdHeartbeatPack",
     "Mr330MpptHeart",
     "Mr330PdHeart",
     "Mr330PdHeartDelta2",
-    "Mr330PdHeartRiver2",
     "Mr350MpptHeart",
     "Mr350PdHeartbeatDelta2Max",
     "RawData",

--- a/custom_components/ef_ble/eflib/model/direct_pd_heartbeat_pack.py
+++ b/custom_components/ef_ble/eflib/model/direct_pd_heartbeat_pack.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from . import RawData
 
 
-class DirectPdDeltaProHeartbeatPack(RawData):
+class DirectPdHeartbeatPack(RawData):
     model: Annotated[int, "B", "model"]
     err_code: Annotated[bytes, "4s", "errCode"]
     sys_ver: Annotated[bytes, "4s", "sysVer"]

--- a/custom_components/ef_ble/eflib/model/pd_heart.py
+++ b/custom_components/ef_ble/eflib/model/pd_heart.py
@@ -88,16 +88,6 @@ class Mr330PdHeartDelta2(Mr330PdHeart):
     redun_charge_flag: Annotated[int, "B", "redunChargeFlag"]
 
 
-class Mr330PdHeartRiver2(Mr330PdHeart):
-    ac_auto_out_config: Annotated[int, "B", "acAutoOutConfig"]
-    min_auto_soc: Annotated[int, "H", "minAutoSoc"]
-    ac_auto_out_pause: Annotated[int, "H", "acAutoOutPause"]
-    watthis_config: Annotated[int, "B", "watthisConfig"]
-    bp_power_soc: Annotated[int, "B", "bppowerSoc"]
-    hysteresis_soc: Annotated[int, "B", "hysteresisSoc"]
-    reply_switchcnt: Annotated[int, "I", "replySwitchcnt"]
-
-
 class Mr350PdHeartbeatCore(BasePdHeart):
     bms_kit_state: Annotated[int, "H", "bmsKitState"]
     other_kit_state: Annotated[int, "B", "otherKitState"]


### PR DESCRIPTION
This PR changes the type of pd heart messages that River 2 used for parsing - we were using Mr330PdHeart, but it turns out that DirectPdHeartbeatPack has almost the same structure with the exception of some fields at the end so it did work for most of the fields. This fixes battery backup sensors as those were at the back of the message and were parsed from different locations.

There is also a small fix for reconfigure user id that could be None causing config flow to crash at edge cases.