### PR TITLE
Fix crash caused by improper handling of enums in sensor registry code

### DIFF
--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, EnumType
 from typing import Any, Final, TypedDict, Unpack
 
 from homeassistant.components.sensor import (
@@ -274,7 +274,7 @@ def enum(
     name: str | None = None,
     **kwargs: Unpack[_SensorKwargs],
 ) -> EcoflowSensorEntityDescription:
-    if options and type(options) is type and issubclass(options, IntFieldValue):
+    if type(options) is EnumType and issubclass(options, IntFieldValue):
         options = options.options()
 
     return EcoflowSensorEntityDescription(


### PR DESCRIPTION
This PR fixes an error with enums introduced in #222  that caused crash for devices that used enum sensors.