### PR TITLE
Fix auth issue that left connection open

### DIFF
--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -876,10 +876,14 @@ class Connection:
         await self._client.stop_notify(self._notify_characteristic)
 
         if encrypted_data[0] != 0x02:
-            raise AuthErrors.KeyInfoReqFailed(
+            exc = AuthErrors.KeyInfoReqFailed(
                 "Received type of KeyInfo is != 0x02, need to dig into: "
                 f"{encrypted_data.hex()}"
             )
+            self._set_state(ConnectionState.ERROR_AUTH_FAILED, exc)
+            if self._client is not None and self._client.is_connected:
+                await self._client.disconnect()
+            raise exc
 
         assert self._encryption is not None
 


### PR DESCRIPTION
My River 2 Plus would get stuck at "initializing" if the auth error was raised, then the client would get stuck with an open connection and wait for the 5 min timeout. This cleanly disconnects and tries again. The connection is now stable -- it's been working great for a few weeks now.

Disclaimer: The change was suggested by Claude Code (Opus), but tested and verified by me (a human).