### PR TITLE
Fix Wave 3 power switch not working

### DIFF
--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -152,11 +152,9 @@ class Device(DeviceBase, ProtobufProps):
         return True
 
     async def enable_power(self, enabled: bool):
+        cfg = ac517_apl_comm_pb2.ConfigWrite()
         if enabled:
-            await self._send_config_packet(
-                ac517_apl_comm_pb2.ConfigWrite(cfg_power_on=True)
-            )
+            cfg.cfg_power_on = True
         else:
-            await self._send_config_packet(
-                ac517_apl_comm_pb2.ConfigWrite(cfg_power_off=True)
-            )
+            cfg.cfg_power_off = True
+        await self._send_config_packet(cfg)


### PR DESCRIPTION
Two issues prevented the Wave 3 power on/off switch from functioning:

1. Config packets were sent to wrong destination address (0x14 instead of 0x42). The Wave 3 receives data from src=0x42, so config packets must target dst=0x42, matching the pattern used by all other protobuf-based devices.

2. enable_power() used cfg_sys_pause=False to turn on, but in proto3 the default value for bool (false) is not serialized, resulting in an empty message that the device ignores. Replaced with cfg_power_on=True / cfg_power_off=True which always serialize correctly.