### PR TITLE
Relax protobuf requirements

### DIFF
--- a/custom_components/ef_ble/manifest.json
+++ b/custom_components/ef_ble/manifest.json
@@ -200,7 +200,7 @@
         "ecdsa~=0.19",
         "crc~=7.1",
         "PyCryptodome~=3.23",
-        "protobuf~=6.33"
+        "protobuf~=6.30"
     ],
 
     "version": "0.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "ecdsa~=0.19",
     "crc~=7.1",
     "PyCryptodome~=3.23",
-    "protobuf~=6.33",
+    "protobuf~=6.30",
     "bleak",
     "bleak_retry_connector",
 


### PR DESCRIPTION
This PR lowers the limit for protobuf requirement to `~=6.30`, we didn't notice that [HA package requirements](https://github.com/home-assistant/core/blob/86d80c96d732036f085e15679c25acfebbaa15a3/homeassistant/package_constraints.txt#L152) do have a strict pin of  `==6.32.0` making conflicts.