### PR TITLE
Move Delta 2 to controls system, add grid bypass switch to Delta 2 and Delta 3 1500

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,37 +546,37 @@ first charging task</sup>
 
 <br>
 
-| *Sensors*                           | *Switches*     | *Sliders*           |
-|-------------------------------------|----------------|---------------------|
-| Battery Level                       | AC Ports       | Max Charge Limit    |
-| Main Battery Level                  | DC 12V Port    | Min Discharge Limit |
-| Extra Battery Level ³               | USB Ports      | Energy Backup       |
-| Extra Battery Temperature ³         | Backup Reserve | AC Charging Speed   |
-| Input Power                         |                |                     |
-| Output Power                        |                |                     |
-| AC Input Power                      |                |                     |
-| AC Input Voltage (disabled)         |                |                     |
-| AC Input Current (disabled)         |                |                     |
-| AC Output Power                     |                |                     |
-| DC Output Power                     |                |                     |
-| DC 12V Output Voltage (disabled)    |                |                     |
-| DC 12V Output Current (disabled)    |                |                     |
-| XT60 Input Power ¹                  |                |                     |
-| XT60 (1) Input Power ²              |                |                     |
-| XT60 (2) Input Power ²              |                |                     |
-| DC Input Voltage (disabled)         |                |                     |
-| DC Input Current (disabled)         |                |                     |
-| USB A (1) Output Power              |                |                     |
-| USB A (2) Output Power              |                |                     |
-| USB A QC (1) Output Power           |                |                     |
-| USB A QC (2) Output Power           |                |                     |
-| USB C (1) Output Power              |                |                     |
-| USB C (2) Output Power              |                |                     |
-| Cell Temperature (disabled)         |                |                     |
-| Charge Time Remaining (disabled)    |                |                     |
-| Discharge Time Remaining (disabled) |                |                     |
+| *Sensors*                           | *Switches*                       | *Sliders*           |
+|-------------------------------------|----------------------------------|---------------------|
+| Battery Level                       | AC Ports                         | Max Charge Limit    |
+| Main Battery Level                  | DC 12V Port                      | Min Discharge Limit |
+| Extra Battery Level ³               | USB Ports                        | Energy Backup       |
+| Extra Battery Temperature ³         | Backup Reserve                   | AC Charging Speed   |
+| Input Power                         | Disable Grid Bypass ¹ (disabled) |                     |
+| Output Power                        |                                  |                     |
+| AC Input Power                      |                                  |                     |
+| AC Input Voltage (disabled)         |                                  |                     |
+| AC Input Current (disabled)         |                                  |                     |
+| AC Output Power                     |                                  |                     |
+| DC Output Power                     |                                  |                     |
+| DC 12V Output Voltage (disabled)    |                                  |                     |
+| DC 12V Output Current (disabled)    |                                  |                     |
+| XT60 Input Power ¹                  |                                  |                     |
+| XT60 (1) Input Power ²              |                                  |                     |
+| XT60 (2) Input Power ²              |                                  |                     |
+| DC Input Voltage (disabled)         |                                  |                     |
+| DC Input Current (disabled)         |                                  |                     |
+| USB A (1) Output Power              |                                  |                     |
+| USB A (2) Output Power              |                                  |                     |
+| USB A QC (1) Output Power           |                                  |                     |
+| USB A QC (2) Output Power           |                                  |                     |
+| USB C (1) Output Power              |                                  |                     |
+| USB C (2) Output Power              |                                  |                     |
+| Cell Temperature (disabled)         |                                  |                     |
+| Charge Time Remaining (disabled)    |                                  |                     |
+| Discharge Time Remaining (disabled) |                                  |                     |
 
-<sup>¹ Only available on Delta 2 and Delta 2 1500</sup><br>
+<sup>¹ Only available on Delta 2 and Delta 3 1500</sup><br>
 <sup>² Only available on Delta 2 Max</sup><br>
 <sup>³ Per extra battery (up to 2)</sup>
 

--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -1,4 +1,6 @@
 from ..devicebase import DeviceBase
+from ..entity import controls
+from ..entity.base import dynamic
 from ..model import (
     AllKitDetailData,
     BaseMpptHeart,
@@ -160,52 +162,12 @@ class Delta2Base(DeviceBase, RawDataProps):
     def ac_commands_dst(self) -> int:
         return 0x05
 
-    async def set_ac_charging_speed(self, value: int):
-        if self.max_ac_charging_power is None:
-            return False
-
-        value = max(1, min(value, self.max_ac_charging_power))
-        # Sending 0 sets to (more than) max-load - better safe
-
-        payload = value.to_bytes(2, "little") + bytes([0xFF])
-
-        packet = Packet(
-            0x21,
-            self.ac_commands_dst,
-            0x20,
-            0x45,
-            payload,
-            version=0x02,
-        )
-        await self._conn.sendPacket(packet)
-        return True
-
-    async def enable_energy_backup(self, enabled: bool):
-        backup_level = getattr(self, "energy_backup_battery_level", 0)
-        if backup_level == 0 and enabled:
-            backup_level = 50
-
-        await self.set_energy_backup_battery_level(backup_level, enabled=enabled)
-
-    async def set_energy_backup_battery_level(self, value: int, enabled: bool = True):
-        if (
-            self.battery_charge_limit_min is None
-            or self.battery_charge_limit_max is None
-        ):
-            return
-
-        value = max(
-            self.battery_charge_limit_min,
-            min(value, self.battery_charge_limit_max),
-        )
-        payload = bytes([0x01 if enabled else 0, value, 0x00, 0x00])
-        packet = Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
-        await self._conn.sendPacket(packet)
-
+    @controls.switch(usb_ports)
     async def enable_usb_ports(self, enabled: bool):
         packet = Packet(0x21, 0x02, 0x20, 0x22, enabled.to_bytes(), version=0x02)
         await self._conn.sendPacket(packet)
 
+    @controls.switch(dc_12v_port)
     async def enable_dc_12v_port(self, enabled: bool):
         packet = Packet(
             0x21,
@@ -217,18 +179,33 @@ class Delta2Base(DeviceBase, RawDataProps):
         )
         await self._conn.sendPacket(packet)
 
+    @controls.outlet(ac_ports)
     async def enable_ac_ports(self, enabled: bool):
         payload = bytes([1 if enabled else 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
         packet = Packet(0x21, self.ac_commands_dst, 0x20, 0x42, payload, version=0x02)
         await self._conn.sendPacket(packet)
 
-    async def set_battery_charge_limit_max(self, limit: int):
-        packet = Packet(0x21, 0x03, 0x20, 0x31, limit.to_bytes(), version=0x02)
+    @controls.battery(battery_charge_limit_max, min=dynamic(battery_charge_limit_min))
+    async def set_battery_charge_limit_max(self, limit: float):
+        if (
+            self.battery_charge_limit_min is not None
+            and limit < self.battery_charge_limit_min
+        ):
+            return False
+        packet = Packet(0x21, 0x03, 0x20, 0x31, int(limit).to_bytes(), version=0x02)
         await self._conn.sendPacket(packet)
+        return True
 
-    async def set_battery_charge_limit_min(self, limit: int):
-        packet = Packet(0x21, 0x03, 0x20, 0x33, limit.to_bytes(), version=0x02)
+    @controls.battery(battery_charge_limit_min, max=dynamic(battery_charge_limit_max))
+    async def set_battery_charge_limit_min(self, limit: float):
+        if (
+            self.battery_charge_limit_max is not None
+            and limit > self.battery_charge_limit_max
+        ):
+            return False
+        packet = Packet(0x21, 0x03, 0x20, 0x33, int(limit).to_bytes(), version=0x02)
         await self._conn.sendPacket(packet)
+        return True
 
     def _update_extra_batteries(self, kit_data: AllKitDetailData):
         battery_entity_map = [

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -1,3 +1,5 @@
+from ..entity import controls
+from ..entity.base import dynamic
 from ..model import (
     Mr330MpptHeart,
     Mr330PdHeartDelta2,
@@ -21,6 +23,8 @@ class Device(Delta2Base):
     energy_backup_battery_level = raw_field(pb_pd.bp_power_soc)
     dc_output_power = raw_field(pb_pd.dc_pv_output_watts)
     ac_charging_speed = raw_field(pb_mppt.cfg_chg_watts)
+
+    disable_grid_bypass = raw_field(pb_pd.reverser, lambda x: ((x >> 8) & 0xFF) == 1)
 
     xt60_input_power = raw_field(pb_pd.dc_pv_input_watts)
 
@@ -48,3 +52,48 @@ class Device(Delta2Base):
             self.max_ac_charging_power = 1500
         else:
             self.max_ac_charging_power = 1200
+
+    @controls.switch(energy_backup)
+    async def enable_energy_backup(self, enabled: bool):
+        backup_level = self.energy_backup_battery_level or 50
+        await self._send_backup_packet(backup_level, enabled=enabled)
+
+    @controls.battery(
+        energy_backup_battery_level,
+        min=dynamic(Delta2Base.battery_charge_limit_min),
+        max=dynamic(Delta2Base.battery_charge_limit_max),
+        availability=energy_backup,
+    )
+    async def set_energy_backup_battery_level(self, value: float):
+        await self._send_backup_packet(int(value), enabled=True)
+        return True
+
+    async def _send_backup_packet(self, value: int, enabled: bool):
+        if (
+            self.battery_charge_limit_min is None
+            or self.battery_charge_limit_max is None
+        ):
+            return
+        value = max(
+            self.battery_charge_limit_min,
+            min(value, self.battery_charge_limit_max),
+        )
+        payload = bytes([0x01 if enabled else 0, value, 0x00, 0x00])
+        packet = Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
+        await self._conn.sendPacket(packet)
+
+    @controls.power(ac_charging_speed, max=dynamic(Delta2Base.max_ac_charging_power))
+    async def set_ac_charging_speed(self, value: float):
+        if self.max_ac_charging_power is None or value < 1:
+            return False
+        payload = int(value).to_bytes(2, "little") + bytes([0xFF])
+        packet = Packet(0x21, self.ac_commands_dst, 0x20, 0x45, payload, version=0x02)
+        await self._conn.sendPacket(packet)
+        return True
+
+    @controls.switch(disable_grid_bypass, enabled=False)
+    async def enable_disable_grid_bypass(self, disabled: bool):
+        packet = Packet(
+            0x21, 0x02, 0x20, 0x60, bytes([1 if disabled else 0]), version=0x02
+        )
+        await self._conn.sendPacket(packet)

--- a/custom_components/ef_ble/eflib/devices/delta2_max.py
+++ b/custom_components/ef_ble/eflib/devices/delta2_max.py
@@ -1,6 +1,8 @@
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
+from ..entity import controls
+from ..entity.base import dynamic
 from ..model import Mr350MpptHeart, Mr350PdHeartbeatDelta2Max
 from ..packet import Packet
 from ..props import dataclass_attr_mapper, raw_field
@@ -43,11 +45,41 @@ class Device(Delta2Base):
     def ac_commands_dst(self):
         return 0x04
 
-    async def set_ac_charging_speed(self, value: int):
-        if self.max_ac_charging_power is None:
+    @controls.switch(energy_backup)
+    async def enable_energy_backup(self, enabled: bool):
+        backup_level = self.energy_backup_battery_level or 50
+        await self._send_backup_packet(backup_level, enabled=enabled)
+
+    @controls.battery(
+        energy_backup_battery_level,
+        min=dynamic(Delta2Base.battery_charge_limit_min),
+        max=dynamic(Delta2Base.battery_charge_limit_max),
+        availability=energy_backup,
+    )
+    async def set_energy_backup_battery_level(self, value: float):
+        await self._send_backup_packet(int(value), enabled=True)
+        return True
+
+    async def _send_backup_packet(self, value: int, enabled: bool):
+        if (
+            self.battery_charge_limit_min is None
+            or self.battery_charge_limit_max is None
+        ):
+            return
+        value = max(
+            self.battery_charge_limit_min,
+            min(value, self.battery_charge_limit_max),
+        )
+        payload = bytes([0x01 if enabled else 0, value, 0x00, 0x00])
+        await self._conn.sendPacket(
+            Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
+        )
+
+    @controls.power(ac_charging_speed, max=dynamic(Delta2Base.max_ac_charging_power))
+    async def set_ac_charging_speed(self, value: float):
+        if self.max_ac_charging_power is None or value < 1:
             return False
-        value = max(1, min(value, self.max_ac_charging_power))
-        payload = bytes([0xFF, 0xFF]) + value.to_bytes(2, "little") + bytes([0xFF])
+        payload = bytes([0xFF, 0xFF]) + int(value).to_bytes(2, "little") + bytes([0xFF])
         await self._conn.sendPacket(
             Packet(0x20, 0x04, 0x20, 0x45, payload, version=0x02)
         )

--- a/custom_components/ef_ble/eflib/devices/delta3_classic.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_classic.py
@@ -47,7 +47,7 @@ class Device(Delta3Base):
     def _after_message_parsed(self):
         pass
 
-    @controls.switch(disable_grid_bypass)
+    @controls.switch(disable_grid_bypass, enabled=False)
     async def enable_disable_grid_bypass(self, enabled: bool):
         await self._send_config_packet(
             pd335_sys_pb2.ConfigWrite(cfg_bypass_out_disable=enabled)

--- a/custom_components/ef_ble/eflib/props/updatable_props.py
+++ b/custom_components/ef_ble/eflib/props/updatable_props.py
@@ -116,9 +116,9 @@ class Field[T]:
         self._set_value(instance, value)
 
     def _set_value(self, instance: UpdatableProps, value: Any):
-        if value == getattr(instance, self.public_name):
-            return
         if (value := self._transform_value(value)) is Skip:
+            return
+        if value == getattr(instance, self.public_name):
             return
         setattr(instance, self.private_name, value)
         instance.updated = True

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -236,6 +236,12 @@
           "off": "mdi:battery-sync-outline"
         }
       },
+      "ac_ports": {
+        "default": "mdi:power-plug",
+        "state": {
+          "off": "mdi:power-plug-off"
+        }
+      },
       "dc_12v_port": {
         "default": "mdi:power-plug",
         "state": {
@@ -249,7 +255,10 @@
         }
       },
       "disable_grid_bypass": {
-        "default": "mdi:transmission-tower-off"
+        "default": "mdi:transmission-tower-off",
+        "state": {
+          "off": "mdi:transmission-tower"
+        }
       },
       "energy_strategy_self_powered": {
         "default": "mdi:solar-power"


### PR DESCRIPTION
This PR migrates Delta 2 and Delta 2 Max devices to the `@controls` decorator system and adds disable grid bypass switch for Delta 2 and Delta 3 1500.