### PR TITLE
Migrate STREAM devices to controls system and improve task controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,27 +358,27 @@ Click on any device below to see available sensors, switches, and controls:
 
 <br>
 
-| *Sensors*                           | *Switches*           | *Sliders*                    | *Selects*       |
-|-------------------------------------|----------------------|------------------------------|-----------------|
-| Battery Level                       | Feed Grid            | Feed Grid Power Limit        | Energy Strategy |
-| Main Battery Level                  | AC (1) ᴬᴹᴾᵁ          | Backup Reserve Level         |                 |
-| Battery Power                       | AC (2) ᴬᴾᵁ           | Charge Limit                 |                 |
-| Grid Power                          | Charging Task ²      | Discharge Limit              |                 |
-| Grid Voltage                        | Discharging Task ³   | Base Load Power ¹            |                 |
-| Grid Frequency                      |                      | Grid Input Power Limit       |                 |
-| Load from Battery                   |                      | Charging Power Limit ²ꜝ      |                 |
-| Load from Grid                      |                      | Charging Target SOC ²ꜝ       |                 |
-| Load from PV ᴹᴾᵁ                    |                      | Discharging Power Limit ³ꜝ   |                 |
-| AC (1) Power ᴬᴹᴾᵁ                   |                      |                              |                 |
-| AC (2) Power ᴬᴾᵁ                    |                      |                              |                 |
-| PV (1) Power ᴹᴾᵁ                    |                      |                              |                 |
-| PV (2) Power ᴹᴾᵁ                    |                      |                              |                 |
-| PV (3) Power ᴾᵁ                     |                      |                              |                 |
-| PV (4) Power ᵁ                      |                      |                              |                 |
-| PV Power Total ᴹᴾᵁ                  |                      |                              |                 |
-| Cell Temperature (disabled)         |                      |                              |                 |
-| Charge Time Remaining (disabled)    |                      |                              |                 |
-| Discharge Time Remaining (disabled) |                      |                              |                 |
+| *Sensors*                           | *Switches*         | *Sliders*                 | *Selects*       |
+|-------------------------------------|--------------------|---------------------------|-----------------|
+| Battery Level                       | Feed Grid          | Feed Grid Power Limit     | Energy Strategy |
+| Main Battery Level                  | AC (1) ᴬᴹᴾᵁ        | Backup Reserve Level      |                 |
+| Battery Power                       | AC (2) ᴬᴾᵁ         | Charge Limit              |                 |
+| Grid Power                          | Charging Task ²    | Discharge Limit           |                 |
+| Grid Voltage                        | Discharging Task ³ | Base Load Power ¹         |                 |
+| Grid Frequency                      |                    | Grid Input Power Limit    |                 |
+| Load from Battery                   |                    | Charging Power Limit ²    |                 |
+| Load from Grid                      |                    | Charging Target SOC ²     |                 |
+| Load from PV ᴹᴾᵁ                    |                    | Discharging Power Limit ³ |                 |
+| AC (1) Power ᴬᴹᴾᵁ                   |                    |                           |                 |
+| AC (2) Power ᴬᴾᵁ                    |                    |                           |                 |
+| PV (1) Power ᴹᴾᵁ                    |                    |                           |                 |
+| PV (2) Power ᴹᴾᵁ                    |                    |                           |                 |
+| PV (3) Power ᴾᵁ                     |                    |                           |                 |
+| PV (4) Power ᵁ                      |                    |                           |                 |
+| PV Power Total ᴹᴾᵁ                  |                    |                           |                 |
+| Cell Temperature (disabled)         |                    |                           |                 |
+| Charge Time Remaining (disabled)    |                    |                           |                 |
+| Discharge Time Remaining (disabled) |                    |                           |                 |
 
 <sup>ᴬ Only available on AC Pro variant</sup><br>
 <sup>ᴹ Only available on Max variant</sup><br>

--- a/README.md
+++ b/README.md
@@ -358,39 +358,35 @@ Click on any device below to see available sensors, switches, and controls:
 
 <br>
 
-| *Sensors*                           | *Switches*  | *Sliders*               | *Selects*       |
-|-------------------------------------|-------------|-------------------------|-----------------|
-| Battery Level                       | Feed Grid   | Feed Grid Power Limit   | Energy Strategy |
-| Main Battery Level                  | AC (1) ᴬᴹᴾᵁ | Backup Reserve Level    |                 |
-| Battery Power                       | AC (2) ᴬᴾᵁ  | Charge Limit            |                 |
-| Grid Power                          |             | Discharge Limit         |                 |
-| Grid Voltage                        |             | Base Load Power ¹       |                 |
-| Grid Frequency                      |             | Grid Input Power Limit  |                 |
-| Load from Battery                   |             | Charging Power Limit ²ꜝ |                 |
-| Load from Grid                      |             | Charging Target SOC ²ꜝ  |                 |
-| Load from PV ᴹᴾᵁ                    |             |                         |                 |
-| AC (1) Power ᴬᴹᴾᵁ                   |             |                         |                 |
-| AC (2) Power ᴬᴾᵁ                    |             |                         |                 |
-| PV (1) Power ᴹᴾᵁ                    |             |                         |                 |
-| PV (2) Power ᴹᴾᵁ                    |             |                         |                 |
-| PV (3) Power ᴾᵁ                     |             |                         |                 |
-| PV (4) Power ᵁ                      |             |                         |                 |
-| PV Power Total ᴹᴾᵁ                  |             |                         |                 |
-| Cell Temperature (disabled)         |             |                         |                 |
-| Charge Time Remaining (disabled)    |             |                         |                 |
-| Discharge Time Remaining (disabled) |             |                         |                 |
+| *Sensors*                           | *Switches*           | *Sliders*                    | *Selects*       |
+|-------------------------------------|----------------------|------------------------------|-----------------|
+| Battery Level                       | Feed Grid            | Feed Grid Power Limit        | Energy Strategy |
+| Main Battery Level                  | AC (1) ᴬᴹᴾᵁ          | Backup Reserve Level         |                 |
+| Battery Power                       | AC (2) ᴬᴾᵁ           | Charge Limit                 |                 |
+| Grid Power                          | Charging Task ²      | Discharge Limit              |                 |
+| Grid Voltage                        | Discharging Task ³   | Base Load Power ¹            |                 |
+| Grid Frequency                      |                      | Grid Input Power Limit       |                 |
+| Load from Battery                   |                      | Charging Power Limit ²ꜝ      |                 |
+| Load from Grid                      |                      | Charging Target SOC ²ꜝ       |                 |
+| Load from PV ᴹᴾᵁ                    |                      | Discharging Power Limit ³ꜝ   |                 |
+| AC (1) Power ᴬᴹᴾᵁ                   |                      |                              |                 |
+| AC (2) Power ᴬᴾᵁ                    |                      |                              |                 |
+| PV (1) Power ᴹᴾᵁ                    |                      |                              |                 |
+| PV (2) Power ᴹᴾᵁ                    |                      |                              |                 |
+| PV (3) Power ᴾᵁ                     |                      |                              |                 |
+| PV (4) Power ᵁ                      |                      |                              |                 |
+| PV Power Total ᴹᴾᵁ                  |                      |                              |                 |
+| Cell Temperature (disabled)         |                      |                              |                 |
+| Charge Time Remaining (disabled)    |                      |                              |                 |
+| Discharge Time Remaining (disabled) |                      |                              |                 |
 
 <sup>ᴬ Only available on AC Pro variant</sup><br>
 <sup>ᴹ Only available on Max variant</sup><br>
 <sup>ᴾ Only available on Pro variant</sup><br>
 <sup>ᵁ Only available on Ultra and Ultra X variants</sup><br>
 <sup>¹ Not available when there's no base load timeframe or more than 1 timeframe configured</sup><br>
-<sup>² Only works if timer task with charging power limit is configured and only works for the
-first charging task</sup>
-
-> **❗ Important:** When changing limits or target SOC using automations, wait at least 1
-> second between each set, otherwise the last one will override all previous ones. This is
-> a current limitation that will be addressed in a future update.
+<sup>² Only available when a charging timer task is configured</sup><br>
+<sup>³ Only available when a discharging timer task is configured</sup>
 
 </details>
 

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -417,7 +417,7 @@ class Connection:
         if self._reconnect_task is not None:
             return
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         self._reconnect_task = self._add_task(self.reconnect(), loop)
 
         def _reconnect_done(task: asyncio.Task[None]):
@@ -1137,12 +1137,12 @@ class Connection:
             callback()
 
         if key is None:
-            asyncio.get_event_loop().call_later(delay, _call_if_connected)
+            asyncio.get_running_loop().call_later(delay, _call_if_connected)
             return
 
         if (h := self._call_later_handles.get(key)) is not None:
             h.cancel()
-        self._call_later_handles[key] = asyncio.get_event_loop().call_later(
+        self._call_later_handles[key] = asyncio.get_running_loop().call_later(
             delay, _call_if_connected
         )
 

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -242,6 +242,7 @@ class Connection:
         self._auth_header_dst = auth_header_dst
 
         self._tasks: set[asyncio.Task] = set()
+        self._call_later_handles: dict[str, asyncio.TimerHandle] = {}
 
         self._logger = ConnectionLogger(self)
         self._state_changed = asyncio.Event()
@@ -1088,6 +1089,10 @@ class Connection:
             task.cancel()
         self._tasks.clear()
 
+        for handle in self._call_later_handles.values():
+            handle.cancel()
+        self._call_later_handles.clear()
+
     def _add_task(
         self,
         coro: Coroutine,
@@ -1117,6 +1122,29 @@ class Connection:
                 await asyncio.sleep(sleep_time)
 
         return self._add_task(_timer_task(), event_loop)
+
+    def call_later(
+        self,
+        delay: float,
+        callback: Callable[[], None],
+        key: str | None = None,
+    ) -> None:
+        def _call_if_connected():
+            if key is not None:
+                self._call_later_handles.pop(key, None)
+            if not self.is_connected:
+                return
+            callback()
+
+        if key is None:
+            asyncio.get_event_loop().call_later(delay, _call_if_connected)
+            return
+
+        if (h := self._call_later_handles.get(key)) is not None:
+            h.cancel()
+        self._call_later_handles[key] = asyncio.get_event_loop().call_later(
+            delay, _call_if_connected
+        )
 
 
 def getEcdhTypeSize(curve_num: int):

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -153,6 +153,31 @@ class DeviceBase(abc.ABC):
 
         self.on_connection_state_change(_register_timer_task)
 
+    def call_later(
+        self,
+        delay: float,
+        callback: Callable[[], None],
+        key: str | None = None,
+    ) -> None:
+        """
+        Schedule `callback` to run after `delay` seconds on the event loop
+
+        All scheduled callbacks are automatically cancelled on disconnect. When `key` is
+        provided, any previously scheduled callback with the same key is cancelled
+        first, making repeated calls act as a debounce/reschedule.
+
+        Parameters
+        ----------
+        delay
+            Seconds to wait before invoking the callback.
+        callback
+            Function to call when the timer fires.
+        key
+            Optional deduplication key. When set, a new call with the same key cancels
+            the previous one.
+        """
+        self._conn.call_later(delay, callback, key)
+
     def with_update_period(self, period: int):
         self._update_period = period
         return self

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -13,8 +13,8 @@ from ..entity.base import dynamic
 from ..packet import Packet
 from ..pb import bk_series_pb2
 from ..props import (
-    Field,
     ProtobufProps,
+    computed_field,
     pb_field,
     proto_attr_mapper,
     repeated_pb_field_type,
@@ -169,37 +169,17 @@ class Device(DeviceBase, ProtobufProps):
     max_ac_in_power = pb_field(pb.pow_sys_ac_in_max)
 
     _resident_load = ResidentLoad()
-    load_power_enabled = Field[bool]()
-    base_load_power = Field[int]()
     max_bp_input = pb_field(pb.max_bp_input)
 
     _charging_task = ChargingTimerTask()
     _discharging_task = DischargingTimerTask()
     _all_timer_tasks = pb_field(pb.all_timer_task)
-    charging_grid_power_limit_enabled = Field[bool]()
-    charging_grid_power_limit = Field[int]()
-    charging_grid_target_soc = Field[int]()
-    charging_task_enabled = Field[bool]()
-    discharging_task_available = Field[bool]()
-    discharging_task_enabled = Field[bool]()
-    discharging_power_limit = Field[int]()
 
     def __init__(
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
         self._timer_task_chain: _TimerTaskChain | None = None
-
-    @property
-    def _dev_target_soc(self):
-        if self._charging_task is None:
-            return None
-
-        for target_soc in self._charging_task.chg_task.dev_target_soc:
-            if target_soc.sn == self._sn:
-                return target_soc
-
-        return None
 
     async def packet_parse(self, data: bytes):
         return Packet.fromBytes(data, xor_payload=True)
@@ -216,32 +196,66 @@ class Device(DeviceBase, ProtobufProps):
             self.update_from_bytes(bk_series_pb2.DisplayPropertyUpload, packet.payload)
             processed = True
 
-        self.load_power_enabled = self._resident_load is not None
-        if self._resident_load is not None:
-            self.base_load_power = self._resident_load.load_power
-
-        self.charging_grid_power_limit_enabled = self._dev_target_soc is not None
-
-        if (target_soc := self._dev_target_soc) is not None:
-            self.charging_grid_power_limit = target_soc.chg_from_grid_power_limited
-            self.charging_grid_target_soc = target_soc.target_soc
-
-        if self._charging_task is not None:
-            self.charging_task_enabled = self._charging_task.is_enable
-
-        self.discharging_task_available = self._discharging_task is not None
-
-        if self._discharging_task is not None:
-            self.discharging_task_enabled = self._discharging_task.is_enable
-            self.discharging_power_limit = (
-                self._discharging_task.home_need_power_limited
-            )
-
-        for field_name in self.updated_fields:
-            self.update_callback(field_name)
-            self.update_state(field_name, getattr(self, field_name))
+        self._notify_updated()
 
         return processed
+
+    @computed_field
+    def load_power_enabled(self) -> bool:
+        return self._resident_load is not None
+
+    @computed_field
+    def base_load_power(self) -> int | None:
+        if self._resident_load is None:
+            return None
+        return self._resident_load.load_power
+
+    @computed_field
+    def charging_grid_power_limit_enabled(self) -> bool:
+        return self._dev_target_soc is not None
+
+    @computed_field
+    def charging_grid_power_limit(self) -> int | None:
+        target = self._dev_target_soc
+        return target.chg_from_grid_power_limited if target is not None else None
+
+    @computed_field
+    def charging_grid_target_soc(self) -> int | None:
+        target = self._dev_target_soc
+        return target.target_soc if target is not None else None
+
+    @computed_field
+    def charging_task_enabled(self) -> bool | None:
+        if self._charging_task is None:
+            return None
+        return self._charging_task.is_enable
+
+    @computed_field
+    def discharging_task_available(self) -> bool:
+        return self._discharging_task is not None
+
+    @computed_field
+    def discharging_task_enabled(self) -> bool | None:
+        if self._discharging_task is None:
+            return None
+        return self._discharging_task.is_enable
+
+    @computed_field
+    def discharging_power_limit(self) -> int | None:
+        if self._discharging_task is None:
+            return None
+        return self._discharging_task.home_need_power_limited
+
+    @property
+    def _dev_target_soc(self):
+        if self._charging_task is None:
+            return None
+
+        for target_soc in self._charging_task.chg_task.dev_target_soc:
+            if target_soc.sn == self._sn:
+                return target_soc
+
+        return None
 
     async def _send_config_packet(self, message: bk_series_pb2.ConfigWrite):
         payload = message.SerializeToString()

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -352,7 +352,6 @@ class Device(DeviceBase, ProtobufProps):
 
     @controls.power(
         charging_grid_power_limit,
-        step=100,
         max=dynamic(max_bp_input),
         availability=dynamic(charging_grid_power_limit_enabled),
     )
@@ -448,7 +447,6 @@ class Device(DeviceBase, ProtobufProps):
 
     @controls.power(
         discharging_power_limit,
-        step=100,
         max=dynamic(max_ac_out_power),
         availability=dynamic(discharging_task_available),
     )

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -167,6 +167,7 @@ class Device(DeviceBase, ProtobufProps):
 
     grid_in_power_limit = pb_field(pb.sys_grid_in_pwr_limit)
     max_ac_in_power = pb_field(pb.pow_sys_ac_in_max)
+    max_ac_out_power = pb_field(pb.pow_sys_ac_out_max)
 
     _resident_load = ResidentLoad()
     max_bp_input = pb_field(pb.max_bp_input)
@@ -258,8 +259,8 @@ class Device(DeviceBase, ProtobufProps):
         return None
 
     async def _send_config_packet(self, message: bk_series_pb2.ConfigWrite):
-        payload = message.SerializeToString()
         message.cfg_utc_time = round(time.time())
+        payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self._conn.sendPacket(packet)
 
@@ -448,6 +449,7 @@ class Device(DeviceBase, ProtobufProps):
     @controls.power(
         discharging_power_limit,
         step=100,
+        max=dynamic(max_ac_out_power),
         availability=dynamic(discharging_task_available),
     )
     async def set_discharging_power_limit(self, limit: float):

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -1,5 +1,11 @@
+import asyncio
+import dataclasses
 import time
 from collections.abc import Callable, Sequence
+from typing import ClassVar
+
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
 
 from ..devicebase import DeviceBase
 from ..entity import controls
@@ -46,6 +52,35 @@ class ChargingTimerTask(repeated_pb_field_type(pb.all_timer_task.time_task)):
                 return task
 
         return None
+
+
+class DischargingTimerTask(repeated_pb_field_type(pb.all_timer_task.time_task)):
+    def get_item(
+        self, value: Sequence[bk_series_pb2.TimerTask]
+    ) -> bk_series_pb2.TimerTask | None:
+        if not value:
+            return None
+
+        for task in value:
+            if proto_has_attr(task, pb_time_task.home_need_power_limited):
+                return task
+
+        return None
+
+
+@dataclasses.dataclass
+class _TimerTaskChain:
+    """
+    Shared state for linked STREAM devices that send the same `all_timer_task` config
+
+    Ensures concurrent commands from different devices in the chain don't overwrite each
+    other.
+    """
+
+    lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
+    pending_mods: list[tuple[int, Callable[[bk_series_pb2.TimerTask], None]]] = (
+        dataclasses.field(default_factory=list)
+    )
 
 
 class EnergyStrategy(IntFieldValue):
@@ -100,6 +135,8 @@ class Device(DeviceBase, ProtobufProps):
     SN_PREFIX = (b"BK51",)
     NAME_PREFIX = "EF-6"
 
+    _timer_task_chains: ClassVar[dict[frozenset[str], _TimerTaskChain]] = {}
+
     battery_level = pb_field(pb.cms_batt_soc)
     battery_level_main = pb_field(pb.bms_batt_soc)
     cell_temperature = pb_field(pb.bms_max_cell_temp)
@@ -134,13 +171,24 @@ class Device(DeviceBase, ProtobufProps):
     _resident_load = ResidentLoad()
     load_power_enabled = Field[bool]()
     base_load_power = Field[int]()
+    max_bp_input = pb_field(pb.max_bp_input)
 
     _charging_task = ChargingTimerTask()
+    _discharging_task = DischargingTimerTask()
     _all_timer_tasks = pb_field(pb.all_timer_task)
     charging_grid_power_limit_enabled = Field[bool]()
     charging_grid_power_limit = Field[int]()
     charging_grid_target_soc = Field[int]()
-    max_bp_input = pb_field(pb.max_bp_input)
+    charging_task_enabled = Field[bool]()
+    discharging_task_available = Field[bool]()
+    discharging_task_enabled = Field[bool]()
+    discharging_power_limit = Field[int]()
+
+    def __init__(
+        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
+    ) -> None:
+        super().__init__(ble_dev, adv_data, sn)
+        self._timer_task_chain: _TimerTaskChain | None = None
 
     @property
     def _dev_target_soc(self):
@@ -177,6 +225,17 @@ class Device(DeviceBase, ProtobufProps):
         if (target_soc := self._dev_target_soc) is not None:
             self.charging_grid_power_limit = target_soc.chg_from_grid_power_limited
             self.charging_grid_target_soc = target_soc.target_soc
+
+        if self._charging_task is not None:
+            self.charging_task_enabled = self._charging_task.is_enable
+
+        self.discharging_task_available = self._discharging_task is not None
+
+        if self._discharging_task is not None:
+            self.discharging_task_enabled = self._discharging_task.is_enable
+            self.discharging_power_limit = (
+                self._discharging_task.home_need_power_limited
+            )
 
         for field_name in self.updated_fields:
             self.update_callback(field_name)
@@ -299,26 +358,105 @@ class Device(DeviceBase, ProtobufProps):
 
         return await self._send_charging_task_packet(set_target_soc)
 
+    async def _send_timer_task_packet(
+        self,
+        target: bk_series_pb2.TimerTask | None,
+        modify: Callable[[bk_series_pb2.TimerTask], None],
+    ) -> bool:
+        chain = self._get_chain()
+        async with chain.lock:
+            if target is None or self._all_timer_tasks is None:
+                return False
+
+            chain.pending_mods.append((target.task_index, modify))
+
+            config = bk_series_pb2.ConfigWrite()
+
+            for task in self._all_timer_tasks.time_task:
+                new_task = config.cfg_all_timer_task.time_task.add()
+                new_task.CopyFrom(task)
+
+                for mod_idx, mod_fn in chain.pending_mods:
+                    if task.task_index == mod_idx:
+                        mod_fn(new_task)
+
+            await self._send_config_packet(config)
+
+            # Clear pending mods after the device has had time to process and send back
+            # updated state
+            self.call_later(
+                5.0,
+                chain.pending_mods.clear,
+                key="pending_task_mods",
+            )
+
+            return True
+
     async def _send_charging_task_packet(
-        self, modify_dev_target_soc: Callable[[bk_series_pb2.DeviceTargetSoc], None]
+        self,
+        modify_dev_target_soc: Callable[[bk_series_pb2.DeviceTargetSoc], None],
     ):
         if (
             self._charging_task is None
-            or self._all_timer_tasks is None
             or len(self._charging_task.chg_task.dev_target_soc) < 1
         ):
             return False
 
-        config = bk_series_pb2.ConfigWrite()
+        sn = self._sn
 
-        for task in self._all_timer_tasks.time_task:
-            new_task = config.cfg_all_timer_task.time_task.add()
-            new_task.CopyFrom(task)
+        def modify(task: bk_series_pb2.TimerTask):
+            for dev_target_soc in task.chg_task.dev_target_soc:
+                if dev_target_soc.sn == sn:
+                    modify_dev_target_soc(dev_target_soc)
 
-            if task.task_index == self._charging_task.task_index:
-                for dev_target_soc in new_task.chg_task.dev_target_soc:
-                    if dev_target_soc.sn == self._sn:
-                        modify_dev_target_soc(dev_target_soc)
+        return await self._send_timer_task_packet(self._charging_task, modify)
 
-        await self._send_config_packet(config)
-        return True
+    @controls.switch(
+        charging_task_enabled,
+        availability=dynamic(charging_grid_power_limit_enabled),
+    )
+    async def enable_charging_task(self, enable: bool):
+        def modify(task: bk_series_pb2.TimerTask):
+            task.is_enable = enable
+
+        await self._send_timer_task_packet(self._charging_task, modify)
+
+    @controls.switch(
+        discharging_task_enabled,
+        availability=dynamic(discharging_task_available),
+    )
+    async def enable_discharging_task(self, enable: bool):
+        def modify(task: bk_series_pb2.TimerTask):
+            task.is_enable = enable
+
+        await self._send_timer_task_packet(self._discharging_task, modify)
+
+    @controls.power(
+        discharging_power_limit,
+        step=100,
+        availability=dynamic(discharging_task_available),
+    )
+    async def set_discharging_power_limit(self, limit: float):
+        def modify(task: bk_series_pb2.TimerTask):
+            task.home_need_power_limited = int(limit)
+
+        return await self._send_timer_task_packet(self._discharging_task, modify)
+
+    def _get_chain(self) -> _TimerTaskChain:
+        if self._timer_task_chain is not None:
+            return self._timer_task_chain
+
+        chain_key = (
+            frozenset(soc.sn for soc in self._charging_task.chg_task.dev_target_soc)
+            if (
+                self._charging_task is not None
+                and len(self._charging_task.chg_task.dev_target_soc) > 0
+            )
+            else frozenset([self._sn])
+        )
+
+        if chain_key not in Device._timer_task_chains:
+            Device._timer_task_chains[chain_key] = _TimerTaskChain()
+
+        self._timer_task_chain = Device._timer_task_chains[chain_key]
+        return self._timer_task_chain

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -2,6 +2,8 @@ import time
 from collections.abc import Callable, Sequence
 
 from ..devicebase import DeviceBase
+from ..entity import controls
+from ..entity.base import dynamic
 from ..packet import Packet
 from ..pb import bk_series_pb2
 from ..props import (
@@ -188,49 +190,64 @@ class Device(DeviceBase, ProtobufProps):
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self._conn.sendPacket(packet)
 
-    async def set_battery_charge_limit_max(self, limit: int):
-        await self._send_config_packet(bk_series_pb2.ConfigWrite(cfg_max_chg_soc=limit))
-        return True
-
-    async def set_battery_charge_limit_min(self, limit: int):
-        await self._send_config_packet(bk_series_pb2.ConfigWrite(cfg_min_dsg_soc=limit))
-        return True
-
-    async def enable_ac_1(self, enable: bool):
+    @controls.battery(
+        battery_charge_limit_max,
+        min=dynamic(battery_charge_limit_min),
+    )
+    async def set_battery_charge_limit_max(self, limit: float):
         await self._send_config_packet(
-            bk_series_pb2.ConfigWrite(cfg_relay2_onoff=enable)
-        )
-
-    async def enable_ac_2(self, enable: bool):
-        await self._send_config_packet(
-            bk_series_pb2.ConfigWrite(cfg_relay3_onoff=enable)
-        )
-
-    async def set_energy_backup_battery_level(self, value: int):
-        await self._send_config_packet(
-            bk_series_pb2.ConfigWrite(cfg_backup_reverse_soc=value)
+            bk_series_pb2.ConfigWrite(cfg_max_chg_soc=int(limit))
         )
         return True
 
-    async def set_feed_grid_pow_limit(self, value: int):
+    @controls.battery(
+        battery_charge_limit_min,
+        max=dynamic(battery_charge_limit_max),
+    )
+    async def set_battery_charge_limit_min(self, limit: float):
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_min_dsg_soc=int(limit))
+        )
+        return True
+
+    @controls.battery(
+        energy_backup_battery_level,
+        min=dynamic(battery_charge_limit_min),
+        max=dynamic(battery_charge_limit_max),
+    )
+    async def set_energy_backup_battery_level(self, value: float):
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_backup_reverse_soc=int(value))
+        )
+        return True
+
+    @controls.power(feed_grid_pow_limit, max=dynamic(feed_grid_pow_max))
+    async def set_feed_grid_pow_limit(self, value: float):
         if self.feed_grid_pow_max is None or value > self.feed_grid_pow_max:
             return False
         await self._send_config_packet(
-            bk_series_pb2.ConfigWrite(cfg_feed_grid_mode_pow_limit=value)
+            bk_series_pb2.ConfigWrite(cfg_feed_grid_mode_pow_limit=int(value))
         )
         return True
 
+    @controls.switch(feed_grid)
     async def enable_feed_grid(self, enable: bool):
         await self._send_config_packet(
             bk_series_pb2.ConfigWrite(cfg_feed_grid_mode=2 if enable else 1)
         )
 
+    @controls.select(energy_strategy, options=EnergyStrategy)
     async def set_energy_strategy(self, strategy: EnergyStrategy):
         cfg = bk_series_pb2.ConfigWrite()
         strategy.as_pb(cfg.cfg_energy_strategy_operate_mode)
         await self._send_config_packet(cfg)
 
-    async def set_load_power(self, limit: int):
+    @controls.power(
+        base_load_power,
+        max=dynamic(feed_grid_pow_max),
+        availability=dynamic(load_power_enabled),
+    )
+    async def set_load_power(self, limit: float):
         if self._resident_load is None:
             return False
 
@@ -239,7 +256,7 @@ class Device(DeviceBase, ProtobufProps):
                 cfg_day_resident_load_list=bk_series_pb2.DayResidentLoadList(
                     load=[
                         bk_series_pb2.ResidentLoad(
-                            load_power=limit,
+                            load_power=int(limit),
                             start_min=self._resident_load.start_min,
                             end_min=self._resident_load.end_min,
                         )
@@ -249,24 +266,36 @@ class Device(DeviceBase, ProtobufProps):
         )
         return True
 
-    async def set_grid_in_pow_limit(self, value: int):
+    @controls.power(grid_in_power_limit, max=dynamic(max_ac_in_power))
+    async def set_grid_in_pow_limit(self, value: float):
         if self.max_ac_in_power is None or value > self.max_ac_in_power or value < 0:
             return False
 
         await self._send_config_packet(
-            bk_series_pb2.ConfigWrite(cfg_sys_grid_in_pwr_limit=value)
+            bk_series_pb2.ConfigWrite(cfg_sys_grid_in_pwr_limit=int(value))
         )
         return True
 
-    async def set_charging_grid_power_limit(self, limit: int):
+    @controls.power(
+        charging_grid_power_limit,
+        step=100,
+        max=dynamic(max_bp_input),
+        availability=dynamic(charging_grid_power_limit_enabled),
+    )
+    async def set_charging_grid_power_limit(self, limit: float):
         def set_power_limit(dev_soc: bk_series_pb2.DeviceTargetSoc):
-            dev_soc.chg_from_grid_power_limited = limit
+            dev_soc.chg_from_grid_power_limited = int(limit)
 
         return await self._send_charging_task_packet(set_power_limit)
 
-    async def set_charging_grid_target_soc(self, soc: int):
+    @controls.battery(
+        charging_grid_target_soc,
+        max=100,
+        availability=dynamic(charging_grid_power_limit_enabled),
+    )
+    async def set_charging_grid_target_soc(self, soc: float):
         def set_target_soc(dev_soc: bk_series_pb2.DeviceTargetSoc):
-            dev_soc.target_soc = soc
+            dev_soc.target_soc = int(soc)
 
         return await self._send_charging_task_packet(set_target_soc)
 

--- a/custom_components/ef_ble/eflib/devices/stream_ac_pro.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac_pro.py
@@ -1,3 +1,5 @@
+from ..entity import controls
+from ..pb import bk_series_pb2
 from ..props import ProtobufProps, pb_field
 from . import stream_ac
 
@@ -14,3 +16,15 @@ class Device(stream_ac.Device, ProtobufProps):
 
     ac_1 = pb_field(pb.relay2_onoff)
     ac_2 = pb_field(pb.relay3_onoff)
+
+    @controls.outlet(ac_1)
+    async def enable_ac_1(self, enable: bool):  # pyright: ignore[reportIncompatibleMethodOverride]
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_relay2_onoff=enable)
+        )
+
+    @controls.outlet(ac_2)
+    async def enable_ac_2(self, enable: bool):  # pyright: ignore[reportIncompatibleMethodOverride]
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_relay3_onoff=enable)
+        )

--- a/custom_components/ef_ble/eflib/devices/stream_ac_pro.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac_pro.py
@@ -18,13 +18,13 @@ class Device(stream_ac.Device, ProtobufProps):
     ac_2 = pb_field(pb.relay3_onoff)
 
     @controls.outlet(ac_1)
-    async def enable_ac_1(self, enable: bool):  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def enable_ac_1(self, enable: bool):
         await self._send_config_packet(
             bk_series_pb2.ConfigWrite(cfg_relay2_onoff=enable)
         )
 
     @controls.outlet(ac_2)
-    async def enable_ac_2(self, enable: bool):  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def enable_ac_2(self, enable: bool):
         await self._send_config_packet(
             bk_series_pb2.ConfigWrite(cfg_relay3_onoff=enable)
         )

--- a/custom_components/ef_ble/eflib/devices/stream_max.py
+++ b/custom_components/ef_ble/eflib/devices/stream_max.py
@@ -1,3 +1,5 @@
+from ..entity import controls
+from ..pb import bk_series_pb2
 from ..props import pb_field
 from . import stream_ac
 
@@ -18,3 +20,9 @@ class Device(stream_ac.Device):
     pv_power_sum = pb_field(pb.pow_get_pv_sum, lambda v: round(v, 2))
 
     load_from_pv = pb_field(pb.pow_get_sys_load_from_pv, lambda v: round(v, 2))
+
+    @controls.outlet(ac_1)
+    async def enable_ac_1(self, enable: bool):  # pyright: ignore[reportIncompatibleMethodOverride]
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_relay2_onoff=enable)
+        )

--- a/custom_components/ef_ble/eflib/devices/stream_max.py
+++ b/custom_components/ef_ble/eflib/devices/stream_max.py
@@ -22,7 +22,7 @@ class Device(stream_ac.Device):
     load_from_pv = pb_field(pb.pow_get_sys_load_from_pv, lambda v: round(v, 2))
 
     @controls.outlet(ac_1)
-    async def enable_ac_1(self, enable: bool):  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def enable_ac_1(self, enable: bool):
         await self._send_config_packet(
             bk_series_pb2.ConfigWrite(cfg_relay2_onoff=enable)
         )

--- a/custom_components/ef_ble/eflib/devices/stream_pro.py
+++ b/custom_components/ef_ble/eflib/devices/stream_pro.py
@@ -1,3 +1,5 @@
+from ..entity import controls
+from ..pb import bk_series_pb2
 from ..props import pb_field
 from . import stream_ac, stream_max
 
@@ -13,3 +15,9 @@ class Device(stream_max.Device):
     ac_2 = pb_field(pb.relay3_onoff)
 
     pv_power_3 = pb_field(pb.pow_get_pv3, lambda v: round(v, 2))
+
+    @controls.outlet(ac_2)
+    async def enable_ac_2(self, enable: bool):
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_relay3_onoff=enable)
+        )

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -316,6 +316,18 @@
         "state": {
           "off": "mdi:transmission-tower-off"
         }
+      },
+      "charging_task_enabled": {
+        "default": "mdi:battery-charging",
+        "state": {
+          "off": "mdi:battery-off"
+        }
+      },
+      "discharging_task_enabled": {
+        "default": "mdi:battery-arrow-down",
+        "state": {
+          "off": "mdi:battery-off-outline"
+        }
       }
     },
     "select": {
@@ -401,6 +413,9 @@
       },
       "feed_grid_mode_power_limit": {
         "default": "mdi:transmission-tower"
+      },
+      "discharging_power_limit": {
+        "default": "mdi:battery-arrow-down"
       }
     }
   }

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -298,6 +298,24 @@
         "state": {
           "off": "mdi:power-plug-off"
         }
+      },
+      "ac_1": {
+        "default": "mdi:power-plug",
+        "state": {
+          "off": "mdi:power-plug-off"
+        }
+      },
+      "ac_2": {
+        "default": "mdi:power-plug",
+        "state": {
+          "off": "mdi:power-plug-off"
+        }
+      },
+      "feed_grid": {
+        "default": "mdi:transmission-tower-export",
+        "state": {
+          "off": "mdi:transmission-tower-off"
+        }
       }
     },
     "select": {
@@ -318,6 +336,15 @@
       },
       "operating_mode_select": {
         "default": "mdi:state-machine"
+      },
+      "energy_strategy": {
+        "default": "mdi:state-machine",
+        "state": {
+          "self_powered": "mdi:solar-power",
+          "scheduled": "mdi:calendar-clock",
+          "tou": "mdi:clock-time-eight",
+          "intelligent_schedule": "mdi:head-lightbulb"
+        }
       }
     },
     "number": {
@@ -356,6 +383,24 @@
       },
       "ac_5p8_charging_power": {
         "default": "mdi:lightning-bolt"
+      },
+      "feed_grid_pow_limit": {
+        "default": "mdi:transmission-tower"
+      },
+      "base_load_power": {
+        "default": "mdi:home-lightning-bolt"
+      },
+      "grid_in_power_limit": {
+        "default": "mdi:transmission-tower"
+      },
+      "charging_grid_power_limit": {
+        "default": "mdi:lightning-bolt"
+      },
+      "charging_grid_target_soc": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "feed_grid_mode_power_limit": {
+        "default": "mdi:transmission-tower"
       }
     }
   }

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -998,6 +998,9 @@
       "feed_grid_mode_power_limit": {
         "name": "Maximum Output Power"
       },
+      "discharging_power_limit": {
+        "name": "Discharging Power Limit"
+      },
       "ac_5p8_charging_power": {
         "name": "AC 5P8 Charging Power"
       },
@@ -1068,6 +1071,12 @@
       },
       "feed_grid": {
         "name": "Feed Grid"
+      },
+      "charging_task_enabled": {
+        "name": "Charging Task"
+      },
+      "discharging_task_enabled": {
+        "name": "Discharging Task"
       }
     }
   }

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -953,6 +953,15 @@
           "self_powered": "Self Powered",
           "scheduled": "Scheduled Tasks"
         }
+      },
+      "energy_strategy": {
+        "name": "Energy Strategy",
+        "state": {
+          "self_powered": "Self Powered",
+          "scheduled": "Scheduled",
+          "tou": "Time of Use",
+          "intelligent_schedule": "Intelligent Schedule"
+        }
       }
     },
     "number": {
@@ -970,6 +979,24 @@
       },
       "ac_c20_charging_power": {
         "name": "AC C20 Charging Power"
+      },
+      "feed_grid_pow_limit": {
+        "name": "Feed Grid Power Limit"
+      },
+      "base_load_power": {
+        "name": "Base Load Power"
+      },
+      "grid_in_power_limit": {
+        "name": "Grid Input Power Limit"
+      },
+      "charging_grid_power_limit": {
+        "name": "Charging Power Limit"
+      },
+      "charging_grid_target_soc": {
+        "name": "Charging Target SOC"
+      },
+      "feed_grid_mode_power_limit": {
+        "name": "Maximum Output Power"
       },
       "ac_5p8_charging_power": {
         "name": "AC 5P8 Charging Power"
@@ -1032,6 +1059,15 @@
       },
       "energy_strategy_tou": {
         "name": "Time-of-Use Mode"
+      },
+      "ac_1": {
+        "name": "AC (1)"
+      },
+      "ac_2": {
+        "name": "AC (2)"
+      },
+      "feed_grid": {
+        "name": "Feed Grid"
       }
     }
   }


### PR DESCRIPTION
This PR migrates all STREAM battery devices to the controls system and adds charging/discharging task controls.

Most noteable changes:
- Added Charging Task and Discharging Task enable/disable switches and Discharging Power Limit slider for STREAM devices
- Added `_send_timer_task_packet` helper with `asyncio.Lock` and pending modification tracking to prevent concurrent commands from overwriting each other
- Added `call_later(delay, callback, key=None)` utility to `Connection`/`DeviceBase` for debounced callbacks with auto-cleanup on disconnect