### PR TITLE
Implement decorator for computed fields and use it for D2, D3, R3 devices, fix ac power speed limit for Delta 3 1500

### DIFF
--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -46,6 +46,7 @@ class DeviceBase(abc.ABC):
     MANUFACTURER_KEY = 0xB5B5
 
     NAME_PREFIX: str
+    SN_PREFIX: tuple[bytes, ...]
 
     _listeners = _Listeners.create()
 

--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -37,8 +37,6 @@ pb_inv = dataclass_attr_mapper(DirectInvDeltaHeartbeatPack)
 
 
 class Delta2Base(DeviceBase, RawDataProps):
-    SN_PREFIX: tuple[bytes, ...]
-
     ac_output_power = raw_field(pb_inv.output_watts)
     ac_input_voltage = raw_field(pb_inv.ac_in_vol, lambda x: round(x / 1000, 2))
     ac_input_current = raw_field(pb_inv.ac_in_amp, lambda x: round(x / 1000, 2))
@@ -87,8 +85,6 @@ class Delta2Base(DeviceBase, RawDataProps):
     dc12v_output_voltage = raw_field(pb_mppt.car_out_vol, lambda x: round(x / 1000, 2))
     dc12v_output_current = raw_field(pb_mppt.car_out_amp, lambda x: round(x / 1000, 2))
 
-    max_ac_charging_power = Field[int]()
-
     @property
     def pd_heart_type(self):
         return BasePdHeart
@@ -115,9 +111,6 @@ class Delta2Base(DeviceBase, RawDataProps):
     @property
     def packet_version(self):
         return 2
-
-    def _after_message_parsed(self):
-        pass
 
     async def data_parse(self, packet: Packet) -> bool:
         """Process the incoming notifications from the device"""
@@ -150,11 +143,7 @@ class Delta2Base(DeviceBase, RawDataProps):
                 self.update_from_bytes(self.mppt_heart_type, packet.payload)
                 processed = True
 
-        self._after_message_parsed()
-
-        for field_name in self.updated_fields:
-            self.update_callback(field_name)
-            self.update_state(field_name, getattr(self, field_name))
+        self._notify_updated()
 
         return processed
 

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -1,5 +1,3 @@
-from collections.abc import Sequence
-
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from google.protobuf.message import Message
@@ -11,8 +9,8 @@ from ..entity.base import dynamic
 from ..packet import Packet
 from ..pb import pd335_bms_bp_pb2, pd335_sys_pb2
 from ..props import (
-    Field,
     ProtobufProps,
+    computed_field,
     pb_field,
     proto_attr_mapper,
     repeated_pb_field_type,
@@ -74,8 +72,6 @@ class DCPortState(IntFieldValue):
 
 
 class Delta3Base(DeviceBase, ProtobufProps):
-    SN_PREFIX: Sequence[bytes]
-
     battery_level = pb_field(pb.cms_batt_soc, lambda value: round(value, 2))
     battery_level_main = pb_field(pb.bms_batt_soc, lambda value: round(value, 2))
 
@@ -103,13 +99,23 @@ class Delta3Base(DeviceBase, ProtobufProps):
     cell_temperature = pb_field(pb.bms_max_cell_temp)
     ac_ports = pb_field(pb.flow_info_ac_out, flow_is_on)
 
-    solar_input_power = Field[float]()
-
     remaining_time_charging = pb_field(pb.cms_chg_rem_time)
     remaining_time_discharging = pb_field(pb.cms_dsg_rem_time)
 
     ac_charging_speed = pb_field(pb.plug_in_info_ac_in_chg_pow_max)
-    max_ac_charging_power = Field[int]()
+
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        return 1500
+
+    @computed_field
+    def solar_input_power(self) -> float:
+        if (
+            self.dc_port_state is DCPortState.SOLAR
+            and self.dc_port_input_power is not None
+        ):
+            return round(self.dc_port_input_power, 2)
+        return 0
 
     dc_charging_max_amps = _DcAmpSettingField(
         pd335_sys_pb2.PV_CHG_VOL_SPEC_12V, pd335_sys_pb2.PV_PLUG_INDEX_1
@@ -121,7 +127,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
     ) -> None:
         super().__init__(ble_dev, adv_data, sn)
         self._time_commands = TimeCommands(self)
-        self.max_ac_charging_power = 1500
 
     async def packet_parse(self, data: bytes):
         return Packet.fromBytes(data, xor_payload=True)
@@ -147,24 +152,9 @@ class Delta3Base(DeviceBase, ProtobufProps):
                 self._time_commands.async_send_all()
             processed = True
 
-        self.solar_input_power = (
-            round(self.dc_port_input_power, 2)
-            if (
-                self.dc_port_state is DCPortState.SOLAR
-                and self.dc_port_input_power is not None
-            )
-            else 0
-        )
-        self._after_message_parsed()
-
-        for field_name in self.updated_fields:
-            self.update_callback(field_name)
-            self.update_state(field_name, getattr(self, field_name))
+        self._notify_updated()
 
         return processed
-
-    def _after_message_parsed(self):
-        pass
 
     async def _send_config_packet(self, message: Message):
         payload = message.SerializeToString()
@@ -179,12 +169,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
 
     @controls.battery(battery_charge_limit_min, max=dynamic(battery_charge_limit_max))
     async def set_battery_charge_limit_min(self, limit: float):
-        if (
-            self.battery_charge_limit_max is not None
-            and limit > self.battery_charge_limit_max
-        ):
-            return False
-
         await self._send_config_packet(
             pd335_sys_pb2.ConfigWrite(cfg_min_dsg_soc=int(limit))
         )
@@ -192,12 +176,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
 
     @controls.battery(battery_charge_limit_max, min=dynamic(battery_charge_limit_min))
     async def set_battery_charge_limit_max(self, limit: float):
-        if (
-            self.battery_charge_limit_min is not None
-            and limit < self.battery_charge_limit_min
-        ):
-            return False
-
         await self._send_config_packet(
             pd335_sys_pb2.ConfigWrite(cfg_max_chg_soc=int(limit))
         )
@@ -205,13 +183,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
 
     @controls.power(ac_charging_speed, max=dynamic(max_ac_charging_power))
     async def set_ac_charging_speed(self, value: float):
-        if (
-            self.max_ac_charging_power is None
-            or value > self.max_ac_charging_power
-            or value < 0
-        ):
-            return False
-
         await self._send_config_packet(
             pd335_sys_pb2.ConfigWrite(
                 cfg_ac_in_chg_mode=pd335_sys_pb2.AC_IN_CHG_MODE_SELF_DEF_POW,
@@ -226,13 +197,6 @@ class Delta3Base(DeviceBase, ProtobufProps):
         value: float,
         plug_index: pd335_sys_pb2.PV_PLUG_INDEX = pd335_sys_pb2.PV_PLUG_INDEX_1,
     ) -> bool:
-        if (
-            self.dc_charging_current_max is None
-            or value < 0
-            or value > self.dc_charging_current_max
-        ):
-            return False
-
         config = pd335_sys_pb2.ConfigWrite()
         config.cfg_pv_dc_chg_setting.pv_plug_index = plug_index
         config.cfg_pv_dc_chg_setting.pv_chg_vol_spec = pd335_sys_pb2.PV_CHG_VOL_SPEC_12V

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -5,6 +5,7 @@ from ..model import (
     Mr330PdHeartDelta2,
 )
 from ..packet import Packet
+from ..props import computed_field
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ._delta2_base import Delta2Base
 
@@ -39,19 +40,15 @@ class Device(Delta2Base):
     def mppt_heart_type(self):
         return Mr330MpptHeart
 
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        if self.battery_1_enabled or self.battery_2_enabled:
+            return 1500
+        return 1200
+
     def __init__(self, ble_dev, adv_data, sn: str) -> None:
         super().__init__(ble_dev, adv_data, sn)
         self._product_type: int | None = None
-        self.max_ac_charging_power = 1200
-
-    def _after_message_parsed(self):
-        self._update_ac_chg_limits()
-
-    def _update_ac_chg_limits(self) -> None:
-        if self.battery_1_enabled or self.battery_2_enabled:
-            self.max_ac_charging_power = 1500
-        else:
-            self.max_ac_charging_power = 1200
 
     @controls.switch(energy_backup)
     async def enable_energy_backup(self, enabled: bool):
@@ -82,10 +79,8 @@ class Device(Delta2Base):
         packet = Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
         await self._conn.sendPacket(packet)
 
-    @controls.power(ac_charging_speed, max=dynamic(Delta2Base.max_ac_charging_power))
+    @controls.power(ac_charging_speed, min=1, max=dynamic(max_ac_charging_power))
     async def set_ac_charging_speed(self, value: float):
-        if self.max_ac_charging_power is None or value < 1:
-            return False
         payload = int(value).to_bytes(2, "little") + bytes([0xFF])
         packet = Packet(0x21, self.ac_commands_dst, 0x20, 0x45, payload, version=0x02)
         await self._conn.sendPacket(packet)

--- a/custom_components/ef_ble/eflib/devices/delta2_max.py
+++ b/custom_components/ef_ble/eflib/devices/delta2_max.py
@@ -1,11 +1,8 @@
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-
 from ..entity import controls
 from ..entity.base import dynamic
 from ..model import Mr350MpptHeart, Mr350PdHeartbeatDelta2Max
 from ..packet import Packet
-from ..props import dataclass_attr_mapper, raw_field
+from ..props import computed_field, dataclass_attr_mapper, raw_field
 from ._delta2_base import Delta2Base, pb_inv
 
 pb_pd = dataclass_attr_mapper(Mr350PdHeartbeatDelta2Max)
@@ -27,11 +24,9 @@ class Device(Delta2Base):
     xt60_1_input_power = raw_field(pb_pd.pv1_charge_watts)
     xt60_2_input_power = raw_field(pb_pd.pv2_charge_watts)
 
-    def __init__(
-        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
-    ) -> None:
-        super().__init__(ble_dev, adv_data, sn)
-        self.max_ac_charging_power = 1800
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        return 1800
 
     @property
     def pd_heart_type(self):
@@ -75,10 +70,8 @@ class Device(Delta2Base):
             Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
         )
 
-    @controls.power(ac_charging_speed, max=dynamic(Delta2Base.max_ac_charging_power))
+    @controls.power(ac_charging_speed, min=1, max=dynamic(max_ac_charging_power))
     async def set_ac_charging_speed(self, value: float):
-        if self.max_ac_charging_power is None or value < 1:
-            return False
         payload = bytes([0xFF, 0xFF]) + int(value).to_bytes(2, "little") + bytes([0xFF])
         await self._conn.sendPacket(
             Packet(0x20, 0x04, 0x20, 0x45, payload, version=0x02)

--- a/custom_components/ef_ble/eflib/devices/delta2_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta2_plus.py
@@ -1,3 +1,4 @@
+from ..props import computed_field
 from . import delta2
 
 
@@ -6,3 +7,7 @@ class Device(delta2.Device):
 
     SN_PREFIX = (b"D361",)
     NAME_PREFIX = "EF-D3"
+
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        return 1500

--- a/custom_components/ef_ble/eflib/devices/delta3_air.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_air.py
@@ -1,6 +1,4 @@
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-
+from ..props import computed_field
 from ._delta3_base import Delta3Base
 
 
@@ -10,11 +8,9 @@ class Device(Delta3Base):
     SN_PREFIX = (b"PR11", b"PR12", b"PR21")
     NAME_PREFIX = "EF-PR"
 
-    def __init__(
-        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
-    ) -> None:
-        super().__init__(ble_dev, adv_data, sn)
-        self.max_ac_charging_power = 1000 if sn[:4] == "PR21" else 500
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        return 1000 if self._sn[:4] == "PR21" else 500
 
     @property
     def device(self):

--- a/custom_components/ef_ble/eflib/devices/delta3_classic.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_classic.py
@@ -1,7 +1,3 @@
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-
-from ..commands import TimeCommands
 from ..entity import controls
 from ..entity.base import dynamic
 from ..pb import pd335_sys_pb2
@@ -36,16 +32,6 @@ class Device(Delta3Base):
         pb.energy_strategy_operate_mode,
         lambda x: x.operate_tou_mode_open if x else None,
     )
-
-    def __init__(
-        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
-    ) -> None:
-        super().__init__(ble_dev, adv_data, sn)
-        self._time_commands = TimeCommands(self)
-        self.max_ac_charging_power = 1500
-
-    def _after_message_parsed(self):
-        pass
 
     @controls.switch(disable_grid_bypass, enabled=False)
     async def enable_disable_grid_bypass(self, enabled: bool):

--- a/custom_components/ef_ble/eflib/devices/delta3_max.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_max.py
@@ -1,6 +1,4 @@
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-
+from ..props import computed_field
 from . import delta3
 
 
@@ -9,8 +7,6 @@ class Device(delta3.Device):
 
     SN_PREFIX = (b"D3N1",)
 
-    def __init__(
-        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
-    ) -> None:
-        super().__init__(ble_dev, adv_data, sn)
-        self.max_ac_charging_power = 1800
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        return 1800

--- a/custom_components/ef_ble/eflib/devices/delta3_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_plus.py
@@ -1,7 +1,7 @@
 from ..entity import controls
 from ..entity.base import dynamic
 from ..pb import pd335_sys_pb2
-from ..props import Field, pb_field
+from ..props import computed_field, pb_field
 from . import delta3
 from ._delta3_base import DCPortState, _DcAmpSettingField, _DcChargingMaxField, pb
 
@@ -19,17 +19,14 @@ class Device(delta3.Device):
     dc_port_2_input_power = pb_field(pb.pow_get_pv2, lambda value: round(value, 2))
     dc_port_2_state = pb_field(pb.plug_in_info_pv2_type, DCPortState.from_value)
 
-    solar_input_power_2 = Field[float]()
-
-    def _after_message_parsed(self):
-        self.solar_input_power_2 = (
-            round(self.dc_port_2_input_power, 2)
-            if (
-                self.dc_port_2_state is DCPortState.SOLAR
-                and self.dc_port_2_input_power is not None
-            )
-            else 0
-        )
+    @computed_field
+    def solar_input_power_2(self) -> float:
+        if (
+            self.dc_port_2_state is DCPortState.SOLAR
+            and self.dc_port_2_input_power is not None
+        ):
+            return round(self.dc_port_2_input_power, 2)
+        return 0
 
     @controls.current(dc_charging_max_amps_2, max=dynamic(dc_charging_current_max_2))
     async def set_dc_charging_amps_max_2(self, value: float) -> bool:

--- a/custom_components/ef_ble/eflib/devices/delta3_ultra.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_ultra.py
@@ -1,6 +1,4 @@
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
-
+from ..props import computed_field
 from . import delta3
 
 
@@ -9,8 +7,6 @@ class Device(delta3.Device):
 
     SN_PREFIX = (b"D751",)
 
-    def __init__(
-        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
-    ) -> None:
-        super().__init__(ble_dev, adv_data, sn)
-        self.max_ac_charging_power = 1800
+    @computed_field
+    def max_ac_charging_power(self) -> int:
+        return 1800

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -8,8 +8,8 @@ from ..entity.base import dynamic
 from ..packet import Packet
 from ..pb import pr705_pb2
 from ..props import (
-    Field,
     ProtobufProps,
+    computed_field,
     pb_field,
     proto_attr_mapper,
     repeated_pb_field_type,
@@ -65,10 +65,7 @@ class Device(DeviceBase, ProtobufProps):
     ac_output_energy = _StatField(pr705_pb2.STATISTICS_OBJECT_AC_OUT_ENERGY)
 
     input_power = pb_field(pb.pow_in_sum_w)
-    input_energy = Field[int]()
-
     output_power = pb_field(pb.pow_out_sum_w)
-    output_energy = Field[int]()
 
     dc_input_power = pb_field(pb.pow_get_pv)
     dc_input_energy = _StatField(pr705_pb2.STATISTICS_OBJECT_PV_IN_ENERGY)
@@ -104,6 +101,28 @@ class Device(DeviceBase, ProtobufProps):
 
     remaining_time_charging = pb_field(pb.cms_chg_rem_time)
     remaining_time_discharging = pb_field(pb.cms_dsg_rem_time)
+
+    @computed_field
+    def input_energy(self) -> int | None:
+        if self.ac_input_energy is not None and self.dc_input_energy is not None:
+            return self.ac_input_energy + self.dc_input_energy
+        return None
+
+    @computed_field
+    def output_energy(self) -> int | None:
+        if (
+            self.ac_output_energy is not None
+            and self.usba_output_energy is not None
+            and self.usbc_output_energy is not None
+            and self.dc12v_output_energy is not None
+        ):
+            return (
+                self.ac_output_energy
+                + self.usba_output_energy
+                + self.usbc_output_energy
+                + self.dc12v_output_energy
+            )
+        return None
 
     def __init__(
         self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
@@ -150,25 +169,7 @@ class Device(DeviceBase, ProtobufProps):
                 self._time_commands.async_send_all()
             processed = True
 
-        if self.ac_input_energy is not None and self.dc_input_energy is not None:
-            self.input_energy = self.ac_input_energy + self.dc_input_energy
-
-        if (
-            self.ac_output_energy is not None
-            and self.usba_output_energy is not None
-            and self.usbc_output_energy is not None
-            and self.dc12v_output_energy is not None
-        ):
-            self.output_energy = (
-                self.ac_output_energy
-                + self.usba_output_energy
-                + self.usbc_output_energy
-                + self.dc12v_output_energy
-            )
-
-        for field_name in self.updated_fields:
-            self.update_callback(field_name)
-            self.update_state(field_name, getattr(self, field_name))
+        self._notify_updated()
 
         return processed
 

--- a/custom_components/ef_ble/eflib/props/__init__.py
+++ b/custom_components/ef_ble/eflib/props/__init__.py
@@ -15,6 +15,7 @@ from .updatable_props import (
     FieldGroup,
     FieldGroupView,
     UpdatableProps,
+    computed_field,
     field_group,
 )
 
@@ -25,6 +26,7 @@ __all__ = [
     "ProtobufProps",
     "RawDataProps",
     "UpdatableProps",
+    "computed_field",
     "dataclass_attr_mapper",
     "field_group",
     "pb_field",

--- a/custom_components/ef_ble/eflib/props/updatable_props.py
+++ b/custom_components/ef_ble/eflib/props/updatable_props.py
@@ -25,6 +25,7 @@ class UpdatableProps:
     updated: bool = False
     _updated_fields: set[str] | None = None
     _fields: ClassVar[list["Field[Any]"]] = []
+    _computed_fields: ClassVar[list["_ComputedField[Any]"]] = []
 
     @property
     def updated_fields(self):
@@ -63,6 +64,16 @@ class UpdatableProps:
             f"  {f.public_name}: {getattr(self, f.public_name)!r}" for f in self._fields
         ]
         return f"{cls}:\n" + "\n".join(lines)
+
+    def _recompute(self):
+        for cf in self._computed_fields:
+            cf.recompute(self)
+
+    def _notify_updated(self):
+        self._recompute()
+        for field_name in self.updated_fields:
+            self.update_callback(field_name)  # type: ignore[attr-defined]
+            self.update_state(field_name, getattr(self, field_name))  # type: ignore[attr-defined]
 
     def _get_entities[E: "EntityType"](
         self,
@@ -194,6 +205,62 @@ class Field[T]:
             sensor.field = self
         self.sensor_type = sensor
         return self
+
+
+class _ComputedField[T](Field[T]):
+    _func: Callable[..., T]
+
+    def __call__(self, func: Callable[..., T]) -> Self:
+        self._func = func
+        return self
+
+    def __set_name__(self, owner: type[UpdatableProps], name: str):
+        super().__set_name__(owner, name)
+        existing = [cf for cf in owner._computed_fields if cf.public_name != name]
+        owner._computed_fields = [*existing, self]
+
+    @overload
+    def __get__(
+        self,
+        instance: None,
+        owner: type[UpdatableProps],
+    ) -> "_ComputedField[T]": ...
+
+    @overload
+    def __get__(
+        self,
+        instance: UpdatableProps,
+        owner: type[UpdatableProps],
+    ) -> T: ...
+
+    def __get__(
+        self,
+        instance: UpdatableProps | None,
+        owner: type[UpdatableProps],
+    ) -> "T | _ComputedField[T]":
+        if instance is None:
+            return self
+        # always compute live from current state. recompute() separately diffs against a
+        # cached value to track which fields changed
+        return self._func(instance)
+
+    def __set__(self, instance: UpdatableProps, value: Any):
+        raise AttributeError(f"cannot set computed field '{self.public_name}' directly")
+
+    def recompute(self, instance: UpdatableProps):
+        new_val = self._func(instance)
+        old_val = getattr(instance, self.private_name, None)
+        if new_val == old_val:
+            return
+        setattr(instance, self.private_name, new_val)
+        instance.updated = True
+        instance.updated_fields.add(self.public_name)
+
+
+def computed_field[T](func: Callable[..., T]) -> _ComputedField[T]:
+    cf = _ComputedField[T]()
+    cf(func)
+    return cf
 
 
 class FieldGroupView[T]:


### PR DESCRIPTION
This PR introduces a new `@computed_field` decorator in `props/updatable_props.py` that automatically dispatches `_notify_updated()` when dependent fields change, eliminating the need for manual computed property boilerplate and refactors all Delta 2, Delta 3 and River 3 device classes.

PR also fixes AC speed limit for Delta 3 1500 to 1500W instead of Delta 2's default 1500W.