### PR TITLE
Add CONTRIBUTING.md and rework issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,61 +1,127 @@
-name: Bug Report
-description: File a bug report
+name: Bug report
+description: Something isn't working as it should (wrong values, crashes, disconnects, errors in the log)
 title: "[Bug]: "
 labels: ["bug"]
-assignees:
-  - octocat
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Before submitting, please:
+
+        - Make sure you're running the [latest release](https://github.com/rabits/ha-ef-ble/releases)
+          and the bug still reproduces.
+        - Search [open issues](https://github.com/rabits/ha-ef-ble/issues) to avoid duplicates.
+          Prefer a 👍 reaction on an existing report over a new one.
+        - For **wrong, missing, or unexpected sensor values**, please use the
+          [New / missing / incorrect sensor](https://github.com/rabits/ha-ef-ble/issues/new?template=sensor_request.yaml) template instead.
+        - For **an EcoFlow device that isn't supported yet**, please use the
+          [New device support](https://github.com/rabits/ha-ef-ble/issues/new?template=device_request.yaml) template instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I'm running the latest release and the bug still reproduces
+          required: true
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "An exception appeared"
+      description: |
+        Describe what you saw and what you expected to see. Include exact steps to reproduce
+        if the bug is triggered by a specific action.
+      placeholder: |
+        Steps to reproduce:
+        1. ...
+        2. ...
+
+        Expected: ...
+        Actual:   ...
     validations:
       required: true
-  - type: textarea
+
+  - type: input
     id: version
     attributes:
-      label: What version of our software are you running?
+      label: Integration version
+      description: e.g. `0.8.4` - find it in HACS or `custom_components/ef_ble/manifest.json`.
+      placeholder: "0.8.4"
     validations:
       required: true
-  - type: textarea
+
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      description: e.g. `2026.2.0` - visible in Settings → About.
+      placeholder: "2026.2.0"
+    validations:
+      required: true
+
+  - type: input
     id: device
     attributes:
-      label: What device are you seeing the problem on?
+      label: Device model
+      description: |
+        The marketing name of the device (e.g. "Delta Pro 3", "STREAM Ultra X", "River 3")
+        and the firmware version if you know it.
+      placeholder: "Delta Pro 3, firmware 1.0.2.123"
     validations:
       required: true
+
   - type: dropdown
     id: bluetooth
     attributes:
-      label: What bluetooth connection are you using?
+      label: Bluetooth connection
       multiple: false
       options:
+        - Internal bluetooth adapter
         - USB dongle
         - ESPHome bluetooth proxy
-        - Internal bluetooth adapter
+        - Other (describe in "What happened?")
     validations:
       required: true
+
   - type: dropdown
     id: options-changed
     attributes:
       label: Have you changed the integration settings?
       multiple: false
       options:
-        - No
-        - Yes (Please write down the changed settings in the next step)
+        - "No"
+        - "Yes (please list them below)"
     validations:
       required: true
+
   - type: textarea
     id: options-details
     attributes:
-      label: Integration settings (if you changed them)
-      description: Please use one line per option
+      label: Changed integration settings
+      description: One line per option
       render: text
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        For most bugs a diagnostics dump makes the report actionable - see
+        [Providing Diagnostics Data](https://github.com/rabits/ha-ef-ble/wiki/Providing-Diagnostics-Data-for-Debugging-or-Implementing-New-Sensors).
+
+        Paste a note here (e.g. "attached as `diagnostics.json`") and attach the file via
+        drag-and-drop in the main issue body after submitting. Diagnostics are safe to share
+        publicly - all potentially sensitive data is AES encrypted.
+
   - type: textarea
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: |
+        Paste any relevant Home Assistant log lines here. Enable debug logging for
+        `custom_components.ef_ble` if the default log level doesn't show anything useful.
+        This field is rendered as a shell code block - no need for backticks.
       render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage question / general discussion
+    url: https://github.com/rabits/ha-ef-ble/discussions
+    about: For setup help, troubleshooting, and general questions please use Discussions - the issue tracker is for actionable bug reports and feature requests.
+  - name: Contributing guide
+    url: https://github.com/rabits/ha-ef-ble/blob/main/CONTRIBUTING.md
+    about: How to report bugs, request features, contribute code, and what to expect from review.

--- a/.github/ISSUE_TEMPLATE/device_request.yaml
+++ b/.github/ISSUE_TEMPLATE/device_request.yaml
@@ -1,0 +1,126 @@
+name: New device support
+description: Request support for an EcoFlow device that isn't listed as supported yet
+title: "[Device]: "
+labels: ["new device"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping expand device coverage! Please skim the wiki first:
+
+        - **[Requesting Support for New Devices](https://github.com/rabits/ha-ef-ble/wiki/Requesting-Support-for-New-Devices)**
+          - overall flow for getting a new device supported.
+        - **[Providing Diagnostics Data](https://github.com/rabits/ha-ef-ble/wiki/Providing-Diagnostics-Data-for-Debugging-or-Implementing-New-Sensors)**
+          - how to capture the diagnostics file we need. Diagnostics are safe to share
+          publicly - all potentially sensitive data is AES encrypted.
+
+        Since v0.6.0 you can add an unsupported device through the integration in
+        diagnostic-collection mode, exercise its features, and attach the resulting file
+        here. That's almost always the fastest path to getting the device supported.
+
+        If you've already built a draft PR (vibe-coded or otherwise), link it below - but
+        please read the
+        [AI-assisted contributions](https://github.com/rabits/ha-ef-ble/blob/main/CONTRIBUTING.md#ai-assisted-contributions)
+        section of the contributing guide first so you know what to expect.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: The device is not listed in the [Supported Devices](https://github.com/rabits/ha-ef-ble#supported-devices) section of the README
+          required: true
+        - label: I searched existing issues and there isn't already a request for this device
+          required: true
+        - label: I've read the [Requesting Support for New Devices](https://github.com/rabits/ha-ef-ble/wiki/Requesting-Support-for-New-Devices) wiki page
+          required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      description: Full marketing name (e.g. "Delta 3 Pro", "Wave 3", "River 2 Max").
+      placeholder: "<device>"
+    validations:
+      required: true
+
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware version
+      description: |
+        Visible in the EcoFlow app under device settings / info. Leave blank if you
+        can't find it.
+
+  - type: input
+    id: sn-prefix
+    attributes:
+      label: Serial number prefix
+      description: |
+        **First 4 characters** of the device's serial number - the integration uses
+        this to recognise the device family. Please don't paste the full SN.
+      placeholder: "AB12"
+
+  - type: dropdown
+    id: bluetooth
+    attributes:
+      label: Bluetooth connection you tested with
+      multiple: false
+      options:
+        - Internal bluetooth adapter
+        - USB dongle
+        - ESPHome bluetooth proxy
+        - Haven't tried yet
+
+  - type: dropdown
+    id: diag-status
+    attributes:
+      label: Diagnostics collection status
+      multiple: false
+      options:
+        - "Attached a diagnostics dump"
+        - "Device connects but I haven't collected diagnostics yet"
+        - "Device won't connect / I can't collect diagnostics"
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        Paste a note here (e.g. "attached as `diagnostics.json`") and drag-and-drop the
+        file into the main issue body after submitting.
+
+        For the most useful capture, exercise as many features as you can while collecting
+        - charge, discharge, toggle AC / DC ports, plug in solar, etc. - so the dump
+        contains as many populated fields as possible.
+
+  - type: textarea
+    id: features
+    attributes:
+      label: Features you care about
+      description: |
+        Which sensors and controls do you most want to see supported for this device?
+        This helps prioritise if the protobuf schema is large.
+      placeholder: |
+        - Battery level
+        - PV input power
+        - AC output toggle
+        - Backup reserve slider
+
+  - type: input
+    id: draft-pr
+    attributes:
+      label: Draft PR (optional)
+      description: Link to a draft / WIP pull request if you've started one.
+      placeholder: "https://github.com/rabits/ha-ef-ble/pull/..."
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: |
+        Related links (Discord threads, forum posts, vendor docs), similar devices that
+        are already supported and might share a protocol, screenshots of the EcoFlow app,
+        etc.

--- a/.github/ISSUE_TEMPLATE/sensor_request.yaml
+++ b/.github/ISSUE_TEMPLATE/sensor_request.yaml
@@ -1,0 +1,114 @@
+name: New / missing / incorrect sensor
+description: A sensor or control that should exist, is missing, or shows a wrong value
+title: "[Sensor]: "
+labels: ["sensor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when:
+
+        - A sensor, switch, select, or number you expect is **missing** from the integration
+        - A sensor is **present but shows the wrong value** (compared to the EcoFlow app or
+          the device's own display)
+        - You'd like to see a **new sensor / control added** for a value the device exposes
+
+        For general bugs (disconnects, crashes, errors in the log) use the
+        [Bug report](https://github.com/rabits/ha-ef-ble/issues/new?template=bug_report.yaml)
+        template. For devices that aren't supported at all use the
+        [New device support](https://github.com/rabits/ha-ef-ble/issues/new?template=device_request.yaml)
+        template.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I'm running the latest release and the issue still reproduces
+          required: true
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of change are you asking for?
+      options:
+        - Missing sensor / control (never appeared)
+        - Wrong value (sensor exists but is incorrect)
+        - New sensor / control (value exists on the device but we don't expose it)
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      description: |
+        The marketing name of the device (e.g. "Delta Pro 3", "STREAM Ultra X")
+        and the firmware version if you know it.
+      placeholder: "STREAM Ultra X, firmware 1.0.2.123"
+    validations:
+      required: true
+
+  - type: input
+    id: sensor-name
+    attributes:
+      label: Sensor / control name
+      description: |
+        What is it called in Home Assistant (for existing sensors) or what would you
+        call it (for new ones)?
+      placeholder: "PV (2) Power"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's wrong or what's needed?
+      description: |
+        For **missing** sensors: where do you expect it to appear, and when did you last
+        see it work (if ever)?
+
+        For **wrong values**: what does HA show, and what does the EcoFlow app / device
+        display show for the same value at the same time? Screenshots of both side-by-side
+        are very helpful.
+
+        For **new** sensors: what does the value represent, where can you see it in the
+        EcoFlow app, and why would it be useful in HA (automations, energy dashboard, etc)?
+    validations:
+      required: true
+
+  - type: input
+    id: integration-version
+    attributes:
+      label: Integration version
+      placeholder: "0.8.4"
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        **Strongly recommended.** Sensor work almost always needs a diagnostics dump to
+        identify which protobuf field on the device holds the value.
+        See [Providing Diagnostics Data](https://github.com/rabits/ha-ef-ble/wiki/Providing-Diagnostics-Data-for-Debugging-or-Implementing-New-Sensors).
+
+        If possible, capture the dump while the value you care about is **non-zero** (e.g.
+        sun on the PV panels, load on the AC output, charger plugged in) so the relevant
+        field is populated. Diagnostics are safe to share publicly - all potentially
+        sensitive data is AES encrypted.
+
+        Paste a note here (e.g. "attached as `diagnostics.json`") and attach the file via
+        drag-and-drop in the main issue body after submitting.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: |
+        Screenshots of the EcoFlow app or the device display, relevant log lines, a link
+        to a Discord / forum thread discussing the same value, or a protobuf field name
+        if you already know which one maps to the sensor - all welcome.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,314 @@
+# Contributing to ha-ef-ble
+
+Thanks for considering a contribution! This integration is maintained by volunteers, and
+improvements of any size - bug reports, documentation fixes, new device support, new
+features - are very welcome.
+
+This document explains how to get set up, how to propose changes, and what to expect
+from the review process. If anything is unclear, open a
+[Discussion](https://github.com/rabits/ha-ef-ble/discussions) or draft issue and we'll
+help out.
+
+## Table of contents
+
+- [Code of conduct](#code-of-conduct)
+- [Ways to contribute](#ways-to-contribute)
+  - [Reporting bugs](#reporting-bugs)
+  - [Reporting a missing or incorrect sensor](#reporting-a-missing-or-incorrect-sensor)
+  - [Requesting support for a new device](#requesting-support-for-a-new-device)
+  - [Suggesting enhancements](#suggesting-enhancements)
+  - [Asking questions](#asking-questions)
+- [Your first code contribution](#your-first-code-contribution)
+- [Development setup](#development-setup)
+  - [Prerequisites](#prerequisites)
+  - [Clone and install](#clone-and-install)
+  - [Running tests](#running-tests)
+  - [Code style and linting](#code-style-and-linting)
+  - [Running the integration in Home Assistant](#running-the-integration-in-home-assistant)
+- [Making a pull request](#making-a-pull-request)
+  - [Branching and commits](#branching-and-commits)
+  - [AI-assisted contributions](#ai-assisted-contributions)
+- [Style guide](#style-guide)
+- [Project layout](#project-layout)
+
+## Code of conduct
+
+Be kind, patient, and constructive. Assume good intent, give concrete feedback, and
+remember that most contributors are hobbyists working in their spare time. Harassment,
+personal attacks, or hostility toward other contributors are not tolerated.
+
+## Ways to contribute
+
+All three of the flows below open through dedicated issue forms in
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) - blank issues are disabled, so
+pick the template that matches what you're reporting.
+
+### Reporting bugs
+
+For crashes, disconnects, errors in the log, or anything broken that isn't specifically
+a sensor value problem, use the
+[Bug report](https://github.com/rabits/ha-ef-ble/issues/new?template=bug_report.yaml)
+template. Before opening it:
+
+1. make sure you're on the latest release and that the bug still reproduces
+2. search existing [issues](https://github.com/rabits/ha-ef-ble/issues) to avoid
+   duplicates - add a 👍 to an existing report rather than opening a new one
+3. fill in every field the template asks for - integration and Home Assistant versions,
+   device model, Bluetooth connection type, any changed settings, and relevant log
+   output. Bug reports without this information are much harder to act on
+4. if the bug is sensor-value-shaped rather than crash-shaped, use the sensor template
+   below instead
+
+### Reporting a missing or incorrect sensor
+
+If a sensor is missing, shows the wrong value, or a value the device exposes isn't
+surfaced in Home Assistant, use the
+[New / missing / incorrect sensor](https://github.com/rabits/ha-ef-ble/issues/new?template=sensor_request.yaml)
+template. Almost all sensor reports need a diagnostics dump to identify the right
+protobuf field - see
+[Providing Diagnostics Data](https://github.com/rabits/ha-ef-ble/wiki/Providing-Diagnostics-Data-for-Debugging-or-Implementing-New-Sensors)
+for how to capture one. Diagnostics are safe to share publicly - all potentially
+sensitive data is AES encrypted. Capture the dump while the value you care about is
+**non-zero** (sun on the panels, load on the output, charger plugged in) so the
+relevant field is actually populated.
+
+### Requesting support for a new device
+
+If you own an EcoFlow device that isn't listed in the README's
+[Supported Devices](README.md#supported-devices) section, use the
+[New device support](https://github.com/rabits/ha-ef-ble/issues/new?template=device_request.yaml)
+template. It mirrors the flow described on the
+[Requesting Support for New Devices](https://github.com/rabits/ha-ef-ble/wiki/Requesting-Support-for-New-Devices)
+wiki page:
+
+1. add the unsupported device through the integration; it will run in a diagnostic
+   collection mode
+2. exercise different ports / features so the captured traffic covers the functionality
+   you care about
+3. attach the diagnostics file to the issue along with the device model, firmware, and
+   SN prefix the template asks for
+
+Some devices can't provide useful diagnostics over BLE. If your device won't connect for
+collection, open the issue anyway with the model and firmware version so we know
+there's demand.
+
+### Suggesting enhancements
+
+Before opening a pull request for a non-trivial change, please **open an issue first**
+describing the motivation and proposed approach. This avoids wasted effort on changes
+that don't fit the integration's scope or conflict with other ongoing work.
+
+Small, focused suggestions (wording fixes, obvious bug fixes, sensor defaults) don't
+need a pre-discussion issue - just send the PR.
+
+### Asking questions
+
+For usage questions, setup troubleshooting, or general discussion, use
+[GitHub Discussions](https://github.com/rabits/ha-ef-ble/discussions). The issue
+templates link to Discussions directly, and blank issues are disabled on the tracker -
+it's only for actionable bug reports and feature requests.
+
+## Your first code contribution
+
+Good starting points:
+
+- issues labelled
+  [`good first issue`](https://github.com/rabits/ha-ef-ble/labels/good%20first%20issue)
+  or [`help wanted`](https://github.com/rabits/ha-ef-ble/labels/help%20wanted)
+- documentation and translation fixes - typos, clarifications, missing sensor entries in
+  the README device tables
+- adding tests for existing device modules under `tests/eflib/`
+
+## Development setup
+
+### Prerequisites
+
+- **Python 3.13 or newer.** The project also runs on 3.14.
+- **[`uv`](https://github.com/astral-sh/uv)** for dependency management and tooling.
+  Install via the [official instructions](https://docs.astral.sh/uv/getting-started/installation/),
+  e.g. `curl -LsSf https://astral.sh/uv/install.sh | sh` on Linux/macOS.
+- **git**, and ideally a running Home Assistant instance to test the integration
+  end-to-end.
+
+### Clone and install
+
+```bash
+git clone https://github.com/rabits/ha-ef-ble.git
+cd ha-ef-ble
+uv sync --all-groups
+```
+
+This creates a `.venv/` with the runtime dependencies plus the `dev`, `test`, and `lint`
+groups - everything needed for the device-library tests and the code-style hooks.
+
+### Running tests
+
+```bash
+uv run pytest tests/eflib
+```
+
+Use `uv run pytest -k <name>` to run a single test and
+`uv run pytest --cov=custom_components.ef_ble` if you want coverage locally. Add tests
+for new device modules - `tests/eflib/test_powerstream.py` and
+`tests/eflib/test_river3.py` are reasonable templates.
+
+### Code style and linting
+
+Style and lint rules are enforced with [`prek`](https://github.com/j178/prek) (a fast
+Rust reimplementation of pre-commit) running the hooks defined in
+[`.pre-commit-config.yaml`](.pre-commit-config.yaml). The same hooks run in CI, so if
+`prek` is happy locally, CI will be too.
+
+The simplest way to run `prek` is through `uvx`, which fetches and runs it in an
+ephemeral environment - no separate install step needed:
+
+```bash
+uvx prek install              # enable the pre-commit git hook (one-time)
+uvx prek run                  # check files staged for the next commit
+uvx prek run --all-files      # check the whole repo (matches CI)
+```
+
+If you run these often and want to skip the per-invocation resolve, install `prek` as a
+persistent tool once with `uv tool install prek` and drop the `uvx` prefix.
+
+The hooks include [`ruff`](https://docs.astral.sh/ruff/) for linting and formatting
+(configured under `[tool.ruff]` in `pyproject.toml`),
+[`rumdl`](https://github.com/rvben/rumdl) for Markdown, and a handful of generic hygiene
+checks (trailing whitespace, line endings, YAML/TOML parsing, accidentally-committed
+private keys).
+
+### Running the integration in Home Assistant
+
+The simplest loop for manual testing is to symlink the component into a local Home
+Assistant config directory:
+
+```bash
+ln -s "$(pwd)/custom_components/ef_ble" /path/to/ha-config/custom_components/ef_ble
+```
+
+Restart Home Assistant after changes to Python code; translation and manifest changes
+may also require a restart rather than a hot-reload.
+
+## Making a pull request
+
+### Branching and commits
+
+- Fork the repo and create a feature branch off `main`:
+  `git checkout -b fix-device-sensor`.
+- Keep each PR focused on a single concern. If your branch fixes a bug *and* refactors
+  something nearby, prefer two PRs (or two commits that can be reviewed independently).
+- Write commit messages in the imperative mood ("Fix PV2 mapping on STREAM Ultra")
+
+### AI-assisted contributions
+
+Using LLMs / AI coding assistants is fine - most of us do nowadays. What matters is that
+**you own the code you submit**: you've read every line, understand why it's there,
+tested that it works, and can respond to review feedback without going back to the model
+for every answer.
+
+**Adding support for a new device is the one place where fully vibe-coded PRs are
+actively welcome.** It's genuinely easier to start from a rough LLM draft plus a
+diagnostics dump than from a blank module - even an imperfect draft gives us a concrete
+starting point, your field mappings, and proof that the device is reachable. Open the
+PR, link the diagnostics file, describe what you tested on the hardware, and be honest
+about which parts you didn't verify.
+
+That said: **we will not merge a vibe-coded new-device PR as-is.** Expect us to use it
+as a reference and rewrite the parts that need to match project patterns - renaming
+fields to line up with existing device modules, consolidating duplicated logic into
+shared transforms, dropping invented APIs, adjusting controls to the conventions in
+`eflib/entity/`, adding tests, and so on. The final commit that lands usually won't
+look much like your original branch. If that's not how you want your contribution
+handled, open an issue with the diagnostics dump instead and we'll pick it up from
+there.
+
+For everything else (bug fixes, refactors, changes to existing devices, protocol /
+packet handling), the bar is higher: unread LLM output, code the author can't explain,
+or changes that ignore existing patterns won't be reviewed in place. Re-read your diff
+top-to-bottom before opening the PR.
+
+## Style guide
+
+Most style is enforced by `ruff`, so the full rule set lives in `pyproject.toml`. A few
+non-obvious conventions:
+
+- **Python≥3.13** features are fair game: pattern matching, PEP 695 generics, `type`
+  statements, f-strings, the walrus operator, dataclasses.
+- **Type hints everywhere.** Public functions, class attributes, and fields declared via
+  `pb_field` / `raw_field` should have meaningful types. The shared transforms in
+  `custom_components/ef_ble/eflib/props/transforms.py` preserve `None` intentionally -
+  prefer them over inline `lambda` helpers.
+- **American English** for identifiers, comments, and user-facing strings.
+- **Logging:** use lazy `%s` formatting (`_LOGGER.debug("got %s", value)`), no trailing
+  periods, no sensitive data, and don't repeat the integration name - it's added
+  automatically.
+- **Async-safe** everywhere: no blocking I/O on the event loop, no `time.sleep`, don't
+  reuse `BleakClient` instances across connects. Use `asyncio.gather` instead of
+  sequential `await`s where possible.
+- **Exceptions:** raise the most specific type that fits (`ConfigEntryAuthFailed`,
+  `ConfigEntryNotReady`, `HomeAssistantError`, `ServiceValidationError`,
+  `UpdateFailed`).Keep `try` blocks minimal - only wrap the call that can raise, not the
+  data processing that follows. Bare `except Exception:` is reserved for config flows
+  and background tasks.
+- **Docstrings:** [NumPy style](https://numpydoc.readthedocs.io/en/latest/format.html)
+  without types in the docstring (`numpy-notypes` variant - argument and return types
+  belong in the signature, not duplicated in the docstring). Use a one-line docstring
+  for short descriptions; when a longer explanation is needed, start the summary on the
+  second line (matches Ruff's `D213`) and use `Parameters` / `Returns` sections for
+  non-obvious arguments and return values. **The summary line does not end with a
+  period.** Document *why*, not what - skip docstrings that only restate the function
+  name.
+
+  ```python
+  class Device(DeviceBase, ProtobufProps):
+      """STREAM AC"""
+
+  def pb_field(
+      attr: Any,
+      transform: Callable[[Any], Any] | None = None,
+  ) -> "ProtobufField[Any]":
+      """
+      Create field that allows value assignment from protocol buffer messages
+
+      Parameters
+      ----------
+      attr
+          Protobuf field attribute of instance returned from `proto_attr_mapper`
+      transform, optional
+          Function that is applied to raw protobuf value
+      """
+  ```
+
+## Project layout
+
+```text
+custom_components/ef_ble/
+├── __init__.py            # HA integration entry point
+├── config_flow.py         # Config flow for pairing
+├── sensor.py / switch.py  # Entity platforms
+├── translations/          # User-facing strings
+└── eflib/                 # Home Assistant-independent device library
+    ├── devices/           # One module per EcoFlow device family
+    ├── pb/                # Generated protobuf bindings (do not edit)
+    ├── props/             # Field descriptors, transforms, prop mixins
+    ├── entity/            # Control / dynamic entity helpers
+    └── ...
+tests/
+├── eflib/                 # Library-level tests (no Home Assistant)
+└── ha/                    # Integration tests using Home Assistant
+```
+
+New device support typically means:
+
+1. a new module in `custom_components/ef_ble/eflib/devices/` with a `Device` class and a
+   `SN_PREFIX` tuple.
+2. field definitions using `pb_field` / `raw_field` and shared transforms from
+   `eflib/props/transforms.py`
+3. controls defined with the `controls.*` decorators where applicable.
+4. tests under `tests/eflib/test_<device>.py`
+5. a new `<details>` block in the README listing the exposed sensors and controls
+
+---
+
+Thanks again for contributing. When in doubt, open an issue or draft PR early - it's
+much easier to course-correct at the design stage than at review time.

--- a/README.md
+++ b/README.md
@@ -722,13 +722,16 @@ Curious about how this integration was created? Check out the reverse engineerin
 
 ### Contributing
 
-Contributions are welcome! If you'd like to help improve this integration:
+Contributions are welcome! If you'd like to help improve this integration, please read
+**[CONTRIBUTING.md](CONTRIBUTING.md)** first - it covers development setup, running
+tests, code style, and the PR workflow.
 
-1. **Open an issue first** to discuss your proposed changes
+Short version:
+
+1. **Open an issue first** to discuss non-trivial changes
 2. Make sure your changes align with the integration's purpose
-3. Submit a pull request with clear descriptions
-
-This helps ensure your contributions can be successfully integrated.
+3. Submit a pull request with a clear description and, where applicable,
+   tests and README updates
 
 ### Requesting Support for New Devices
 


### PR DESCRIPTION
This PR adds a contributing guide and brings the issue templates up to date so first-time contributors and bug reporters have a clear on-ramp.

Full list of changes:
- **New `CONTRIBUTING.md`** - covering bug reports, diagnostics-based sensor / new-device requests, development setup with `uv`, running tests, the `uvx prek` workflow, PR conventions, an AI-assisted contributions policy (vibe-coded new-device PRs welcome as drafts but will be rewritten; higher bar elsewhere), and a numpy-notypes docstring style guide
- **Reworked `bug_report.yaml`** with pre-submission checks, separate Home Assistant and integration version fields, firmware-aware device-model input, a diagnostics attachment prompt linking to the wiki, and routing hints that send sensor-value and new-device reports to the two dedicated templates below
- **New templates** - `sensor_request.yaml` for missing / wrong / newly-requested sensors (with a dropdown to pick the flavour and an explicit "capture diagnostics while the value is non-zero" nudge), `device_request.yaml` for new-device support requests (model / firmware / SN prefix / BT connection / diagnostics status / priority features / optional draft PR link) with the wiki flow and `CONTRIBUTING.md#ai-assisted-contributions` linked in the header, and `config.yml` that disables blank issues and points usage questions at GitHub Discussions

