### PR TITLE
Add V4 wire format support, refactor Packet to dataclasses and align naming scheme for packets

### DIFF
--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -72,6 +72,7 @@ class PacketVersion(enum.StrEnum):
 
     V2 = "v2"
     V3 = "v3"
+    V4 = "v4"
 
     def to_num(self):
         """Get packet version as number used for device config"""

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -829,14 +829,14 @@ class Connection:
         reply_packet = Packet(
             packet.dst,  # Switching src to dst
             packet.src,  # Switching dst to src
-            packet.cmdSet,
-            packet.cmdId,
+            packet.cmd_set,
+            packet.cmd_id,
             packet.payload,
             0x01,
             0x01,  # Replacing 0 with 1
             packet.version,
             packet.seq,
-            packet.productId,
+            packet.product_id,
         )
         # Running reply asynchroneously
         self._add_task(self.sendPacket(reply_packet))
@@ -1057,8 +1057,8 @@ class Connection:
             # Handling autoAuthentication response
             if (
                 packet.src == self._auth_header_dst
-                and packet.cmdSet == 0x35
-                and packet.cmdId == 0x86
+                and packet.cmd_set == 0x35
+                and packet.cmd_id == 0x86
             ):
                 await self._check_auth(packet)
                 self._connection_attempt = 0

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -230,7 +230,7 @@ class DeviceBase(abc.ABC):
 
     async def packet_parse(self, data: bytes):
         """Parse packet"""
-        return Packet.fromBytes(data)
+        return Packet.from_bytes(data)
 
     @property
     def connection_log(self):

--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -119,7 +119,7 @@ class Delta2Base(DeviceBase, RawDataProps):
         processed = False
         self.reset_updated()
 
-        match packet.src, packet.cmdSet, packet.cmdId:
+        match packet.src, packet.cmd_set, packet.cmd_id:
             case 0x02, 0x20, 0x02:
                 self.update_from_bytes(self.pd_heart_type, packet.payload)
                 processed = True

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -126,7 +126,7 @@ class Delta3Base(DeviceBase, ProtobufProps):
         self._time_commands = TimeCommands(self)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     @classmethod
     def check(cls, sn):
@@ -136,14 +136,14 @@ class Delta3Base(DeviceBase, ProtobufProps):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x02 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(pd335_sys_pb2.DisplayPropertyUpload, packet.payload)
 
             processed = True
         elif (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             if len(packet.payload) == 0:
                 self._time_commands.async_send_all()

--- a/custom_components/ef_ble/eflib/devices/alternator_charger.py
+++ b/custom_components/ef_ble/eflib/devices/alternator_charger.py
@@ -99,20 +99,20 @@ class Device(DeviceBase, ProtobufProps):
         return f"Alternator Charger {model}".strip()
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
 
-        if packet.src == 0x14 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x14 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(
                 dc009_apl_comm_pb2.DisplayPropertyUpload, packet.payload
             )
             processed = True
         elif (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             if len(packet.payload) == 0:
                 self._time_commands.async_send_all()

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -30,7 +30,7 @@ class Device(Delta2Base):
     xt60_input_power = raw_field(pb_pd.dc_pv_input_watts)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     @property
     def pd_heart_type(self):

--- a/custom_components/ef_ble/eflib/devices/delta_pro.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro.py
@@ -119,12 +119,12 @@ class Device(DeviceBase, RawDataProps):
         )
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet) -> bool:
         self.reset_updated()
 
-        match packet.src, packet.cmdSet, packet.cmdId:
+        match packet.src, packet.cmd_set, packet.cmd_id:
             case 0x03, 0x03, 0x0E:
                 async with self._lock:
                     self._initialized = True

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -104,20 +104,20 @@ class Device(DeviceBase, ProtobufProps):
         return sn[:4] in cls.SN_PREFIX
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x02 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(mr521_pb2.DisplayPropertyUpload, packet.payload)
 
             processed = True
         elif (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -309,14 +309,14 @@ class Device(DeviceBase, ProtobufProps):
         self._time_commands = TimeCommands(self)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet) -> bool:
         """Process the incoming notifications from the device"""
 
         processed = True
         self.reset_updated()
-        match (packet.src, packet.cmdSet, packet.cmdId):
+        match (packet.src, packet.cmd_set, packet.cmd_id):
             case 0x02, 0x02, 0x01:
                 # Ping
                 self._logger.debug(

--- a/custom_components/ef_ble/eflib/devices/powerpulse_ev.py
+++ b/custom_components/ef_ble/eflib/devices/powerpulse_ev.py
@@ -81,13 +81,13 @@ class Device(DeviceBase, ProtobufProps):
         return f"PowerPulse EV Charger ({model})"
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet) -> bool:
         processed = False
         self.reset_updated()
 
-        match packet.src, packet.cmdSet, packet.cmdId:
+        match packet.src, packet.cmd_set, packet.cmd_id:
             case (0x02, 0x02, 0x21):
                 self.update_from_bytes(cp307_iot_pb2.HeartBeat, packet.payload)
                 processed = True

--- a/custom_components/ef_ble/eflib/devices/powerstream.py
+++ b/custom_components/ef_ble/eflib/devices/powerstream.py
@@ -72,13 +72,13 @@ class Device(DeviceBase, ProtobufProps):
         await self._conn.send_auth_status_packet()
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet) -> bool:
         self.reset_updated()
 
         msg = None
-        match packet.src, packet.cmdSet, packet.cmdId:
+        match packet.src, packet.cmd_set, packet.cmd_id:
             case (0x35, 0x14, 0x01):
                 msg = self.update_from_bytes(
                     wn511_sys_pb2.inverter_heartbeat, packet.payload

--- a/custom_components/ef_ble/eflib/devices/river2.py
+++ b/custom_components/ef_ble/eflib/devices/river2.py
@@ -106,7 +106,7 @@ class Device(DeviceBase, RawDataProps):
         self.reset_updated()
         processed = False
 
-        match (packet.src, packet.cmdSet, packet.cmdId):
+        match (packet.src, packet.cmd_set, packet.cmd_id):
             case 0x02, 0x20, 0x02:
                 self.update_from_bytes(DirectPdHeartbeatPack, packet.payload)
                 processed = True

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -146,19 +146,19 @@ class Device(DeviceBase, ProtobufProps):
         return f"River 3 {model}".strip()
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x02 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(pr705_pb2.DisplayPropertyUpload, packet.payload)
             processed = True
         elif (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -224,16 +224,16 @@ class Device(DeviceBase, ProtobufProps):
 
         prev_error_count = self.error_count
 
-        if packet.src == 0x0B and packet.cmdSet == 0x0C:
+        if packet.src == 0x0B and packet.cmd_set == 0x0C:
             if (
-                packet.cmdId == 0x01
+                packet.cmd_id == 0x01
             ):  # master_info, load_info, backup_info, watt_info, master_ver_info
                 self._logger.debug("Parsed data: %r", packet)
 
                 await self._conn.replyPacket(packet)
                 self.update_from_bytes(pd303_pb2.ProtoTime, packet.payload)
                 processed = True
-            elif packet.cmdId == 0x20:  # backup_incre_info
+            elif packet.cmd_id == 0x20:  # backup_incre_info
                 self._logger.debug("Parsed data: %r", packet)
 
                 await self._conn.replyPacket(packet)
@@ -241,19 +241,19 @@ class Device(DeviceBase, ProtobufProps):
 
                 processed = True
 
-            elif packet.cmdId == 0x21:  # is_get_cfg_flag
+            elif packet.cmd_id == 0x21:  # is_get_cfg_flag
                 self._logger.debug("Parsed data: %r", packet)
                 self.update_from_bytes(pd303_pb2.ProtoPushAndSet, packet.payload)
                 processed = True
 
-        elif packet.src == 0x35 and packet.cmdSet == 0x35 and packet.cmdId == 0x20:
+        elif packet.src == 0x35 and packet.cmd_set == 0x35 and packet.cmd_id == 0x20:
             self._logger.debug("Ping received: %r", packet)
             processed = True
 
         elif (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             # Device requested for time and timezone offset, so responding with that
             # otherwise it will not be able to send us predictions and config data
@@ -261,7 +261,7 @@ class Device(DeviceBase, ProtobufProps):
                 self._time_commands.async_send_all()
             processed = True
 
-        elif packet.src == 0x0B and packet.cmdSet == 0x01 and packet.cmdId == 0x55:
+        elif packet.src == 0x0B and packet.cmd_set == 0x01 and packet.cmd_id == 0x55:
             # Device reply that it's online and ready
             self._conn._add_task(self.set_config_flag(True))
             processed = True

--- a/custom_components/ef_ble/eflib/devices/smart_generator.py
+++ b/custom_components/ef_ble/eflib/devices/smart_generator.py
@@ -123,19 +123,19 @@ class Device(DeviceBase, ProtobufProps):
         return sn.startswith(cls.SN_PREFIX)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x08 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x08 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(ge305_sys_pb2.DisplayPropertyUpload, packet.payload)
             processed = True
         elif (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             if len(packet.payload) == 0:
                 self._time_commands.async_send_all()

--- a/custom_components/ef_ble/eflib/devices/smart_meter.py
+++ b/custom_components/ef_ble/eflib/devices/smart_meter.py
@@ -52,13 +52,13 @@ class Device(DeviceBase, ProtobufProps):
     l3_grid_energy = pb_field(pb.grid_connection_data_record.today_active_L3)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()
 
-        match packet.src, packet.cmdSet, packet.cmdId:
+        match packet.src, packet.cmd_set, packet.cmd_id:
             case (0x02, 0xFE, 0x15):
                 self.update_from_bytes(
                     bk622_common_pb2.DisplayPropertyUpload, packet.payload

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -181,7 +181,7 @@ class Device(DeviceBase, ProtobufProps):
         self._timer_task_chain: _TimerTaskChain | None = None
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     @classmethod
     def check(cls, sn):
@@ -191,7 +191,7 @@ class Device(DeviceBase, ProtobufProps):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x02 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(bk_series_pb2.DisplayPropertyUpload, packet.payload)
             processed = True
 

--- a/custom_components/ef_ble/eflib/devices/stream_microinverter.py
+++ b/custom_components/ef_ble/eflib/devices/stream_microinverter.py
@@ -48,13 +48,13 @@ class Device(DeviceBase, ProtobufProps):
         return sn[:4] in cls.SN_PREFIX
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x02 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x02 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(bk_series_pb2.DisplayPropertyUpload, packet.payload)
             processed = True
 

--- a/custom_components/ef_ble/eflib/devices/unsupported.py
+++ b/custom_components/ef_ble/eflib/devices/unsupported.py
@@ -85,7 +85,7 @@ class UnsupportedDevice(DeviceBase):
 
     async def data_parse(self, packet: Packet) -> bool:
         self._logger.log_filtered(
-            LogOptions.DESERIALIZED_MESSAGES, "Device message: %r", packet.payloadHex
+            LogOptions.DESERIALIZED_MESSAGES, "Device message: %r", packet.payload_hex
         )
         processed = False
 

--- a/custom_components/ef_ble/eflib/devices/unsupported.py
+++ b/custom_components/ef_ble/eflib/devices/unsupported.py
@@ -76,7 +76,7 @@ class UnsupportedDevice(DeviceBase):
                 f"/{self._diagnostics.packet_buffer_size}"
             )
 
-        packet = Packet.fromBytes(data)
+        packet = Packet.from_bytes(data)
         if Packet.is_invalid(packet):
             self.collecting_data = "error"
 
@@ -91,8 +91,8 @@ class UnsupportedDevice(DeviceBase):
 
         if (
             packet.src == 0x35
-            and packet.cmdSet == 0x01
-            and packet.cmdId == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
+            and packet.cmd_set == 0x01
+            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
         ):
             if len(packet.payload) == 0:
                 self._time_commands.async_send_all()

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -99,13 +99,13 @@ class Device(DeviceBase, RawDataProps):
         return sn.startswith(cls.SN_PREFIX)
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet) -> bool:
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x42 and packet.cmdSet == 0x42 and packet.cmdId == 0x50:
+        if packet.src == 0x42 and packet.cmd_set == 0x42 and packet.cmd_id == 0x50:
             self.update_from_bytes(KT210SAC, packet.payload)
             processed = True
 

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -116,7 +116,7 @@ class Device(DeviceBase, RawDataProps):
                 self.update_callback("drain_mode")
                 self.update_state("drain_mode", self.drain_mode)
 
-        # elif packet.src == 0x06 and packet.cmdSet == 0x20 and packet.cmdId == 0x32:
+        # elif packet.src == 0x06 and packet.cmd_set == 0x20 and packet.cmd_id == 0x32:
         #     processed = False
 
         for field_name in self.updated_fields:

--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -139,19 +139,19 @@ class Device(DeviceBase, ProtobufProps):
         return sn[:4] in cls.SN_PREFIX
 
     async def packet_parse(self, data: bytes):
-        return Packet.fromBytes(data, xor_payload=True)
+        return Packet.from_bytes(data, xor_payload=True)
 
     async def data_parse(self, packet: Packet):
         processed = False
         self.reset_updated()
 
-        if packet.src == 0x42 and packet.cmdSet == 0xFE and packet.cmdId == 0x15:
+        if packet.src == 0x42 and packet.cmd_set == 0xFE and packet.cmd_id == 0x15:
             self.update_from_bytes(
                 ac517_apl_comm_pb2.DisplayPropertyUpload, packet.payload
             )
             processed = True
 
-        if packet.src == 0x42 and packet.cmdSet == 0xFE and packet.cmdId == 0x16:
+        if packet.src == 0x42 and packet.cmd_set == 0xFE and packet.cmd_id == 0x16:
             self.update_from_bytes(
                 ac517_apl_comm_pb2.RuntimePropertyUpload, packet.payload
             )

--- a/custom_components/ef_ble/eflib/encpacket.py
+++ b/custom_components/ef_ble/eflib/encpacket.py
@@ -1,4 +1,6 @@
 import struct
+from dataclasses import dataclass
+from typing import ClassVar
 
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
@@ -6,49 +8,40 @@ from Crypto.Util.Padding import pad
 from .crc import crc16
 
 
+@dataclass(slots=True)
 class EncPacket:
     """Outside wrapper of Packet that actually transferred through the BLE channel"""
 
-    PREFIX = b"\x5a\x5a"
+    frame_type: int
+    payload_type: int
+    payload: bytes
+    cmd_id: int = 0
+    version: int = 0
+    enc_key: bytes | None = None
+    iv: bytes | None = None
 
-    FRAME_TYPE_COMMAND = 0x00
-    FRAME_TYPE_PROTOCOL = 0x01
-    FRAME_TYPE_PROTOCOL_INT = 0x10
+    PREFIX: ClassVar[bytes] = b"\x5a\x5a"
 
-    PAYLOAD_TYPE_VX_PROTOCOL = 0x00
-    PAYLOAD_TYPE_ODM_PROTOCOL = 0x04
+    FRAME_TYPE_COMMAND: ClassVar[int] = 0x00
+    FRAME_TYPE_PROTOCOL: ClassVar[int] = 0x01
+    FRAME_TYPE_PROTOCOL_INT: ClassVar[int] = 0x10
 
-    def __init__(
-        self,
-        frame_type,
-        payload_type,
-        payload,
-        cmd_id=0,
-        version=0,
-        enc_key=None,
-        iv=None,
-    ):
-        self._frame_type = frame_type
-        self._payload_type = payload_type
-        self._payload = payload
-        self._cmd_id = cmd_id
-        self._version = version
-        self._enc_key = enc_key
-        self._iv = iv
+    PAYLOAD_TYPE_VX_PROTOCOL: ClassVar[int] = 0x00
+    PAYLOAD_TYPE_ODM_PROTOCOL: ClassVar[int] = 0x04
 
-    def encryptPayload(self):
-        if self._enc_key is None and self._iv is None:
-            return self._payload  # Not encrypted
+    def encrypt_payload(self) -> bytes:
+        if self.enc_key is None or self.iv is None:
+            return self.payload  # Not encrypted
 
-        engine = AES.new(self._enc_key, AES.MODE_CBC, self._iv)
-        return engine.encrypt(pad(self._payload, AES.block_size))
+        engine = AES.new(self.enc_key, AES.MODE_CBC, self.iv)
+        return engine.encrypt(pad(self.payload, AES.block_size))
 
-    def toBytes(self):
+    def to_bytes(self) -> bytes:
         """Will serialize the internal data to bytes stream"""
-        payload = self.encryptPayload()
+        payload = self.encrypt_payload()
 
         data = (
-            EncPacket.PREFIX + struct.pack("<B", self._frame_type << 4) + b"\x01"
+            EncPacket.PREFIX + struct.pack("<B", self.frame_type << 4) + b"\x01"
         )  # Unknown byte
         data += struct.pack("<H", len(payload) + 2)  # +2 here is len(crc16)
         data += payload

--- a/custom_components/ef_ble/eflib/frame_assembler.py
+++ b/custom_components/ef_ble/eflib/frame_assembler.py
@@ -140,7 +140,17 @@ class RawHeaderAssembler(FrameAssembler):
             payload_length = struct.unpack("<H", data[2:4])[0]
             version = data[1]
 
-            inner_overhead = 15 if version >= 3 else 13
+            # Bytes after the 5-byte unencrypted header that are NOT payload_length:
+            #   V4  (0x04): outer[5..7] (3 B) + CRC16 (2 B) = 5   (payload_length includes 8-B inner cmd)
+            #   V3  (0x03): product+seq+zeros+addr+cmd (13 B) + CRC16 (2 B) = 15
+            #   V19 (0x13): same 13-B cmd section; no CRC16; \xbb\xbb is inside payload_length = 13
+            #   V2  (0x02): product+seq+zeros+addr+cmd (11 B) + CRC16 (2 B) = 13
+            if version == 4:
+                inner_overhead = 5
+            if version in (3, 4):
+                inner_overhead = 15
+            else:
+                inner_overhead = 13
             inner_len = inner_overhead + payload_length
             encrypted_len = (inner_len + 15) // 16 * 16
             frame_len = 5 + encrypted_len

--- a/custom_components/ef_ble/eflib/frame_assembler.py
+++ b/custom_components/ef_ble/eflib/frame_assembler.py
@@ -26,7 +26,7 @@ class FrameAssembler(ABC):
 
     @abstractmethod
     async def reassemble(self, data: bytes) -> list[bytes]:
-        """Decode wire bytes into decrypted payloads ready for Packet.fromBytes()"""
+        """Decode wire bytes into decrypted payloads ready for Packet.from_bytes()"""
 
 
 class EncPacketAssembler(FrameAssembler):
@@ -45,7 +45,7 @@ class EncPacketAssembler(FrameAssembler):
             0,
             self._encryption.session_key,
             self._encryption.iv,
-        ).toBytes()
+        ).to_bytes()
 
     async def reassemble(self, data: bytes) -> list[bytes]:
         if self._buffer:
@@ -147,7 +147,7 @@ class RawHeaderAssembler(FrameAssembler):
             #   V2  (0x02): product+seq+zeros+addr+cmd (11 B) + CRC16 (2 B) = 13
             if version == 4:
                 inner_overhead = 5
-            if version in (3, 4):
+            elif version >= 3:
                 inner_overhead = 15
             else:
                 inner_overhead = 13
@@ -182,7 +182,7 @@ class SimplePacketAssembler:
             EncPacket.FRAME_TYPE_COMMAND,
             EncPacket.PAYLOAD_TYPE_VX_PROTOCOL,
             payload,
-        ).toBytes()
+        ).to_bytes()
 
     def parse(self, data: bytes) -> bytes | None:
         """

--- a/custom_components/ef_ble/eflib/frame_assembler.py
+++ b/custom_components/ef_ble/eflib/frame_assembler.py
@@ -40,7 +40,7 @@ class EncPacketAssembler(FrameAssembler):
         return EncPacket(
             EncPacket.FRAME_TYPE_PROTOCOL,
             EncPacket.PAYLOAD_TYPE_VX_PROTOCOL,
-            packet.toBytes(),
+            packet.to_bytes(),
             0,
             0,
             self._encryption.session_key,
@@ -109,7 +109,7 @@ class RawHeaderAssembler(FrameAssembler):
         return False
 
     async def encode(self, packet: Packet) -> bytes:
-        raw = packet.toBytes()
+        raw = packet.to_bytes()
         header = raw[:5]
         inner = raw[5:]
         encrypted = await self._encryption.encrypt(inner)

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -1,5 +1,6 @@
 import logging
 import struct
+from functools import cached_property
 from typing import TypeGuard
 
 from .crc import crc8, crc16
@@ -8,8 +9,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Packet:
-    """Needed to parse and make the internal packet structure"""
-
     PREFIX = b"\xaa"
 
     NET_BLE_COMMAND_CMD_CHECK_RET_TIME = 0x53
@@ -39,9 +38,6 @@ class Packet:
         self._seq = seq if seq is not None else b"\x00\x00\x00\x00"
         self._product_id = product_id
 
-        # For representation
-        self._payload_hex = bytearray(self._payload).hex()
-
     @property
     def src(self):
         return self._src
@@ -62,9 +58,9 @@ class Packet:
     def payload(self):
         return self._payload
 
-    @property
-    def payloadHex(self):
-        return self._payload_hex
+    @cached_property
+    def payload_hex(self):
+        return bytearray(self._payload).hex()
 
     @property
     def dsrc(self):
@@ -87,24 +83,30 @@ class Packet:
         return self._product_id
 
     @staticmethod
-    def fromBytes(data: bytes, xor_payload: bool = False):
-        """Deserializes bytes stream into internal data"""
+    def fromBytes(
+        data: bytes, xor_payload: bool = False
+    ) -> "Packet | PacketV4 | InvalidPacket":
         if not data.startswith(Packet.PREFIX):
             error_msg = "Unable to parse packet - prefix is incorrect: %s"
             _LOGGER.error(error_msg, bytearray(data).hex())
             return InvalidPacket(error_msg % bytearray(data).hex())
 
         version = data[1]
-        if (version == 2 and len(data) < 18) or (version in [3, 4] and len(data) < 20):
+
+        if version == 4:
+            return PacketV4.fromBytes(data)
+
+        if (version == 2 and len(data) < 18) or (
+            version in [3, 0x13] and len(data) < 20
+        ):
             error_msg = "Unable to parse packet - too small: %s"
             _LOGGER.error(error_msg, bytearray(data).hex())
             return InvalidPacket(error_msg % bytearray(data).hex())
 
         payload_length = struct.unpack("<H", data[2:4])[0]
 
-        # there are also version 19 packets that do not contain crc16 checksum
-        if version in [2, 3, 4]:
-            # Check whole packet CRC16
+        # Version 19 (0x13, V4 protocol stack) has no CRC16 checksum
+        if version in [2, 3]:
             if crc16(data[:-2]) != struct.unpack("<H", data[-2:])[0]:
                 error_msg = "Unable to parse packet - incorrect CRC16: %s"
                 _LOGGER.error(error_msg, bytearray(data).hex())
@@ -121,7 +123,7 @@ class Packet:
 
         # Seq is used for multiple purposes, so leaving as is
         seq = data[6:10]
-        # data[10:12] # static zeroes?
+        # data[10:12] # static zeroes in V2/V3; used differently in V19
         src = data[12]
         dst = data[13]
 
@@ -139,7 +141,7 @@ class Packet:
 
             # If first byte of seq is set - we need to xor payload with it to get the
             # real data
-            if xor_payload and seq[0] != b"\x00":
+            if xor_payload and seq[0] != 0:
                 payload = bytes([c ^ seq[0] for c in payload])
 
             if version == 0x13 and payload[-2:] == b"\xbb\xbb":
@@ -196,7 +198,7 @@ class Packet:
             f"dst=0x{self._dst:02X}, "
             f"cmd_set=0x{self._cmd_set:02X}, "
             f"cmd_id=0x{self._cmd_id:02X}, "
-            f"payload=bytes.fromhex('{self._payload_hex}'), "
+            f"payload=bytes.fromhex('{self.payload_hex}'), "
             f"dsrc=0x{self._dsrc:02X}, "
             f"ddst=0x{self._ddst:02X}, "
             f"version=0x{self._version:02X}, "
@@ -206,9 +208,289 @@ class Packet:
         )
 
     @staticmethod
-    def is_invalid(packet: "Packet") -> TypeGuard["InvalidPacket"]:
-        """Check if the given packet is invalid"""
+    def is_invalid(
+        packet: "Packet | PacketV4 | InvalidPacket",
+    ) -> TypeGuard["InvalidPacket"]:
+        """Check if the given packet is invalid."""
         return isinstance(packet, InvalidPacket)
+
+
+class PacketV4:
+    """
+    V4 (version 0x04) packet codec.
+
+    Wire format:
+      [0]      0xaa prefix
+      [1]      version
+      [2:3]    payload_length LE
+      [4]      CRC8 of bytes 0..3 - also the XOR key for bytes [8:]
+      [5]      type_byte: enc_type[7:5] | check_type[4:2] | is_rw_cmd[1] | is_ack[0]
+      [6]      v4_type_a - part of V4 session info
+      [7]      v4_type_b - layer-3 XOR key when non-zero
+
+      [8]      cmd_flags  (inner cmd header byte 0, always has bit 5 set after XOR)
+      [9]      frame_type
+      [10]     payload_type
+      [11]     time_snap_b0
+      [12]     src
+      [13]     dst
+      [14]     cmd_set
+      [15]     cmd_id
+      [16:8+payload_length-1] data payload (for SHP3 - first 22 bytes is routing header)
+
+      [8+payload_length:-1]   CRC16 LE  (computed over obfuscated bytes)
+
+    Two layers of obfuscation are applied to the body:
+
+    1. CRC8 layer (always applied) - every byte from position [8] onward (inner cmd
+       header + payload) is XOR'd with the outer header CRC8 value at data[4]
+    2. v4_type_b layer (applied to the application payload only when v4_type_b is
+       non-zero)
+    """
+
+    PREFIX = b"\xaa"
+    VERSION = 0x04
+
+    def __init__(
+        self,
+        src,
+        dst,
+        cmd_set,
+        cmd_id,
+        payload=b"",
+        enc_type=0,
+        check_type=0,
+        is_rw_cmd=False,
+        is_ack=False,
+        frame_type=0,
+        payload_type=0,
+        cmd_flags=0x20,
+        v4_type_a=0,
+        v4_type_b=0,
+        time_snap_b0=0,
+    ):
+        self._src = src
+        self._dst = dst
+        self._cmd_set = cmd_set
+        self._cmd_id = cmd_id
+        self._payload = payload
+
+        self._enc_type = enc_type
+        self._check_type = check_type
+        self._is_rw_cmd = is_rw_cmd
+        self._is_ack = is_ack
+        self._frame_type = frame_type
+        self._payload_type = payload_type
+        self._cmd_flags = cmd_flags
+        self._v4_type_a = v4_type_a
+        self._v4_type_b = v4_type_b
+        self._time_snap_b0 = time_snap_b0
+
+    @property
+    def src(self):
+        return self._src
+
+    @property
+    def dst(self):
+        return self._dst
+
+    @property
+    def cmdSet(self):
+        return self._cmd_set
+
+    @property
+    def cmdId(self):
+        return self._cmd_id
+
+    @property
+    def payload(self):
+        return self._payload
+
+    @cached_property
+    def payload_hex(self):
+        return bytearray(self._payload).hex()
+
+    @property
+    def version(self):
+        return self.VERSION
+
+    @property
+    def encType(self):
+        return self._enc_type
+
+    @property
+    def checkType(self):
+        return self._check_type
+
+    @property
+    def isRwCmd(self):
+        return self._is_rw_cmd
+
+    @property
+    def isAck(self):
+        return self._is_ack
+
+    @property
+    def frameType(self):
+        return self._frame_type
+
+    @property
+    def payloadType(self):
+        return self._payload_type
+
+    @property
+    def cmdFlags(self):
+        return self._cmd_flags
+
+    @property
+    def v4TypeA(self):
+        return self._v4_type_a
+
+    @property
+    def v4TypeB(self):
+        return self._v4_type_b
+
+    @property
+    def timeSnapB0(self):
+        return self._time_snap_b0
+
+    @staticmethod
+    def fromBytes(data: bytes) -> "PacketV4 | InvalidPacket":
+        if len(data) < 18:
+            error_msg = "Unable to parse packet - too small: %s"
+            _LOGGER.error(error_msg, bytearray(data).hex())
+            return InvalidPacket(error_msg % bytearray(data).hex())
+
+        payload_length = struct.unpack("<H", data[2:4])[0]
+
+        if crc16(data[:-2]) != struct.unpack("<H", data[-2:])[0]:
+            error_msg = "Unable to parse packet - incorrect CRC16: %s"
+            _LOGGER.error(error_msg, bytearray(data).hex())
+            return InvalidPacket(error_msg % bytearray(data).hex())
+
+        if crc8(data[:4]) != data[4]:
+            error_msg = "Unable to parse packet - incorrect header CRC8: %s"
+            _LOGGER.error(error_msg, bytearray(data).hex())
+            return InvalidPacket(error_msg % bytearray(data).hex())
+
+        if payload_length < 8:
+            error_msg = "Unable to parse packet - V4 payload too short: %s"
+            _LOGGER.error(error_msg, bytearray(data).hex())
+            return InvalidPacket(error_msg % bytearray(data).hex())
+
+        # Outer header fields - bytes [5:7] are not obfuscated
+        type_byte = data[5]
+        enc_type = (type_byte >> 5) & 0x7
+        check_type = (type_byte >> 2) & 0x7
+        is_rw_cmd = bool((type_byte >> 1) & 0x1)
+        is_ack = bool(type_byte & 0x1)
+        v4_type_a = data[6]
+        v4_type_b = data[7]
+
+        # Layer-2 deobfuscate - XOR bytes [8:8+payload_length] with the CRC8 key
+        xor_key = data[4]
+        inner_and_payload = bytes(b ^ xor_key for b in data[8 : 8 + payload_length])
+
+        # Inner command header occupies the first 8 bytes of the deobfuscated block
+        cmd_flags = inner_and_payload[0]
+        frame_type = inner_and_payload[1]
+        payload_type_val = inner_and_payload[2]
+        time_snap_b0 = inner_and_payload[3]
+        src = inner_and_payload[4]
+        dst = inner_and_payload[5]
+        cmd_set = inner_and_payload[6]
+        cmd_id = inner_and_payload[7]
+
+        actual_payload_len = payload_length - 8
+        if actual_payload_len > 0:
+            payload = inner_and_payload[8 : 8 + actual_payload_len]
+            # Layer-3 deobfuscation - when v4_type_b is non-zero the device XOR-encodes
+            # the application payload with it before encryption
+            if v4_type_b:
+                payload = bytes(b ^ v4_type_b for b in payload)
+        else:
+            payload = b""
+
+        return PacketV4(
+            src=src,
+            dst=dst,
+            cmd_set=cmd_set,
+            cmd_id=cmd_id,
+            payload=payload,
+            enc_type=enc_type,
+            check_type=check_type,
+            is_rw_cmd=is_rw_cmd,
+            is_ack=is_ack,
+            frame_type=frame_type,
+            payload_type=payload_type_val,
+            cmd_flags=cmd_flags,
+            v4_type_a=v4_type_a,
+            v4_type_b=v4_type_b,
+            time_snap_b0=time_snap_b0,
+        )
+
+    def toBytes(self) -> bytes:
+        inner_cmd = bytes(
+            [
+                self._cmd_flags,
+                self._frame_type,
+                self._payload_type,
+                self._time_snap_b0,
+                self._src,
+                self._dst,
+                self._cmd_set,
+                self._cmd_id,
+            ]
+        )
+
+        payload_length = 8 + len(self._payload)
+
+        type_byte = (
+            ((self._enc_type & 0x7) << 5)
+            | ((self._check_type & 0x7) << 2)
+            | (int(self._is_rw_cmd) << 1)
+            | int(self._is_ack)
+        )
+
+        # Build outer header; CRC8 byte is also the XOR key for the inner content
+        data = PacketV4.PREFIX
+        data += struct.pack("<B", self.VERSION) + struct.pack("<H", payload_length)
+        crc8_byte = crc8(data)
+        data += struct.pack("<B", crc8_byte)
+        data += struct.pack("<B", type_byte)
+        data += struct.pack("<B", self._v4_type_a) + struct.pack("<B", self._v4_type_b)
+
+        if self._v4_type_b:
+            payload = bytes(b ^ self._v4_type_b for b in self._payload)
+        else:
+            payload = self._payload
+        inner_content = inner_cmd + payload
+        data += bytes(b ^ crc8_byte for b in inner_content)
+
+        data += struct.pack("<H", crc16(data))
+
+        return data
+
+    def __repr__(self):
+        return (
+            "PacketV4("
+            f"src=0x{self._src:02X}, "
+            f"dst=0x{self._dst:02X}, "
+            f"cmd_set=0x{self._cmd_set:02X}, "
+            f"cmd_id=0x{self._cmd_id:02X}, "
+            f"payload=bytes.fromhex('{self.payload_hex}'), "
+            f"enc_type={self._enc_type}, "
+            f"check_type={self._check_type}, "
+            f"is_rw_cmd={self._is_rw_cmd}, "
+            f"is_ack={self._is_ack}, "
+            f"frame_type=0x{self._frame_type:02X}, "
+            f"payload_type=0x{self._payload_type:02X}, "
+            f"cmd_flags=0x{self._cmd_flags:02X}, "
+            f"v4_type_a=0x{self._v4_type_a:02X}, "
+            f"v4_type_b=0x{self._v4_type_b:02X}, "
+            f"time_snap_b0=0x{self._time_snap_b0:02X}"
+            ")"
+        )
 
 
 class InvalidPacket(Packet):

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -1,7 +1,6 @@
 import logging
 import struct
 from dataclasses import dataclass
-from functools import cached_property
 from typing import ClassVar, TypeGuard
 
 from .crc import crc8, crc16
@@ -9,13 +8,12 @@ from .crc import crc8, crc16
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class Packet:
     """
-    V2 / V3 / V0x13 packet codec.
+    V2 / V3 / V0x13 packet codec
 
     V4 (version 0x04) is a different wire format and lives in `PacketV4`.
-    `Packet.fromBytes` dispatches to it transparently for v4 frames.
     """
 
     src: int
@@ -33,7 +31,7 @@ class Packet:
     NET_BLE_COMMAND_CMD_CHECK_RET_TIME: ClassVar[int] = 0x53
     NET_BLE_COMMAND_CMD_SET_RET_TIME: ClassVar[int] = 0x52
 
-    @cached_property
+    @property
     def payload_hex(self) -> str:
         return self.payload.hex()
 
@@ -169,10 +167,10 @@ class Packet:
         return isinstance(packet, InvalidPacket)
 
 
-@dataclass
+@dataclass(slots=True)
 class PacketV4:
     """
-    V4 (version 0x04) packet codec.
+    V4 (version 0x04) packet codec
 
     Wire format:
       [0]      0xaa prefix
@@ -226,7 +224,7 @@ class PacketV4:
     def version(self) -> int:
         return self.VERSION
 
-    @cached_property
+    @property
     def payload_hex(self) -> str:
         return self.payload.hex()
 
@@ -238,6 +236,11 @@ class PacketV4:
             return InvalidPacket(error_msg % bytearray(data).hex())
 
         payload_length = struct.unpack("<H", data[2:4])[0]
+
+        if len(data) != 8 + payload_length + 2:
+            error_msg = "Unable to parse packet - V4 length mismatch: %s"
+            _LOGGER.error(error_msg, bytearray(data).hex())
+            return InvalidPacket(error_msg % bytearray(data).hex())
 
         if crc16(data[:-2]) != struct.unpack("<H", data[-2:])[0]:
             error_msg = "Unable to parse packet - incorrect CRC16: %s"
@@ -372,8 +375,10 @@ class PacketV4:
 class InvalidPacket(Packet):
     """Represents an invalid packet that could not be parsed."""
 
+    __slots__ = ("error_message",)
+
     def __init__(self, error_message: str):
-        super().__init__(src=0, dst=0, cmd_set=0, cmd_id=0)
+        Packet.__init__(self, src=0, dst=0, cmd_set=0, cmd_id=0)
         self.error_message = error_message
 
     def __bool__(self) -> bool:

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -1,89 +1,44 @@
 import logging
 import struct
+from dataclasses import dataclass
 from functools import cached_property
-from typing import TypeGuard
+from typing import ClassVar, TypeGuard
 
 from .crc import crc8, crc16
 
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
 class Packet:
-    PREFIX = b"\xaa"
+    """
+    V2 / V3 / V0x13 packet codec.
 
-    NET_BLE_COMMAND_CMD_CHECK_RET_TIME = 0x53
-    NET_BLE_COMMAND_CMD_SET_RET_TIME = 0x52
+    V4 (version 0x04) is a different wire format and lives in `PacketV4`.
+    `Packet.fromBytes` dispatches to it transparently for v4 frames.
+    """
 
-    def __init__(
-        self,
-        src,
-        dst,
-        cmd_set,
-        cmd_id,
-        payload=b"",
-        dsrc=1,
-        ddst=1,
-        version=3,
-        seq=None,
-        product_id=0,
-    ):
-        self._src = src
-        self._dst = dst
-        self._cmd_set = cmd_set
-        self._cmd_id = cmd_id
-        self._payload = payload
-        self._dsrc = dsrc
-        self._ddst = ddst
-        self._version = version
-        self._seq = seq if seq is not None else b"\x00\x00\x00\x00"
-        self._product_id = product_id
+    src: int
+    dst: int
+    cmd_set: int
+    cmd_id: int
+    payload: bytes = b""
+    dsrc: int = 1
+    ddst: int = 1
+    version: int = 3
+    seq: bytes = b"\x00\x00\x00\x00"
+    product_id: int = 0
 
-    @property
-    def src(self):
-        return self._src
-
-    @property
-    def dst(self):
-        return self._dst
-
-    @property
-    def cmdSet(self):
-        return self._cmd_set
-
-    @property
-    def cmdId(self):
-        return self._cmd_id
-
-    @property
-    def payload(self):
-        return self._payload
+    PREFIX: ClassVar[bytes] = b"\xaa"
+    NET_BLE_COMMAND_CMD_CHECK_RET_TIME: ClassVar[int] = 0x53
+    NET_BLE_COMMAND_CMD_SET_RET_TIME: ClassVar[int] = 0x52
 
     @cached_property
-    def payload_hex(self):
-        return bytearray(self._payload).hex()
-
-    @property
-    def dsrc(self):
-        return self._dsrc
-
-    @property
-    def ddst(self):
-        return self._ddst
-
-    @property
-    def version(self):
-        return self._version
-
-    @property
-    def seq(self):
-        return self._seq
-
-    @property
-    def productId(self):
-        return self._product_id
+    def payload_hex(self) -> str:
+        return self.payload.hex()
 
     @staticmethod
-    def fromBytes(
+    def from_bytes(
         data: bytes, xor_payload: bool = False
     ) -> "Packet | PacketV4 | InvalidPacket":
         if not data.startswith(Packet.PREFIX):
@@ -94,7 +49,7 @@ class Packet:
         version = data[1]
 
         if version == 4:
-            return PacketV4.fromBytes(data)
+            return PacketV4.from_bytes(data)
 
         if (version == 2 and len(data) < 18) or (
             version in [3, 0x13] and len(data) < 20
@@ -159,51 +114,50 @@ class Packet:
             seq=seq,
         )
 
-    def toBytes(self):
-        """Will serialize the internal data to bytes stream"""
+    def to_bytes(self) -> bytes:
+        """Serialize the internal data to bytes stream."""
         # Header
         data = Packet.PREFIX
-        data += struct.pack("<B", self._version) + struct.pack("<H", len(self._payload))
+        data += struct.pack("<B", self.version) + struct.pack("<H", len(self.payload))
         # Header crc
         data += struct.pack("<B", crc8(data))
         # Additional data
-        data += self.productByte() + self._seq
+        data += self.product_byte() + self.seq
         data += b"\x00\x00"  # Unknown static zeroes, no strings attached right now
 
-        data += struct.pack("<B", self._src) + struct.pack("<B", self._dst)
+        data += struct.pack("<B", self.src) + struct.pack("<B", self.dst)
 
         # V3+ includes dsrc/ddst fields, V2 does not
-        if self._version >= 0x03:
-            data += struct.pack("<B", self._dsrc) + struct.pack("<B", self._ddst)
+        if self.version >= 0x03:
+            data += struct.pack("<B", self.dsrc) + struct.pack("<B", self.ddst)
 
-        data += struct.pack("<B", self._cmd_set) + struct.pack("<B", self._cmd_id)
+        data += struct.pack("<B", self.cmd_set) + struct.pack("<B", self.cmd_id)
         # Payload
-        data += self._payload
+        data += self.payload
         # Packet crc
         data += struct.pack("<H", crc16(data))
 
         return data
 
-    def productByte(self):
-        """Return magics depends on product id"""
-
-        if self._product_id >= 0:
+    def product_byte(self) -> bytes:
+        """Return magic depending on product id."""
+        if self.product_id >= 0:
             return b"\x0d"
         return b"\x0c"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "Packet("
-            f"src=0x{self._src:02X}, "
-            f"dst=0x{self._dst:02X}, "
-            f"cmd_set=0x{self._cmd_set:02X}, "
-            f"cmd_id=0x{self._cmd_id:02X}, "
+            f"src=0x{self.src:02X}, "
+            f"dst=0x{self.dst:02X}, "
+            f"cmd_set=0x{self.cmd_set:02X}, "
+            f"cmd_id=0x{self.cmd_id:02X}, "
             f"payload=bytes.fromhex('{self.payload_hex}'), "
-            f"dsrc=0x{self._dsrc:02X}, "
-            f"ddst=0x{self._ddst:02X}, "
-            f"version=0x{self._version:02X}, "
-            f"seq={self._seq}, "
-            f"product_id=0x{self._product_id:02X}"
+            f"dsrc=0x{self.dsrc:02X}, "
+            f"ddst=0x{self.ddst:02X}, "
+            f"version=0x{self.version:02X}, "
+            f"seq={self.seq}, "
+            f"product_id=0x{self.product_id:02X}"
             ")"
         )
 
@@ -215,6 +169,7 @@ class Packet:
         return isinstance(packet, InvalidPacket)
 
 
+@dataclass
 class PacketV4:
     """
     V4 (version 0x04) packet codec.
@@ -248,114 +203,35 @@ class PacketV4:
        non-zero)
     """
 
-    PREFIX = b"\xaa"
-    VERSION = 0x04
+    src: int
+    dst: int
+    cmd_set: int
+    cmd_id: int
+    payload: bytes = b""
+    enc_type: int = 0
+    check_type: int = 0
+    is_rw_cmd: bool = False
+    is_ack: bool = False
+    frame_type: int = 0
+    payload_type: int = 0
+    cmd_flags: int = 0x20
+    v4_type_a: int = 0
+    v4_type_b: int = 0
+    time_snap_b0: int = 0
 
-    def __init__(
-        self,
-        src,
-        dst,
-        cmd_set,
-        cmd_id,
-        payload=b"",
-        enc_type=0,
-        check_type=0,
-        is_rw_cmd=False,
-        is_ack=False,
-        frame_type=0,
-        payload_type=0,
-        cmd_flags=0x20,
-        v4_type_a=0,
-        v4_type_b=0,
-        time_snap_b0=0,
-    ):
-        self._src = src
-        self._dst = dst
-        self._cmd_set = cmd_set
-        self._cmd_id = cmd_id
-        self._payload = payload
-
-        self._enc_type = enc_type
-        self._check_type = check_type
-        self._is_rw_cmd = is_rw_cmd
-        self._is_ack = is_ack
-        self._frame_type = frame_type
-        self._payload_type = payload_type
-        self._cmd_flags = cmd_flags
-        self._v4_type_a = v4_type_a
-        self._v4_type_b = v4_type_b
-        self._time_snap_b0 = time_snap_b0
+    PREFIX: ClassVar[bytes] = b"\xaa"
+    VERSION: ClassVar[int] = 0x04
 
     @property
-    def src(self):
-        return self._src
-
-    @property
-    def dst(self):
-        return self._dst
-
-    @property
-    def cmdSet(self):
-        return self._cmd_set
-
-    @property
-    def cmdId(self):
-        return self._cmd_id
-
-    @property
-    def payload(self):
-        return self._payload
-
-    @cached_property
-    def payload_hex(self):
-        return bytearray(self._payload).hex()
-
-    @property
-    def version(self):
+    def version(self) -> int:
         return self.VERSION
 
-    @property
-    def encType(self):
-        return self._enc_type
-
-    @property
-    def checkType(self):
-        return self._check_type
-
-    @property
-    def isRwCmd(self):
-        return self._is_rw_cmd
-
-    @property
-    def isAck(self):
-        return self._is_ack
-
-    @property
-    def frameType(self):
-        return self._frame_type
-
-    @property
-    def payloadType(self):
-        return self._payload_type
-
-    @property
-    def cmdFlags(self):
-        return self._cmd_flags
-
-    @property
-    def v4TypeA(self):
-        return self._v4_type_a
-
-    @property
-    def v4TypeB(self):
-        return self._v4_type_b
-
-    @property
-    def timeSnapB0(self):
-        return self._time_snap_b0
+    @cached_property
+    def payload_hex(self) -> str:
+        return self.payload.hex()
 
     @staticmethod
-    def fromBytes(data: bytes) -> "PacketV4 | InvalidPacket":
+    def from_bytes(data: bytes) -> "PacketV4 | InvalidPacket":
         if len(data) < 18:
             error_msg = "Unable to parse packet - too small: %s"
             _LOGGER.error(error_msg, bytearray(data).hex())
@@ -429,27 +305,27 @@ class PacketV4:
             time_snap_b0=time_snap_b0,
         )
 
-    def toBytes(self) -> bytes:
+    def to_bytes(self) -> bytes:
         inner_cmd = bytes(
             [
-                self._cmd_flags,
-                self._frame_type,
-                self._payload_type,
-                self._time_snap_b0,
-                self._src,
-                self._dst,
-                self._cmd_set,
-                self._cmd_id,
+                self.cmd_flags,
+                self.frame_type,
+                self.payload_type,
+                self.time_snap_b0,
+                self.src,
+                self.dst,
+                self.cmd_set,
+                self.cmd_id,
             ]
         )
 
-        payload_length = 8 + len(self._payload)
+        payload_length = 8 + len(self.payload)
 
         type_byte = (
-            ((self._enc_type & 0x7) << 5)
-            | ((self._check_type & 0x7) << 2)
-            | (int(self._is_rw_cmd) << 1)
-            | int(self._is_ack)
+            ((self.enc_type & 0x7) << 5)
+            | ((self.check_type & 0x7) << 2)
+            | (int(self.is_rw_cmd) << 1)
+            | int(self.is_ack)
         )
 
         # Build outer header; CRC8 byte is also the XOR key for the inner content
@@ -458,12 +334,12 @@ class PacketV4:
         crc8_byte = crc8(data)
         data += struct.pack("<B", crc8_byte)
         data += struct.pack("<B", type_byte)
-        data += struct.pack("<B", self._v4_type_a) + struct.pack("<B", self._v4_type_b)
+        data += struct.pack("<B", self.v4_type_a) + struct.pack("<B", self.v4_type_b)
 
-        if self._v4_type_b:
-            payload = bytes(b ^ self._v4_type_b for b in self._payload)
+        if self.v4_type_b:
+            payload = bytes(b ^ self.v4_type_b for b in self.payload)
         else:
-            payload = self._payload
+            payload = self.payload
         inner_content = inner_cmd + payload
         data += bytes(b ^ crc8_byte for b in inner_content)
 
@@ -471,37 +347,37 @@ class PacketV4:
 
         return data
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             "PacketV4("
-            f"src=0x{self._src:02X}, "
-            f"dst=0x{self._dst:02X}, "
-            f"cmd_set=0x{self._cmd_set:02X}, "
-            f"cmd_id=0x{self._cmd_id:02X}, "
+            f"src=0x{self.src:02X}, "
+            f"dst=0x{self.dst:02X}, "
+            f"cmd_set=0x{self.cmd_set:02X}, "
+            f"cmd_id=0x{self.cmd_id:02X}, "
             f"payload=bytes.fromhex('{self.payload_hex}'), "
-            f"enc_type={self._enc_type}, "
-            f"check_type={self._check_type}, "
-            f"is_rw_cmd={self._is_rw_cmd}, "
-            f"is_ack={self._is_ack}, "
-            f"frame_type=0x{self._frame_type:02X}, "
-            f"payload_type=0x{self._payload_type:02X}, "
-            f"cmd_flags=0x{self._cmd_flags:02X}, "
-            f"v4_type_a=0x{self._v4_type_a:02X}, "
-            f"v4_type_b=0x{self._v4_type_b:02X}, "
-            f"time_snap_b0=0x{self._time_snap_b0:02X}"
+            f"enc_type={self.enc_type}, "
+            f"check_type={self.check_type}, "
+            f"is_rw_cmd={self.is_rw_cmd}, "
+            f"is_ack={self.is_ack}, "
+            f"frame_type=0x{self.frame_type:02X}, "
+            f"payload_type=0x{self.payload_type:02X}, "
+            f"cmd_flags=0x{self.cmd_flags:02X}, "
+            f"v4_type_a=0x{self.v4_type_a:02X}, "
+            f"v4_type_b=0x{self.v4_type_b:02X}, "
+            f"time_snap_b0=0x{self.time_snap_b0:02X}"
             ")"
         )
 
 
 class InvalidPacket(Packet):
-    """Represents an invalid packet that could not be parsed"""
+    """Represents an invalid packet that could not be parsed."""
 
     def __init__(self, error_message: str):
-        super().__init__(src=0, dst=0, cmd_set=0, cmd_id=0, payload=b"")
+        super().__init__(src=0, dst=0, cmd_set=0, cmd_id=0)
         self.error_message = error_message
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"InvalidPacket(error_message='{self.error_message}')"

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 @dataclass(slots=True)
 class Packet:
     """
-    V2 / V3 / V0x13 packet codec
+    V2 / V3 / V19 packet codec
 
     V4 (version 0x04) is a different wire format and lives in `PacketV4`.
     """

--- a/tests/eflib/test_delta2_max.py
+++ b/tests/eflib/test_delta2_max.py
@@ -10,12 +10,12 @@ def packet_sequence():
     Raw packet sequence captured from a Delta 2 Max device
 
     Packet types cover all main modules:
-    - src=0x03, cmdSet=0x20, cmdId=0x32: BmsHeartbeatBatteryMain
-    - src=0x03, cmdSet=0x03, cmdId=0x0e: AllKitDetailData
-    - src=0x02, cmdSet=0x20, cmdId=0x02: PdHeart
-    - src=0x03, cmdSet=0x20, cmdId=0x02: EmsDeltaHeartbeatPack
-    - src=0x05, cmdSet=0x20, cmdId=0x02: MpptHeart
-    - src=0x04, cmdSet=0x20, cmdId=0x02: InvDeltaHeartbeatPack
+    - src=0x03, cmd_set=0x20, cmd_id=0x32: BmsHeartbeatBatteryMain
+    - src=0x03, cmd_set=0x03, cmd_id=0x0e: AllKitDetailData
+    - src=0x02, cmd_set=0x20, cmd_id=0x02: PdHeart
+    - src=0x03, cmd_set=0x20, cmd_id=0x02: EmsDeltaHeartbeatPack
+    - src=0x05, cmd_set=0x20, cmd_id=0x02: MpptHeart
+    - src=0x04, cmd_set=0x20, cmd_id=0x02: InvDeltaHeartbeatPack
     """
     return [
         "aa02c000580efdc7000002510321203200010200000000330101024b26d0000087ffffff1001409c0000bf730000709900000400000064060d040d1210190f0000409c000016df9642000000000000000000000000030000020010050d040d040d040d050d050d040d040d050d050d050d050d060d050d050d050d051000110012001000100056302e312e320301ffff30303030303030303030303030303030510200009642000000004ebc93420600010202000000000000000000ffffffffffffffff00000000000000000000c642fac7",
@@ -49,19 +49,19 @@ async def test_delta2_max_parses_all_packets_successfully(device, packet_sequenc
 
     for i, hex_packet in enumerate(packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
-        expected_src, expected_cmdSet, expected_cmdId = expected_packets[i]
+        expected_src, expected_cmd_set, expected_cmd_id = expected_packets[i]
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == expected_src, (
             f"Packet {i} has unexpected src: {packet.src:#04x} != {expected_src:#04x}"
         )
-        assert packet.cmdSet == expected_cmdSet, (
-            f"Packet {i} has unexpected cmdSet: "
-            f"{packet.cmdSet:#04x} != {expected_cmdSet:#04x}"
+        assert packet.cmd_set == expected_cmd_set, (
+            f"Packet {i} has unexpected cmd_set: "
+            f"{packet.cmd_set:#04x} != {expected_cmd_set:#04x}"
         )
-        assert packet.cmdId == expected_cmdId, (
-            f"Packet {i} has unexpected cmdId: "
-            f"{packet.cmdId:#04x} != {expected_cmdId:#04x}"
+        assert packet.cmd_id == expected_cmd_id, (
+            f"Packet {i} has unexpected cmd_id: "
+            f"{packet.cmd_id:#04x} != {expected_cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_delta2_plus.py
+++ b/tests/eflib/test_delta2_plus.py
@@ -10,13 +10,13 @@ def packet_sequence():
     Raw packet sequence captured from a Delta 3 1500 (Delta 2 Plus) device
 
     Packet types cover all main modules:
-    - src=0x02, cmdSet=0x20, cmdId=0x02: PdHeart (power delivery)
-    - src=0x03, cmdSet=0x03, cmdId=0x0e: AllKitDetailData
-    - src=0x03, cmdSet=0x20, cmdId=0x02: EmsDeltaHeartbeatPack (energy management)
-    - src=0x03, cmdSet=0x20, cmdId=0x32: BmsHeartbeatBatteryMain (main battery)
-    - src=0x04, cmdSet=0x20, cmdId=0x02: InvDeltaHeartbeatPack (inverter)
-    - src=0x05, cmdSet=0x20, cmdId=0x02: MpptHeart (solar controller)
-    - src=0x06, cmdSet=0x20, cmdId=0x32: BmsHeartbeatBattery1 (addon battery)
+    - src=0x02, cmd_set=0x20, cmd_id=0x02: PdHeart (power delivery)
+    - src=0x03, cmd_set=0x03, cmd_id=0x0e: AllKitDetailData
+    - src=0x03, cmd_set=0x20, cmd_id=0x02: EmsDeltaHeartbeatPack (energy management)
+    - src=0x03, cmd_set=0x20, cmd_id=0x32: BmsHeartbeatBatteryMain (main battery)
+    - src=0x04, cmd_set=0x20, cmd_id=0x02: InvDeltaHeartbeatPack (inverter)
+    - src=0x05, cmd_set=0x20, cmd_id=0x02: MpptHeart (solar controller)
+    - src=0x06, cmd_set=0x20, cmd_id=0x32: BmsHeartbeatBattery1 (addon battery)
     """
     return [
         "aa028500422c000000000200022120024e000000004d0000010000000000623e01b501cde8ffff0000000000000000000000002978000000030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b5013e0100000000010000005005000000000000000c55",
@@ -52,19 +52,19 @@ async def test_delta2_plus_parses_all_packets_successfully(device, packet_sequen
 
     for i, hex_packet in enumerate(packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
-        expected_src, expected_cmdSet, expected_cmdId = expected_packets[i]
+        expected_src, expected_cmd_set, expected_cmd_id = expected_packets[i]
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == expected_src, (
             f"Packet {i} has unexpected src: {packet.src:#04x} != {expected_src:#04x}"
         )
-        assert packet.cmdSet == expected_cmdSet, (
-            f"Packet {i} has unexpected cmdSet: "
-            f"{packet.cmdSet:#04x} != {expected_cmdSet:#04x}"
+        assert packet.cmd_set == expected_cmd_set, (
+            f"Packet {i} has unexpected cmd_set: "
+            f"{packet.cmd_set:#04x} != {expected_cmd_set:#04x}"
         )
-        assert packet.cmdId == expected_cmdId, (
-            f"Packet {i} has unexpected cmdId: "
-            f"{packet.cmdId:#04x} != {expected_cmdId:#04x}"
+        assert packet.cmd_id == expected_cmd_id, (
+            f"Packet {i} has unexpected cmd_id: "
+            f"{packet.cmd_id:#04x} != {expected_cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_delta_pro.py
+++ b/tests/eflib/test_delta_pro.py
@@ -10,12 +10,12 @@ def packet_sequence():
     Packet sequence for testing Delta Pro device parsing.
 
     Packet types cover all main modules:
-    - src=0x03, cmdSet=0x03, cmdId=0x0e: AllKitDetailData
-    - src=0x03, cmdSet=0x20, cmdId=0x02: DirectEmsDeltaHeartbeatPack
-    - src=0x02, cmdSet=0x20, cmdId=0x02: DirectPdDeltaProHeartbeatPack
-    - src=0x03, cmdSet=0x20, cmdId=0x32: DirectBmsMDeltaHeartbeatPack
-    - src=0x04, cmdSet=0x20, cmdId=0x02: DirectInvDeltaHeartbeatPack
-    - src=0x05, cmdSet=0x20, cmdId=0x02: DirectMpptHeartbeatPack
+    - src=0x03, cmd_set=0x03, cmd_id=0x0e: AllKitDetailData
+    - src=0x03, cmd_set=0x20, cmd_id=0x02: DirectEmsDeltaHeartbeatPack
+    - src=0x02, cmd_set=0x20, cmd_id=0x02: DirectPdDeltaProHeartbeatPack
+    - src=0x03, cmd_set=0x20, cmd_id=0x32: DirectBmsMDeltaHeartbeatPack
+    - src=0x04, cmd_set=0x20, cmd_id=0x02: DirectInvDeltaHeartbeatPack
+    - src=0x05, cmd_set=0x20, cmd_id=0x02: DirectMpptHeartbeatPack
     """
     return [
         "aa025300860d0000000000000321030e0153000200014241545041434b3030310000000000000e000400012305000119010001000000005db1b3425a000000000000000000000000000000000000000000000000000000000000000000000000000000b98a",
@@ -49,19 +49,19 @@ async def test_delta_pro_parses_all_packets_successfully(device, packet_sequence
 
     for i, hex_packet in enumerate(packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
-        expected_src, expected_cmdSet, expected_cmdId = expected_packets[i]
+        expected_src, expected_cmd_set, expected_cmd_id = expected_packets[i]
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == expected_src, (
             f"Packet {i} has unexpected src: {packet.src:#04x} != {expected_src:#04x}"
         )
-        assert packet.cmdSet == expected_cmdSet, (
-            f"Packet {i} has unexpected cmdSet: "
-            f"{packet.cmdSet:#04x} != {expected_cmdSet:#04x}"
+        assert packet.cmd_set == expected_cmd_set, (
+            f"Packet {i} has unexpected cmd_set: "
+            f"{packet.cmd_set:#04x} != {expected_cmd_set:#04x}"
         )
-        assert packet.cmdId == expected_cmdId, (
-            f"Packet {i} has unexpected cmdId: "
-            f"{packet.cmdId:#04x} != {expected_cmdId:#04x}"
+        assert packet.cmd_id == expected_cmd_id, (
+            f"Packet {i} has unexpected cmd_id: "
+            f"{packet.cmd_id:#04x} != {expected_cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_dpu.py
+++ b/tests/eflib/test_dpu.py
@@ -9,9 +9,9 @@ def packet_sequence():
     """
     Raw packet sequence captured from a DPU device
 
-    Packet 1 (cmdId=0x04): BpInfoReport - battery pack info (3 battery packs)
-    Packet 2 (src=0x06, cmdId=0x10): APPParaHeartbeatReport - system parameters
-    Packet 3 (cmdId=0x03): AppShowHeartbeatReport - system status and power data
+    Packet 1 (cmd_id=0x04): BpInfoReport - battery pack info (3 battery packs)
+    Packet 2 (src=0x06, cmd_id=0x10): APPParaHeartbeatReport - system parameters
+    Packet 3 (cmd_id=0x03): AppShowHeartbeatReport - system status and power data
     """
     return [
         "aa134500662c14a1c602011d0221010102041e011c150c363114141494391414d4512caf2b54704c331e011c160c393114141494391414d4512cfe4154704c311e011c170c3f3114141494391414d4512cbb4454704c37f209",
@@ -34,24 +34,24 @@ async def test_dpu_parses_all_packets_successfully(device, packet_sequence):
     expected_packets = [
         (0x02, 0x02, 0x04),  # BpInfoReport
         (0x06, 0xFE, 0x10),  # APPParaHeartbeatReport (not handled by device)
-        (0x02, 0x02, 0x03),  # AppShowHeartbeatReport (cmdId=0x03, not 0x01)
+        (0x02, 0x02, 0x03),  # AppShowHeartbeatReport (cmd_id=0x03, not 0x01)
     ]
 
     for i, hex_packet in enumerate(packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
-        expected_src, expected_cmdSet, expected_cmdId = expected_packets[i]
+        expected_src, expected_cmd_set, expected_cmd_id = expected_packets[i]
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == expected_src, (
             f"Packet {i} has unexpected src: {packet.src:#04x} != {expected_src:#04x}"
         )
-        assert packet.cmdSet == expected_cmdSet, (
-            f"Packet {i} has unexpected cmdSet: "
-            f"{packet.cmdSet:#04x} != {expected_cmdSet:#04x}"
+        assert packet.cmd_set == expected_cmd_set, (
+            f"Packet {i} has unexpected cmd_set: "
+            f"{packet.cmd_set:#04x} != {expected_cmd_set:#04x}"
         )
-        assert packet.cmdId == expected_cmdId, (
-            f"Packet {i} has unexpected cmdId: "
-            f"{packet.cmdId:#04x} != {expected_cmdId:#04x}"
+        assert packet.cmd_id == expected_cmd_id, (
+            f"Packet {i} has unexpected cmd_id: "
+            f"{packet.cmd_id:#04x} != {expected_cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_powerpulse_ev.py
+++ b/tests/eflib/test_powerpulse_ev.py
@@ -9,7 +9,7 @@ def packet_sequence():
     """
     Raw packet sequence captured from a PowerPulse 9.6 kW EV charger (C101)
 
-    Heartbeat packets are src=0x02, cmdSet=0x02, cmdId=0x21 (HeartBeat).
+    Heartbeat packets are src=0x02, cmd_set=0x02, cmd_id=0x21 (HeartBeat).
     The charger is idle/unplugged (system_state=1) with line voltage ~239 V.
     """
     return [
@@ -35,11 +35,11 @@ async def test_powerpulse_ev_parses_all_packets_successfully(device, packet_sequ
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == 0x02, f"Packet {i} has unexpected src: {packet.src:#04x}"
-        assert packet.cmdSet == 0x02, (
-            f"Packet {i} has unexpected cmdSet: {packet.cmdSet:#04x}"
+        assert packet.cmd_set == 0x02, (
+            f"Packet {i} has unexpected cmd_set: {packet.cmd_set:#04x}"
         )
-        assert packet.cmdId == 0x21, (
-            f"Packet {i} has unexpected cmdId: {packet.cmdId:#04x}"
+        assert packet.cmd_id == 0x21, (
+            f"Packet {i} has unexpected cmd_id: {packet.cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_powerstream.py
+++ b/tests/eflib/test_powerstream.py
@@ -10,8 +10,8 @@ def packet_sequence():
     Raw packet sequence captured from a PowerStream device
 
     Packet types cover all main modules:
-    - src=0x35, cmdSet=0x14, cmdId=0x01: inverter_heartbeat (PV, battery, grid data)
-    - src=0x35, cmdSet=0x14, cmdId=0x04: inv_heartbeat_type2 (system parameters)
+    - src=0x35, cmd_set=0x14, cmd_id=0x01: inverter_heartbeat (PV, battery, grid data)
+    - src=0x35, cmd_set=0x14, cmd_id=0x04: inv_heartbeat_type2 (system parameters)
     """
     return [
         "aa13fe01b90de03d00000000352101011401e8e0f0e0f8e0c0e0c8e0d0e0d8e0a0e0a8e0b0e0b8e480e488e590e398e660e14ae268e148f770e1e278e1dc40e156e248e130e250e145fa58e1e520e154e128e14ce230e16be438e149e400e1e008e1e010e132e118e1ff60e2e068e20fc170e256e278e2e040e26ff248e201e250e210e158e2e020e213e330e2e238e2f100e2e008e2e010e2e018e2e060e310e168e3e070e3e078e3e040e38448e3e150e3e058e3e020e36de128e3e230e320de38e345b600e300c608e3e010e310e118e3e060e4e068e4e070e410e178e410e140e4e748e4e050e4e058e4e020e4e028e4e030e4400bc138e43010d300e4e508e4e810e4e018e420de60e5e068e5e070e510e178e5391f1f1f1f1f1f1f1fe140e5e048e55ee150e53fd058e510ce70e600d078e620de40e6e148e6c350e66d1f15c258e6e120e64c53745ee628e624755e0de630e6203166601d1f1f1f1fe138e6e100e6e008e605e110e6e068e7e170e76c79372ce678e7aa40e7d448e7e050e7e058e78820e720de28e7e038e774ba00e7e608e7e315e7b9d699a918e73ce660e856f168e872f870e8e078e8e040e8e048e872f850e8c858e8e020e8391f1f1f1f1f1f1f1fe128e8e038e8e000e8e008e8fa10e8e018e8e360e9e068e9e070e9e078e9e040e9e048e9e050e9e020e970fc28e967433c2ce630e970fc38e9e000e9e008e9e010e9e018e9e060eae0ef43",
@@ -37,19 +37,19 @@ async def test_powerstream_parses_all_packets_successfully(device, packet_sequen
 
     for i, hex_packet in enumerate(packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
-        expected_src, expected_cmdSet, expected_cmdId = expected_packets[i]
+        expected_src, expected_cmd_set, expected_cmd_id = expected_packets[i]
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == expected_src, (
             f"Packet {i} has unexpected src: {packet.src:#04x} != {expected_src:#04x}"
         )
-        assert packet.cmdSet == expected_cmdSet, (
-            f"Packet {i} has unexpected cmdSet: "
-            f"{packet.cmdSet:#04x} != {expected_cmdSet:#04x}"
+        assert packet.cmd_set == expected_cmd_set, (
+            f"Packet {i} has unexpected cmd_set: "
+            f"{packet.cmd_set:#04x} != {expected_cmd_set:#04x}"
         )
-        assert packet.cmdId == expected_cmdId, (
-            f"Packet {i} has unexpected cmdId: "
-            f"{packet.cmdId:#04x} != {expected_cmdId:#04x}"
+        assert packet.cmd_id == expected_cmd_id, (
+            f"Packet {i} has unexpected cmd_id: "
+            f"{packet.cmd_id:#04x} != {expected_cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_river3.py
+++ b/tests/eflib/test_river3.py
@@ -9,7 +9,7 @@ def packet_sequence():
     """
     Raw packet sequence captured from a River 3 UPS device
 
-    All packets are DisplayPropertyUpload (src=0x02, cmdSet=0xFE, cmdId=0x15)
+    All packets are DisplayPropertyUpload (src=0x02, cmd_set=0xFE, cmd_id=0x15)
     containing battery, power, and system status information
     """
     return [
@@ -37,11 +37,11 @@ async def test_river3_parses_all_packets_successfully(device, packet_sequence):
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == 0x02, f"Packet {i} has unexpected src: {packet.src:#04x}"
-        assert packet.cmdSet == 0xFE, (
-            f"Packet {i} has unexpected cmdSet: {packet.cmdSet:#04x}"
+        assert packet.cmd_set == 0xFE, (
+            f"Packet {i} has unexpected cmd_set: {packet.cmd_set:#04x}"
         )
-        assert packet.cmdId == 0x15, (
-            f"Packet {i} has unexpected cmdId: {packet.cmdId:#04x}"
+        assert packet.cmd_id == 0x15, (
+            f"Packet {i} has unexpected cmd_id: {packet.cmd_id:#04x}"
         )
 
 

--- a/tests/eflib/test_shp2.py
+++ b/tests/eflib/test_shp2.py
@@ -46,9 +46,9 @@ async def test_shp2_parses_all_packets_successfully(device, packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == 0x0B, f"Packet {i} has unexpected src"
-        assert packet.cmdSet == 0x0C, f"Packet {i} has unexpected cmdSet"
-        assert packet.cmdId == expected_cmd_ids[i], (
-            f"Packet {i} has unexpected cmdId: 0x{packet.cmdId:02x}"
+        assert packet.cmd_set == 0x0C, f"Packet {i} has unexpected cmd_set"
+        assert packet.cmd_id == expected_cmd_ids[i], (
+            f"Packet {i} has unexpected cmd_id: 0x{packet.cmd_id:02x}"
         )
 
 

--- a/tests/eflib/test_wave3.py
+++ b/tests/eflib/test_wave3.py
@@ -33,11 +33,11 @@ async def test_wave3_parses_all_packets_successfully(device, packet_sequence):
 
         assert packet is not None, f"Packet {i} failed to parse"
         assert packet.src == 0x42, f"Packet {i} has unexpected src: {packet.src:#04x}"
-        assert packet.cmdSet == 0xFE, (
-            f"Packet {i} has unexpected cmdSet: {packet.cmdSet:#04x}"
+        assert packet.cmd_set == 0xFE, (
+            f"Packet {i} has unexpected cmd_set: {packet.cmd_set:#04x}"
         )
-        assert packet.cmdId == 0x15, (
-            f"Packet {i} has unexpected cmdId: {packet.cmdId:#04x}"
+        assert packet.cmd_id == 0x15, (
+            f"Packet {i} has unexpected cmd_id: {packet.cmd_id:#04x}"
         )
 
 


### PR DESCRIPTION
This PR adds support for the V4 wire format used by newer EcoFlow devices (e.g. SHP3, DPU X) and refactors the existing `Packet` and `EncPacket` into a dataclasses and aligns naming of their attributes to snake case.

Full list of changes:

- **Added `PacketV4` codec for the V4 wire format** - implements the two-layer XOR obfuscation (CRC8 key over the inner cmd block plus optional `v4_type_b` key over the application payload) and a CRC16 trailer computed over the obfuscated bytes - V4 packets are used
- **Transparent dispatch from `Packet.from_bytes`** - V3 and V4 frames go through the same entrypoint; when `version == 0x04` parsing is delegated to `PacketV4.from_bytes` so device modules don't need to know which wire format they received
- **Refactored `Packet`/`PacketV4` to `@dataclass`** - replaces the hand-written `__init__`/property soup with a dataclass and a few `cached_property` derived fields, and aligns naming to snake_case (`cmd_set`/`cmd_id`/`payload_hex`/`product_id` instead of mixed `cmdSet`/`cmdId`/`payloadHex`/`productId`); call sites across all device modules updated accordingly - no behavioural changes
