### PR TITLE
Fix energy backup and backup reserve not working on latest Delta 3 firmwares, fix D3+ DC (2) Max Amp slider

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta3_classic.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_classic.py
@@ -1,7 +1,7 @@
 from ..entity import controls
 from ..entity.base import dynamic
 from ..pb import pd335_sys_pb2
-from ..props import pb_field
+from ..props import computed_field, pb_field
 from ..props.transforms import flow_is_on, out_power
 from ._delta3_base import Delta3Base, pb
 
@@ -12,8 +12,7 @@ class Device(Delta3Base):
     SN_PREFIX = (b"P321",)
     NAME_PREFIX = "EF-P3"
 
-    energy_backup = pb_field(pb.energy_backup_en)
-    energy_backup_battery_level = pb_field(pb.energy_backup_start_soc)
+    energy_backup_battery_level = pb_field(pb.backup_reverse_soc)
 
     dc_12v_port = pb_field(pb.flow_info_12v, flow_is_on)
     dc12v_output_power = pb_field(pb.pow_get_12v, out_power)
@@ -33,6 +32,10 @@ class Device(Delta3Base):
         pb.energy_strategy_operate_mode,
         lambda x: x.operate_tou_mode_open if x else None,
     )
+
+    @computed_field
+    def energy_backup(self):
+        return self.energy_strategy_self_powered
 
     @controls.switch(disable_grid_bypass, enabled=False)
     async def enable_disable_grid_bypass(self, enabled: bool):
@@ -61,11 +64,10 @@ class Device(Delta3Base):
     @controls.switch(energy_backup)
     async def enable_energy_backup(self, enabled: bool):
         config = pd335_sys_pb2.ConfigWrite()
-        config.cfg_energy_backup.energy_backup_en = enabled
+        config.cfg_energy_strategy_operate_mode.operate_self_powered_open = enabled
         if enabled and self.energy_backup_battery_level is not None:
-            config.cfg_energy_backup.energy_backup_start_soc = (
-                self.energy_backup_battery_level or 50
-            )
+            config.cfg_backup_reverse_soc = self.energy_backup_battery_level or 50
+
         await self._send_config_packet(config)
 
     @controls.battery(

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -73,12 +73,14 @@ class NumberType(ControlType):
 
         control = self
 
-        async def _check_limits(device: "DeviceBase", value: float) -> bool:
+        async def _check_limits(
+            device: "DeviceBase", value: float, *args, **kwargs
+        ) -> bool:
             if (low := _resolve(control.min, device)) is not None:
                 value = max(low, value)
             if (high := _resolve(control.max, device)) is not None:
                 value = min(high, value)
-            return await func(device, value)
+            return await func(device, value, *args, **kwargs)
 
         self.set_value_func = _check_limits
 


### PR DESCRIPTION
This PR fixes the energy backup switch and backup reserve level on all Delta 3 models against the latest device firmware, where the protobuf fields driving these controls are no longer present - we were using fields used in River 3 which may have been included in Delta 3 firmware, but that wasn't the right way to do it as app does not recognize `Energy Backup` as a control - it is a `Self Powered Mode`.

PR also fixes second Delta 3 Plus DC slider that was broken when porting it to controls - limit checking decorator was not passing all args to the decorated method. Supersedes #302 