### PR TITLE
Add fan running binary sensor to River 3 and Delta 3

### DIFF
--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -124,6 +124,11 @@ def shp2_channel(
 _BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "error_happened": problem("error", entity_category=EntityCategory.DIAGNOSTIC),
     "plugged_in_ac": plug(),
+    "fan_running": _make_desc(
+        BinarySensorDeviceClass.RUNNING,
+        enabled=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     "error_occurred": problem(
         enabled=False,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -97,9 +97,17 @@ class Delta3Base(DeviceBase, ProtobufProps):
 
     ac_charging_speed = pb_field(pb.plug_in_info_ac_in_chg_pow_max)
 
+    _pcs_fan_level = pb_field(pb.pcs_fan_level)
+
     @computed_field
     def error_occurred(self) -> bool:
         return bool(self.error_code)
+
+    @computed_field
+    def fan_running(self) -> bool | None:
+        if self._pcs_fan_level is None:
+            return None
+        return self._pcs_fan_level > 0
 
     @computed_field
     def max_ac_charging_power(self) -> int:

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -94,10 +94,17 @@ class Device(DeviceBase, ProtobufProps):
     remaining_time_discharging = pb_field(pb.cms_dsg_rem_time)
 
     error_code = pb_field(pb.errcode)
+    _pcs_fan_level = pb_field(pb.pcs_fan_level)
 
     @computed_field
     def error_occurred(self) -> bool:
         return bool(self.error_code)
+
+    @computed_field
+    def fan_running(self) -> bool | None:
+        if self._pcs_fan_level is None:
+            return None
+        return self._pcs_fan_level > 0
 
     @computed_field
     def input_energy(self) -> int | None:

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -1,6 +1,12 @@
 {
   "entity": {
     "binary_sensor": {
+      "fan_running": {
+        "default": "mdi:fan",
+        "state": {
+          "off": "mdi:fan-off"
+        }
+      },
       "channel_is_enabled": {
         "default": "mdi:power-plug-battery",
         "state": {

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -331,6 +331,9 @@
       "plugged_in_ac": {
         "name": "AC Plugged In"
       },
+      "fan_running": {
+        "name": "Fan Running"
+      },
       "storm_mode": {
         "name": "Storm Mode"
       },
@@ -813,9 +816,6 @@
       },
       "condensate_water_level": {
         "name": "Water Level"
-      },
-      "pcs_fan_level": {
-        "name": "Fan Level"
       },
       "in_drainage": {
         "name": "In Drainage"


### PR DESCRIPTION
This PR exposes a new `Fan Running` binary sensor on all River 3 and Delta 3 variants. 
