### PR TITLE
Add second DC port to Delta 3 Ultra Plus

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta3_ultra_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_ultra_plus.py
@@ -1,10 +1,11 @@
 from collections.abc import Sequence
 
-from ..entity import controls
+from ..entity import controls, dynamic
 from ..pb import pd335_sys_pb2
-from ..props import pb_field, repeated_pb_field_type
-from ..props.transforms import flow_is_on, out_power
+from ..props import computed_field, pb_field, repeated_pb_field_type
+from ..props.transforms import flow_is_on, out_power, pround
 from . import delta3, delta3_ultra
+from ._delta3_base import DCPortState, _DcAmpSettingField, _DcChargingMaxField
 
 pb = delta3.pb
 
@@ -31,7 +32,29 @@ class Device(delta3_ultra.Device):
     ac_power_2_3 = _ACPortPower(4)
 
     usbc3_output_power = pb_field(pb.pow_get_typec3, out_power)
-    max_ac_charging_power = pb_field(pb.plug_in_info_ac_in_chg_hal_pow_max)
+
+    dc_charging_max_amps_2 = _DcAmpSettingField(
+        pd335_sys_pb2.PV_CHG_VOL_SPEC_12V, pd335_sys_pb2.PV_PLUG_INDEX_2
+    )
+    dc_charging_current_max_2 = _DcChargingMaxField(pd335_sys_pb2.PV_CHG_VOL_SPEC_12V)
+
+    dc_port_2_input_power = pb_field(pb.pow_get_pv2, pround(2))
+    dc_port_2_state = pb_field(pb.plug_in_info_pv2_type, DCPortState.from_value)
+
+    @computed_field
+    def solar_input_power_2(self) -> float:
+        if (
+            self.dc_port_2_state is DCPortState.SOLAR
+            and self.dc_port_2_input_power is not None
+        ):
+            return round(self.dc_port_2_input_power, 2)
+        return 0
+
+    @controls.current(dc_charging_max_amps_2, max=dynamic(dc_charging_current_max_2))
+    async def set_dc_charging_amps_max_2(self, value: float) -> bool:
+        return await self.set_dc_charging_amps_max(
+            value, plug_index=pd335_sys_pb2.PV_PLUG_INDEX_2
+        )
 
     @controls.outlet(ac_ports_2)
     async def enable_ac_ports_2(self, enabled: bool):


### PR DESCRIPTION
The Delta 3 Ultra Plus exposes a second DC input plug that was not yet wired up. This PR adds the corresponding DC port 2 input power and port state sensors, the derived solar input power, and a current limit control for second dc port.