### PR TITLE
Add missing MR54 serial num suffix to Delta Pro 3

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -35,7 +35,7 @@ class DCPortState(IntFieldValue):
 class Device(DeviceBase, ProtobufProps):
     """Delta Pro 3"""
 
-    SN_PREFIX = (b"MR51",)
+    SN_PREFIX = (b"MR51", b"MR54")
     NAME_PREFIX = "EF-DP3"
 
     battery_level = pb_field(pb.cms_batt_soc, pround(2))


### PR DESCRIPTION
This PR adds serial number prefix MR54 to Delta Pro 3 that we missed.