### PR TITLE
Fix entity callback registration when device lacks the property

### DIFF
--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -49,7 +49,7 @@ class EcoflowEntity(Entity):
         get_state: Callable[[Any], SkipWrite | Any] = lambda x: x,
         default_state: Any = None,
     ):
-        if prop_name is None:
+        if prop_name is None or not hasattr(self._device, prop_name):
             return
 
         if value := getattr(self._device, prop_name, None):


### PR DESCRIPTION
This PR fixes the AC ports switch on River 2 Max (and likely other unmigrated devices) being stuck as unavailable since 0.8.6. Fix is generic rather than tweaking the deprecated entry: _register_update_callback now bails out when the device doesn't expose prop_name, so any future description referencing a state or availability prop the device doesn't implement is silently ignored instead of bricking the entity.

