### PR TITLE
Update connection.py

### DIFF
--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -784,10 +784,39 @@ class Connection:
         await self.add_error(err)
 
     async def _start_notify(self, callback: Callable):
-        kwargs = {}
+        # Dictionary to hold extra arguments for the notify call
+        notifyKeywordArguments = {}
+        
+        # Check if the bluez start notify option is enabled in the integration settings
         if self._options.bluez_start_notify:
-            kwargs["bluez"] = {"use_start_notify": True}
-        await self._client.start_notify(self._notify_characteristic, callback, **kwargs)
+            notifyKeywordArguments["bluez"] = {"use_start_notify": True}
+            
+        # Assign the target characteristic to a descriptive camel case variable
+        notifyCharacteristic = self._notify_characteristic
+        
+        try:
+            # Attempt to start the notification stream with the device using the constructed arguments
+            await self._client.start_notify(notifyCharacteristic, callback, **notifyKeywordArguments)
+        except Exception as caughtException:
+            # Convert the exception to a string so we can check the specific error message
+            errorMessage = str(caughtException)
+            
+            # Check if BlueZ has locked the notification channel in a ghost state
+            if "Notify acquired" in errorMessage or "NotPermitted" in errorMessage:
+                self._logger.warning("Ghost notify state detected. Attempting to clear the lock.")
+                
+                # Attempt to explicitly stop the notification to force BlueZ to release the lock
+                try:
+                    await self._client.stop_notify(notifyCharacteristic)
+                except Exception:
+                    # Ignore secondary errors while trying to clear the broken state
+                    pass
+                
+                # Force a disconnect to tear down the broken connection completely
+                await self.disconnect()
+            
+            # Re-raise the exception to abort the current setup attempt cleanly
+            raise caughtException
 
     async def _sendRequest(self, send_data: bytes, response_handler=None):
         # Make sure the connection is here, otherwise just skipping


### PR DESCRIPTION
Added logic (from Gemini).   fix(connection): catch and clear BlueZ ghost notify locks on brownout from stream inverters restarting each dawn and not completing the connection due to brownouts.

fix(connection): catch and clear BlueZ ghost notify locks on brownout

Wrap the `_start_notify` call in a try-except block to intercept  `[org.bluez.Error.NotPermitted] Notify acquired` exceptions. 

When solar-powered devices like Stream microinverters drop offline  abruptly during dawn/dusk power fluctuations, BlueZ can retain a  "ghost" subscription lock on the notification characteristic.  Subsequent reconnection attempts then fail permanently with a  NotPermitted error, jamming the host machine's Bluetooth adapter  and exhausting available connection slots.

This patch addresses the issue by:
- Catching "Notify acquired" or "NotPermitted" error strings during setup
- Explicitly calling `stop_notify` to force BlueZ to release the lock
- Executing a hard `disconnect()` to clean up the broken socket state
- Re-raising the exception to allow a clean retry on the next cycle

Error Evidence from Logs:
-------------------------
Logger: custom_components.ef_ble.eflib.connection
Captured exception: [org.bluez.Error.NotPermitted] Notify acquired:
  File "/config/custom_components/ef_ble/eflib/connection.py", line 757, in sendRequest
    await self._sendRequest(send_data, response_handler)
  File "/config/custom_components/ef_ble/eflib/connection.py", line 796, in _sendRequest
    await self._start_notify(response_handler)
  File "/config/custom_components/ef_ble/eflib/connection.py", line 783, in _start_notify
    await self._client.start_notify(self._notify_characteristic, callback, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/bleak/__init__.py", line 846, in start_notify
    await self._backend.start_notify( characteristic, wrapped_callback, bluez=bluez, cb=cb, **kwargs )
  File "/usr/local/lib/python3.14/site-packages/bleak/backends/bluezdbus/client.py", line 940, in start_notify
    assert_reply(reply)
BleakDBusError: [org.bluez.Error.NotPermitted] Notify acquired

Exception occured when sending request on try 0: [org.bluez.Error.Failed] Not connected, retrying in 1 seconds
Exception occured when sending request on try 0: [org.bluez.Error.NotPermitted] Notify acquired, retrying in 1 seconds