### PR TITLE
Fix region mapping for EF login from config flow, refactor login into a separate class

### DIFF
--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -644,12 +644,12 @@ class _SchemaBuilder:
                             CONF_REGION,
                             SelectSelector(
                                 SelectSelectorConfig(
-                                    options=[r.value.lower() for r in Region],
+                                    options=[r.value for r in Region],
                                     mode=SelectSelectorMode.DROPDOWN,
                                     translation_key="ecoflow_region",
                                 ),
                             ),
-                            Region.AUTO.value.lower(),
+                            Region.AUTO.value,
                         )
                         .build()
                     ),

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import enum
 import logging
 from collections.abc import Iterable, Mapping
@@ -64,6 +63,7 @@ from .eflib.connection import Connection, ConnectionState
 from .eflib.device_mappings import battery_name_from_device
 from .eflib.exceptions import AuthErrors
 from .eflib.logging_util import LogOptions
+from .eflib.login import EcoFlowLogin, Region
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -511,61 +511,11 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         return Store(self.hass, self.VERSION, f"{DOMAIN}.user_id")
 
     async def _ecoflow_login(self, email: str, password: str, region: str):
-        session = async_get_clientsession(self.hass)
-
-        identifier = email.strip()
-        digits = identifier.removeprefix("+").replace(" ", "")
-        is_phone = digits.isdigit() and 6 <= len(digits) <= 15
-
-        match region:
-            case "EU":
-                base_url = "api-e.ecoflow.com"
-            case "US":
-                base_url = "api-a.ecoflow.com"
-            case "CN":
-                base_url = "api-cn.ecoflow.com"
-            case _:
-                # Auto-detect: phone numbers default to China region
-                base_url = "api-cn.ecoflow.com" if is_phone else "api.ecoflow.com"
-
-        json_payload = {
-            "scene": "IOT_APP",
-            "appVersion": "1.0.0",
-            "password": base64.b64encode(password.encode()).decode(),
-            "oauth": {
-                "bundleId": "com.ef.EcoFlow",
-            },
-            "userType": "ECOFLOW",
-        }
-
-        if region == "CN" and not is_phone:
-            return {"login": "CN region requires phone number, not email"}
-        if region not in ("EU", "US") and is_phone:
-            json_payload["phone"] = identifier.removeprefix("+86")
-        else:
-            json_payload["email"] = identifier
-
-        async with session.post(
-            url=f"https://{base_url}/auth/login",
-            json=json_payload,
-            headers={
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
-        ) as response:
-            if not response.ok:
-                return {
-                    "login": (
-                        f"Login failed with status code {response.status}: "
-                        f"{response.reason}"
-                    )
-                }
-
-            result_json = await response.json()
-            if result_json["code"] != "0":
-                return {"login": f"Login failed: '{result_json['message']}'"}
-
-            self._user_id = result_json["data"]["user"]["userId"]
+        client = EcoFlowLogin(async_get_clientsession(self.hass))
+        result = await client.login(email, password, region)
+        if result.error or result.user_id is None:
+            return {"login": result.error or "Login failed"}
+        self._user_id = result.user_id
         self._email = ""
         self._collapsed = True
         return {}
@@ -691,7 +641,15 @@ class _SchemaBuilder:
                         .optional(CONF_EMAIL, str)
                         .optional(CONF_PASSWORD, str)
                         .optional(
-                            CONF_REGION, vol.In(["Auto", "EU", "US", "CN"]), "Auto"
+                            CONF_REGION,
+                            SelectSelector(
+                                SelectSelectorConfig(
+                                    options=[r.value.lower() for r in Region],
+                                    mode=SelectSelectorMode.DROPDOWN,
+                                    translation_key="ecoflow_region",
+                                ),
+                            ),
+                            Region.AUTO.value.lower(),
                         )
                         .build()
                     ),

--- a/custom_components/ef_ble/eflib/login.py
+++ b/custom_components/ef_ble/eflib/login.py
@@ -1,0 +1,144 @@
+"""EcoFlow account login helper - region routing and credential probing."""
+
+import base64
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import aiohttp
+
+
+class Region(StrEnum):
+    """Selectable EcoFlow account region"""
+
+    AUTO = "Auto"
+    US = "US"
+    EU = "EU"
+    APAC = "APAC"
+    CN = "CN"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "Region | None":
+        if isinstance(value, str):
+            for member in cls:
+                if member.value.lower() == value.lower():
+                    return member
+        return None
+
+    @property
+    def base_url(self) -> str | None:
+        """API host for this region, or None for AUTO."""
+        return _REGION_BASE_URL.get(self)
+
+
+_REGION_BASE_URL: dict[Region, str] = {
+    Region.US: "api.ecoflow.com",
+    Region.EU: "api-e.ecoflow.com",
+    Region.APAC: "api-a.ecoflow.com",
+    Region.CN: "api-cn.ecoflow.com",
+}
+
+# AUTO tries these in order for email logins. Phone numbers go straight to CN.
+# `api.ecoflow.com` does not route to other regions automatically, so each endpoint
+# has to be probed explicitly.
+_AUTO_REGION_ORDER: tuple[Region, ...] = (Region.US, Region.EU, Region.APAC)
+
+
+@dataclass(frozen=True)
+class LoginResult:
+    user_id: str | None = None
+    error: str | None = None
+
+
+class EcoFlowLogin:
+    """Resolve an EcoFlow user ID from credentials and a region selection"""
+
+    def __init__(self, session: aiohttp.ClientSession) -> None:
+        self._session = session
+
+    @staticmethod
+    def is_phone_identifier(identifier: str) -> bool:
+        """Return True if identifier looks like an E.164 phone number"""
+        digits = identifier.removeprefix("+").replace(" ", "")
+        return digits.isdigit() and 6 <= len(digits) <= 15
+
+    async def login(
+        self,
+        identifier: str,
+        password: str,
+        region: Region | str,
+    ) -> LoginResult:
+        """
+        Resolve an EcoFlow user ID for the given identifier/password/region
+
+        In `Region.AUTO` mode phone numbers go to `CN` and email addresses are tried
+        against the regions in `_AUTO_REGION_ORDER` until one succeeds.
+        """
+        region = Region(region)
+        identifier = identifier.strip()
+        is_phone = self.is_phone_identifier(identifier)
+
+        if region is Region.CN and not is_phone:
+            return LoginResult(error="CN region requires phone number, not email")
+
+        if region is Region.AUTO:
+            regions_to_try = (Region.CN,) if is_phone else _AUTO_REGION_ORDER
+        else:
+            regions_to_try = (region,)
+
+        last_error: str | None = None
+        for try_region in regions_to_try:
+            assert try_region.base_url is not None
+            result = await self._try_login_at(
+                try_region.base_url,
+                identifier,
+                password,
+                is_phone=is_phone and try_region is Region.CN,
+            )
+            if result.user_id is not None:
+                return result
+            last_error = result.error
+
+        return LoginResult(error=last_error)
+
+    async def _try_login_at(
+        self,
+        base_url: str,
+        identifier: str,
+        password: str,
+        *,
+        is_phone: bool,
+    ) -> LoginResult:
+        json_payload: dict[str, Any] = {
+            "scene": "IOT_APP",
+            "appVersion": "1.0.0",
+            "password": base64.b64encode(password.encode()).decode(),
+            "oauth": {"bundleId": "com.ef.EcoFlow"},
+            "userType": "ECOFLOW",
+        }
+        if is_phone:
+            json_payload["phone"] = identifier.removeprefix("+86")
+        else:
+            json_payload["email"] = identifier
+
+        async with self._session.post(
+            url=f"https://{base_url}/auth/login",
+            json=json_payload,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        ) as response:
+            if not response.ok:
+                return LoginResult(
+                    error=(
+                        f"Login failed with status code {response.status}: "
+                        f"{response.reason}"
+                    )
+                )
+
+            result_json = await response.json()
+            if result_json["code"] != "0":
+                return LoginResult(error=f"Login failed: '{result_json['message']}'")
+
+            return LoginResult(user_id=result_json["data"]["user"]["userId"])

--- a/custom_components/ef_ble/eflib/login.py
+++ b/custom_components/ef_ble/eflib/login.py
@@ -9,13 +9,15 @@ import aiohttp
 
 
 class Region(StrEnum):
-    """Selectable EcoFlow account region"""
+    """Selectable EcoFlow API host"""
 
-    AUTO = "Auto"
-    US = "US"
-    EU = "EU"
-    APAC = "APAC"
-    CN = "CN"
+    AUTO = "auto"
+    API = "api"
+    API_E = "api-e"
+    API_A = "api-a"
+    API_J = "api-j"
+    API_R = "api-r"
+    API_CN = "api-cn"
 
     @classmethod
     def _missing_(cls, value: object) -> "Region | None":
@@ -27,21 +29,10 @@ class Region(StrEnum):
 
     @property
     def base_url(self) -> str | None:
-        """API host for this region, or None for AUTO."""
-        return _REGION_BASE_URL.get(self)
-
-
-_REGION_BASE_URL: dict[Region, str] = {
-    Region.US: "api.ecoflow.com",
-    Region.EU: "api-e.ecoflow.com",
-    Region.APAC: "api-a.ecoflow.com",
-    Region.CN: "api-cn.ecoflow.com",
-}
-
-# AUTO tries these in order for email logins. Phone numbers go straight to CN.
-# `api.ecoflow.com` does not route to other regions automatically, so each endpoint
-# has to be probed explicitly.
-_AUTO_REGION_ORDER: tuple[Region, ...] = (Region.US, Region.EU, Region.APAC)
+        """Hostname for this region, or None for `AUTO`"""
+        if self is Region.AUTO:
+            return None
+        return f"{self.value}.ecoflow.com"
 
 
 @dataclass(frozen=True)
@@ -68,38 +59,24 @@ class EcoFlowLogin:
         password: str,
         region: Region | str,
     ) -> LoginResult:
-        """
-        Resolve an EcoFlow user ID for the given identifier/password/region
-
-        In `Region.AUTO` mode phone numbers go to `CN` and email addresses are tried
-        against the regions in `_AUTO_REGION_ORDER` until one succeeds.
-        """
+        """Resolve an EcoFlow user ID for the given identifier/password/region"""
         region = Region(region)
         identifier = identifier.strip()
         is_phone = self.is_phone_identifier(identifier)
 
-        if region is Region.CN and not is_phone:
-            return LoginResult(error="CN region requires phone number, not email")
+        if region is Region.API_CN and not is_phone:
+            return LoginResult(error="api-cn requires phone number, not email")
 
         if region is Region.AUTO:
-            regions_to_try = (Region.CN,) if is_phone else _AUTO_REGION_ORDER
-        else:
-            regions_to_try = (region,)
+            region = Region.API_CN if is_phone else Region.API
 
-        last_error: str | None = None
-        for try_region in regions_to_try:
-            assert try_region.base_url is not None
-            result = await self._try_login_at(
-                try_region.base_url,
-                identifier,
-                password,
-                is_phone=is_phone and try_region is Region.CN,
-            )
-            if result.user_id is not None:
-                return result
-            last_error = result.error
-
-        return LoginResult(error=last_error)
+        assert region.base_url is not None
+        return await self._try_login_at(
+            region.base_url,
+            identifier,
+            password,
+            is_phone=is_phone and region is Region.API_CN,
+        )
 
     async def _try_login_at(
         self,

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -48,7 +48,7 @@
               "region": "Region"
             },
             "data_description": {
-              "region": "Pick the region matching your EcoFlow account: US (Global / United States), EU (Europe), APAC (Asia-Pacific), CN (China - phone number only). Auto tries CN for phone numbers and US/EU/APAC in order otherwise. If you receive an \"Account does not exist\" message, try selecting your region explicitly."
+              "region": "Pick the EcoFlow API host matching your account. Auto uses api.ecoflow.com for email and api-cn for phone numbers. Your account may live on a different host than your actual geographic region, so if you receive an \"Account does not exist\" message, try selecting the host explicitly."
             }
           },
           "log_options": {
@@ -105,7 +105,7 @@
               "region": "Region"
             },
             "data_description": {
-              "region": "Pick the region matching your EcoFlow account: US (Global / United States), EU (Europe), APAC (Asia-Pacific), CN (China - phone number only). Auto tries CN for phone numbers and US/EU/APAC in order otherwise. If you receive an \"Account does not exist\" message, try selecting your region explicitly."
+              "region": "Pick the EcoFlow API host matching your account. Auto uses api.ecoflow.com for email and api-cn for phone numbers. Your account may live on a different host than your actual geographic region, so if you receive an \"Account does not exist\" message, try selecting the host explicitly."
             }
           },
           "log_options": {
@@ -157,7 +157,7 @@
               "region": "Region"
             },
             "data_description": {
-              "region": "Pick the region matching your EcoFlow account: US (Global / United States), EU (Europe), APAC (Asia-Pacific), CN (China - phone number only). Auto tries CN for phone numbers and US/EU/APAC in order otherwise. If you receive an \"Account does not exist\" message, try selecting your region explicitly."
+              "region": "Pick the EcoFlow API host matching your account. Auto uses api.ecoflow.com for email and api-cn for phone numbers. Your account may live on a different host than your actual geographic region, so if you receive an \"Account does not exist\" message, try selecting the host explicitly."
             }
           },
           "log_options": {
@@ -1115,11 +1115,13 @@
   "selector": {
     "ecoflow_region": {
       "options": {
-        "auto": "Auto (try CN for phone, US / EU / APAC for email)",
-        "us": "US (Global / United States)",
-        "eu": "EU (Europe)",
-        "apac": "APAC (Asia-Pacific)",
-        "cn": "CN (China - phone number only)"
+        "auto": "Auto (api.ecoflow.com for email, api-cn for phone)",
+        "api": "api.ecoflow.com (Global / US)",
+        "api-e": "api-e.ecoflow.com (Europe)",
+        "api-a": "api-a.ecoflow.com (Asia / MEA)",
+        "api-j": "api-j.ecoflow.com (Japan)",
+        "api-r": "api-r.ecoflow.com (Russia)",
+        "api-cn": "api-cn.ecoflow.com (China - phone number only)"
       }
     }
   }

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -48,7 +48,7 @@
               "region": "Region"
             },
             "data_description": {
-              "region": "For China phone number login, use CN or Auto. If you receive an \"Account does not exist\" message, try selecting a different region."
+              "region": "Pick the region matching your EcoFlow account: US (Global / United States), EU (Europe), APAC (Asia-Pacific), CN (China - phone number only). Auto tries CN for phone numbers and US/EU/APAC in order otherwise. If you receive an \"Account does not exist\" message, try selecting your region explicitly."
             }
           },
           "log_options": {
@@ -105,7 +105,7 @@
               "region": "Region"
             },
             "data_description": {
-              "region": "For China phone number login, use CN or Auto. If you receive an \"Account does not exist\" message, try selecting a different region."
+              "region": "Pick the region matching your EcoFlow account: US (Global / United States), EU (Europe), APAC (Asia-Pacific), CN (China - phone number only). Auto tries CN for phone numbers and US/EU/APAC in order otherwise. If you receive an \"Account does not exist\" message, try selecting your region explicitly."
             }
           },
           "log_options": {
@@ -157,7 +157,7 @@
               "region": "Region"
             },
             "data_description": {
-              "region": "For China phone number login, use CN or Auto. If you receive an \"Account does not exist\" message, try selecting a different region."
+              "region": "Pick the region matching your EcoFlow account: US (Global / United States), EU (Europe), APAC (Asia-Pacific), CN (China - phone number only). Auto tries CN for phone numbers and US/EU/APAC in order otherwise. If you receive an \"Account does not exist\" message, try selecting your region explicitly."
             }
           },
           "log_options": {
@@ -1109,6 +1109,17 @@
       },
       "discharging_task_enabled": {
         "name": "Discharging Task"
+      }
+    }
+  },
+  "selector": {
+    "ecoflow_region": {
+      "options": {
+        "auto": "Auto (try CN for phone, US / EU / APAC for email)",
+        "us": "US (Global / United States)",
+        "eu": "EU (Europe)",
+        "apac": "APAC (Asia-Pacific)",
+        "cn": "CN (China - phone number only)"
       }
     }
   }


### PR DESCRIPTION
This PR consolidates region routing and credential probing that lived inline in the config flow into a dedicated `eflib.login` helper, fixes the region map that had wrong labels.
PR also adds an automatic detection of region by trying regions in order of US/Global, EU, APAC, though this may sometimes yield incorrect results.