### PR TITLE
Fix PowerStream battery level over-reporting in upper SoC range

### DIFF
--- a/custom_components/ef_ble/eflib/devices/powerstream.py
+++ b/custom_components/ef_ble/eflib/devices/powerstream.py
@@ -34,7 +34,7 @@ class Device(DeviceBase, ProtobufProps):
     pv_current_2 = pb_field(pb.pv2_input_cur, pdiv(10, 1))
     pv_temperature_2 = pb_field(pb.pv2_temp, pdiv(10, 1))
 
-    battery_level = pb_field(pb_inv2.new_psdr_heartbeat.f32_show_soc, pround(2))
+    battery_level = pb_field(pb_inv2.new_psdr_heartbeat.f32_lcd_show_soc, pround(2))
     battery_power = pb_field(pb.bat_input_watts, pdiv(10, 1))
     battery_temperature = pb_field(pb.bat_temp, pdiv(10, 1))
 

--- a/tests/eflib/test_powerstream.py
+++ b/tests/eflib/test_powerstream.py
@@ -163,7 +163,7 @@ async def test_powerstream_exact_values_from_known_packets(device, packet_sequen
         await device.data_parse(await device.packet_parse(bytes.fromhex(packet)))
 
     expected = {
-        Device.battery_level: 46.15,
+        Device.battery_level: 31.02,
         Device.battery_power: 0.0,
         Device.battery_temperature: 21.0,
         Device.pv_power_1: 6.0,


### PR DESCRIPTION
This PR fixes a long-standing discrepancy where the PowerStream's `Battery Level` sensor reads different values than the actual SoC in the upper range (GnoX/ha-ef-ble#79), visible when compared side-by-side with a connected device on the same battery via BLE and via the cloud.