### PR TITLE
fix: guard BleakClient.disconnect() with timeout to prevent FAILED_UNLOAD (fixes #338)

### DIFF
--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -1,5 +1,6 @@
 """The unofficial EcoFlow BLE devices integration"""
 
+import asyncio
 import logging
 from collections.abc import Callable
 from functools import partial
@@ -192,7 +193,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> b
     """Unload a config entry."""
     _cancel_reappear_callback(hass, entry)
     device = entry.runtime_data
-    await device.disconnect()
+    try:
+        async with asyncio.timeout(6.0):
+            await device.disconnect()
+    except TimeoutError:
+        _LOGGER.warning(
+            "Timed out waiting for device disconnect during unload of entry %s. "
+            "The BLE client may be in a mid-auth flap. Forcing cleanup to avoid "
+            "ConfigEntryState.FAILED_UNLOAD.",
+            entry.entry_id,
+        )
     device.with_logging_options(LogOptions.no_options())
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -486,9 +486,16 @@ class Connection:
         if self._client is not None and self._client.is_connected:
             self._set_state(ConnectionState.DISCONNECTING)
             try:
-                await self._client.disconnect()
+                async with asyncio.timeout(5.0):
+                    await self._client.disconnect()
             except (EOFError, BleakError) as e:
                 self._logger.debug("Disconnect failed (already down): %s", e)
+            except TimeoutError:
+                self._logger.warning(
+                    "BleakClient.disconnect() timed out after 5 s — "
+                    "a write-with-response was still pending on the ESPHome "
+                    "proxy socket (device flap during auth). Forcing local cleanup."
+                )
 
         self._client = None
         if self._state == ConnectionState.DISCONNECTING:


### PR DESCRIPTION
Fixes #338

## What

Add `asyncio.timeout` guards to `Connection.disconnect()` and `async_unload_entry` so a slow or hung `BleakClient.disconnect()` call can never leave a config entry in `ConfigEntryState.FAILED_UNLOAD`.

## Why

v0.9.0 introduced `EncPacketAssembler` with `write_with_response = True` for auth-phase GATT writes. Under a BLE flap pattern (device connects → starts auth → drops before ATT ack returns through the ESPHome proxy), `BleakClient.disconnect()` blocks waiting for the proxy socket to drain the pending `BluetoothDeviceConnectionResponse` — up to `Connection.Options.timeout` (20 s by default).

`async_unload_entry` → `device.disconnect()` → `Connection.disconnect()` → `BleakClient.disconnect()` has no deadline. HA's config entry manager sees the unload take > 20 s and marks the entry `ConfigEntryState.FAILED_UNLOAD`. In this state:
- the entry cannot be reloaded without a full HA restart
- a full HA restart re-triggers the same flap pattern
- the cycle repeats indefinitely

This was not reproducible on v0.8.5 because `SimplePacketAssembler` was used for auth (`write_with_response = False`), so `write_gatt_char` never waited for an ATT ack.

## Changes

### `eflib/connection.py` — `Connection.disconnect()`

```python
# Before
try:
    await self._client.disconnect()
except (EOFError, BleakError) as e:
    self._logger.debug("Disconnect failed (already down): %s", e)

# After
try:
    async with asyncio.timeout(5.0):
        await self._client.disconnect()
except (EOFError, BleakError) as e:
    self._logger.debug("Disconnect failed (already down): %s", e)
except TimeoutError:
    self._logger.warning(
        "BleakClient.disconnect() timed out after 5 s — "
        "a write-with-response was still pending on the ESPHome "
        "proxy socket (device flap during auth). Forcing local cleanup."
    )
```

On timeout the method continues: `_client` is set to `None` and state transitions to `DISCONNECTED`. The ESPHome proxy socket drains on its own when the proxy detects the BLE drop.

### `__init__.py` — `async_unload_entry`

```python
# Before
await device.disconnect()

# After
try:
    async with asyncio.timeout(6.0):
        await device.disconnect()
except TimeoutError:
    _LOGGER.warning(
        "Timed out waiting for device disconnect during unload of entry %s. "
        "The BLE client may be in a mid-auth flap. Forcing cleanup to avoid "
        "ConfigEntryState.FAILED_UNLOAD.",
        entry.entry_id,
    )
```

The outer timeout (6 s) is slightly larger than the inner one (5 s) so the inner `TimeoutError` is normally caught first and logged at the connection level. The outer guard is a belt-and-suspenders fallback for any other code path that could block `device.disconnect()`.

## Tested on

- EcoFlow Smart Home Panel 2 (HD30825) + Delta Pro Ultra (YJ0178)
- ESPHome BLE proxy: wired ESP32-POE, bleak-esphome backend, −59/−69 dBm
- Home Assistant 2025.x, Python 3.13, NixOS
- Both devices authenticate cleanly after applying this fix
- Repeated `async_schedule_reload` calls during BLE flap no longer result in `FAILED_UNLOAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)