### PR TITLE
Add local binding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,9 +697,13 @@ Click on any device below to see available sensors, switches, and controls:
 ### Prerequisites
 
 - Home Assistant with Bluetooth support
-- Your device must be **bound to your account** through the EcoFlow app before setup
-- Your **User ID** from the EcoFlow app (can be retrieved via the config flow login form
-  during setup)
+- One of:
+  - An **EcoFlow account** and a device already bound to it (the integration retrieves
+    your User ID via the login form during setup), or
+  - A **numeric User ID** you already have (e.g. from a previous setup or another local
+    tool), or
+  - A previously **unbound device** if you intend to use local binding (see
+    [Authentication](#authentication))
 - [HACS](https://hacs.xyz/) installed (recommended method)
 
 ### Method 1: HACS Installation (Recommended)
@@ -739,6 +743,27 @@ via Bluetooth LE.
 > [!TIP]
 > For detailed configuration help, FAQ, and troubleshooting common issues (like BLE
 > disconnections), see the [**Wiki**](https://github.com/rabits/ha-ef-ble/wiki)
+
+### Authentication
+
+When you add a device the integration asks how to source its **User ID**. The User ID is
+the device's binding key. Once a device is bound to a given ID, only that same ID can
+authenticate to it until the device is factory-reset. Pick one of:
+
+- **EcoFlow account login** Enter your EcoFlow email and password. The integration
+  contacts EcoFlow's servers once to look up your User ID, then operates entirely over
+  Bluetooth. Suitable when you already have a working EcoFlow account and a device
+  already bound to it.
+- **Existing user ID** Type your numeric User ID directly. No internet connection
+  required. Useful if you already know the ID (e.g. from a previous setup, or from
+  another local tool that's already talking to the device).
+- **Local binding (no EcoFlow account)** Pick this for first-time setup of an
+  **unbound** device without ever requring an EcoFlow account. The integration
+  generates a 10-digit numeric User ID, pre-fills it in the form so you can see and
+  copy it, then binds the device to that ID. **Save the ID somewhere safe** it's
+  the key any other local tool will need to talk to the same device. After setup the
+  ID is also surfaced as a diagnostic sensor on the device entity, so you can recover
+  it later if needed.
 
 ---
 

--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_DIAGNOSTICS_ON_EXCEPTION,
     CONF_DIAGNOSTICS_OPTIONS,
     CONF_EXTRA_BATTERY,
+    CONF_LOCAL_BINDING,
     CONF_PACKET_VERSION,
     CONF_UPDATE_PERIOD,
     CONF_USER_ID,
@@ -74,6 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
 
     address = entry.data.get(CONF_ADDRESS)
     user_id = entry.data.get(CONF_USER_ID)
+    local_binding = entry.data.get(CONF_LOCAL_BINDING, False)
     merged_options = entry.data | entry.options
     update_period = merged_options.get(CONF_UPDATE_PERIOD, DEFAULT_UPDATE_PERIOD)
     packet_version = PacketVersion.from_str(
@@ -128,6 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
             .connect(
                 user_id=user_id,
                 max_attempts=0 if eflib.is_solar_only(device) else None,
+                local_binding=local_binding,
             )
         )
         state = await device.wait_until_authenticated_or_error(raise_on_error=True)

--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import enum
 import logging
+import secrets
 from collections.abc import Iterable, Mapping
 from functools import cached_property
 from typing import Any, ClassVar, cast
@@ -45,6 +46,7 @@ from .const import (
     CONF_DIAGNOSTICS_ON_EXCEPTION,
     CONF_DIAGNOSTICS_OPTIONS,
     CONF_EXTRA_BATTERY,
+    CONF_LOCAL_BINDING,
     CONF_LOG_BLEAK,
     CONF_LOG_CONNECTION,
     CONF_LOG_ENCRYPTED_PAYLOADS,
@@ -88,6 +90,24 @@ class PacketVersion(enum.StrEnum):
             return PacketVersion.V3
 
 
+class AuthMode(enum.StrEnum):
+    """How the device's authentication user_id is sourced at setup."""
+
+    CLOUD_LOGIN = "cloud_login"
+    EXISTING_USER_ID = "existing_user_id"
+    LOCAL_BINDING = "local_binding"
+
+
+def _generate_numeric_user_id() -> str:
+    """
+    Generate a 10-digit numeric user_id for local-only binding.
+
+    Shape matches EcoFlow cloud user IDs, so tools that parse the value
+    as an integer keep working.
+    """
+    return str(secrets.randbelow(9_000_000_000) + 1_000_000_000)
+
+
 class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
     """EcoFlow BLE ConfigFlow"""
 
@@ -109,6 +129,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._user_id_validated: bool = False
         self._log_options = LogOptions.no_options()
         self._collapsed = True
+        self._auth_mode: AuthMode = AuthMode.CLOUD_LOGIN
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -125,7 +146,56 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._set_name_from_discovery(self._discovery_info, device.name)
 
         _LOGGER.debug("Discovered device: %s", device)
-        return await self.async_step_bluetooth_confirm()
+        return await self.async_step_auth_mode()
+
+    async def async_step_auth_mode(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Pick how the user_id is sourced for this device."""
+        if user_input is not None:
+            self._auth_mode = AuthMode(user_input["auth_mode"])
+            if self._auth_mode == AuthMode.LOCAL_BINDING:
+                self._user_id = _generate_numeric_user_id()
+            return await self._next_confirm_step()
+
+        return self.async_show_form(
+            step_id="auth_mode",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("auth_mode", default=AuthMode.CLOUD_LOGIN.value): (
+                        SelectSelector(
+                            SelectSelectorConfig(
+                                options=[
+                                    SelectOptionDict(
+                                        value=AuthMode.CLOUD_LOGIN.value,
+                                        label="EcoFlow account login",
+                                    ),
+                                    SelectOptionDict(
+                                        value=AuthMode.EXISTING_USER_ID.value,
+                                        label="Enter an existing EcoFlow user ID",
+                                    ),
+                                    SelectOptionDict(
+                                        value=AuthMode.LOCAL_BINDING.value,
+                                        label="Local binding (no EcoFlow account)",
+                                    ),
+                                ],
+                                mode=SelectSelectorMode.LIST,
+                            )
+                        )
+                    )
+                }
+            ),
+        )
+
+    async def _next_confirm_step(self) -> ConfigFlowResult:
+        """Route to the right confirm step after the auth-mode pick."""
+        if self._discovery_info is not None:
+            return await self.async_step_bluetooth_confirm()
+        if self._discovered_device is not None and eflib.is_unsupported(
+            self._discovered_device
+        ):
+            return await self.async_step_unsupported_device()
+        return await self.async_step_device_confirm()
 
     async def async_step_bluetooth_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -138,7 +208,9 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         title = f"{device.device} ({self._local_names[device.address]})"
 
-        if data := await self._store.async_load():
+        if self._auth_mode != AuthMode.LOCAL_BINDING and (
+            data := await self._store.async_load()
+        ):
             self._user_id = data["user_id"]
 
         self._set_confirm_only()
@@ -162,7 +234,9 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=(
                 schema_builder()
                 .user_id(self._user_id)
-                .login(self._collapsed)
+                .login(
+                    self._collapsed, condition=self._auth_mode == AuthMode.CLOUD_LOGIN
+                )
                 .required(CONF_ADDRESS, vol.In([full_name]))
                 .update_period()
                 .conf_log(self._log_options)
@@ -181,10 +255,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                 user_input[CONF_ADDRESS]
             ]
 
-            if eflib.is_unsupported(self._discovered_device):
-                return await self.async_step_unsupported_device()
-
-            return await self.async_step_device_confirm()
+            return await self.async_step_auth_mode()
 
         current_addresses = self._async_current_ids()
 
@@ -248,7 +319,9 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         errors = {}
 
-        if data := await self._store.async_load():
+        if self._auth_mode != AuthMode.LOCAL_BINDING and (
+            data := await self._store.async_load()
+        ):
             self._user_id = data["user_id"]
 
         if user_input is not None:
@@ -266,7 +339,9 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=(
                 schema_builder()
                 .user_id(self._user_id)
-                .login(self._collapsed)
+                .login(
+                    self._collapsed, condition=self._auth_mode == AuthMode.CLOUD_LOGIN
+                )
                 .update_period()
                 .conf_log(self._log_options)
                 .advanced_connection_options()
@@ -280,7 +355,9 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         assert eflib.is_unsupported(self._discovered_device)
         device = self._discovered_device
 
-        if data := await self._store.async_load():
+        if self._auth_mode != AuthMode.LOCAL_BINDING and (
+            data := await self._store.async_load()
+        ):
             self._user_id = data["user_id"]
 
         errors = {}
@@ -312,7 +389,9 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                     default=PacketVersion.from_str(f"v{device.packet_version}"),
                 )
-                .login(self._collapsed)
+                .login(
+                    self._collapsed, condition=self._auth_mode == AuthMode.CLOUD_LOGIN
+                )
                 .conf_log(self._log_options)
                 .advanced_connection_options()
                 .build()
@@ -389,6 +468,12 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         entry_data["local_name"] = self._local_names.get(device.address, None)
         entry_data.pop("login", None)
 
+        entry_data[CONF_LOCAL_BINDING] = self._auth_mode == AuthMode.LOCAL_BINDING
+        # In local-binding mode the user_id may have been auto-generated after the
+        # form was submitted; persist the value actually used to bind the device.
+        if entry_data[CONF_LOCAL_BINDING]:
+            entry_data[CONF_USER_ID] = self._user_id
+
         if CONF_EXTRA_BATTERY not in entry_data:
             entry_data[CONF_EXTRA_BATTERY] = _find_enabled_batteries(
                 device, range(1, 6)
@@ -404,6 +489,18 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return None
 
+    async def _handle_cloud_login(
+        self, password: str, region: str
+    ) -> dict[str, Any] | None:
+        """Dispatch EcoFlow account login if credentials were submitted."""
+        if not self._email and not password:
+            return None
+        if not self._email:
+            return {"login": "email_empty"}
+        if not password:
+            return {"login": "password_empty"}
+        return await self._ecoflow_login(self._email, password, region)
+
     async def _validate_user_id(
         self, device: eflib.DeviceBase, user_input: dict[str, Any]
     ) -> dict[str, Any]:
@@ -418,16 +515,17 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         packet_version = PacketVersion.from_str(user_input.get(CONF_PACKET_VERSION))
 
         self._collapsed = False
+        local_binding = self._auth_mode == AuthMode.LOCAL_BINDING
 
-        if not self._email and not password and not user_id:
+        if local_binding and not user_id:
+            user_id = _generate_numeric_user_id()
+
+        if not local_binding and not self._email and not password and not user_id:
             return {CONF_USER_ID: "User ID cannot be empty"}
 
-        if self._email or password:
-            if not self._email:
-                return {"login": "email_empty"}
-            if not password:
-                return {"login": "password_empty"}
-            return await self._ecoflow_login(self._email, password, region)
+        login_result = await self._handle_cloud_login(password, region)
+        if login_result is not None:
+            return login_result
 
         self._user_id = user_id
 
@@ -441,7 +539,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             .with_connection_options(Connection.Options(timeout=timeout))
         )
 
-        await device.connect(self._user_id)
+        await device.connect(self._user_id, local_binding=local_binding)
         exc = None
         try:
             conn_state, exc = await asyncio.wait_for(
@@ -469,7 +567,8 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                 error = "unknown"
             case ConnectionState.AUTHENTICATED:
                 self._user_id_validated = True
-                await self._store.async_save(data={"user_id": self._user_id})
+                if not local_binding:
+                    await self._store.async_save(data={"user_id": self._user_id})
             case _:
                 error = (
                     "error_try_refresh"
@@ -682,7 +781,9 @@ class _SchemaBuilder:
 
         return self.update({marker(CONF_USER_ID, default=user_id): str})
 
-    def login(self, collapsed: bool = True):
+    def login(self, collapsed: bool = True, condition: bool = True):
+        if not condition:
+            return self
         return self.update(
             {
                 vol.Required("login"): section(

--- a/custom_components/ef_ble/const.py
+++ b/custom_components/ef_ble/const.py
@@ -4,6 +4,7 @@ DOMAIN = "ef_ble"
 MANUFACTURER = "EcoFlow"
 
 CONF_USER_ID = "user_id"
+CONF_LOCAL_BINDING = "local_binding"
 CONF_UPDATE_PERIOD = "update_period"
 CONF_CONNECTION_TIMEOUT = "connection_timeout"
 CONF_PACKET_VERSION = "packet_version"

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -219,6 +219,7 @@ class Connection:
         packet_version: int = 0x03,
         encrypt_type: int = 7,
         auth_header_dst: int = 0x35,
+        local_binding: bool = False,
     ) -> None:
         self._ble_dev = ble_dev
         self._address = ble_dev.address
@@ -242,6 +243,7 @@ class Connection:
         self._retry_on_disconnect = False
         self._retry_on_disconnect_delay = 10
         self._auth_header_dst = auth_header_dst
+        self._local_binding = local_binding
 
         self._tasks: set[asyncio.Task] = set()
         self._call_later_handles: dict[str, asyncio.TimerHandle] = {}
@@ -1045,6 +1047,31 @@ class Connection:
             await self._client.disconnect()
         raise exc
 
+    async def _set_authentication(self):
+        """
+        Bind an unbound device locally (no EcoFlow account).
+
+        Sends `setAuthentication` (0x85) carrying the same MD5(user_id+sn)
+        payload as `checkAuth` (0x86). The 0x86 step must have already been
+        sent — the device only accepts 0x85 after a 0x86 that returned
+        `NeedBindInstallFirst` (0x04).
+        """
+        md5_data = hashlib.md5((self._user_id + self._dev_sn).encode("ASCII")).digest()
+        payload = ("".join(f"{c:02X}" for c in md5_data)).encode("ASCII")
+
+        packet = Packet(
+            0x21,
+            self._auth_header_dst,
+            0x35,
+            0x85,
+            payload,
+            0x01,
+            0x01,
+            self._packet_version,
+        )
+
+        await self.sendPacket(packet)
+
     async def send_auth_status_packet(self):
         """Send the auth status packet used for initial auth wake-up."""
         pkt = Packet(
@@ -1078,18 +1105,40 @@ class Connection:
                 and packet.cmd_set == 0x35
                 and packet.cmd_id == 0x86
             )
+            is_bind_reply = (
+                packet.src == self._auth_header_dst
+                and packet.cmd_set == 0x35
+                and packet.cmd_id == 0x85
+            )
             authenticating = self._state == ConnectionState.AUTHENTICATING
 
             if is_auth_reply and authenticating:
+                exc = AuthErrors.from_payload(packet.payload)
+                if self._local_binding and exc is AuthErrors.NeedBindInstallFirst:
+                    self._logger.info(
+                        "Device unbound (NeedBindInstallFirst), "
+                        "attempting first-time binding"
+                    )
+                    await self._set_authentication()
+                    processed = True
+                else:
+                    await self._check_auth(packet)
+                    self._connection_attempt = 0
+                    self._reconnect_attempt = 0
+                    processed = True
+                    self._logger.info("Auth completed, everything is fine")
+                    self._set_state(ConnectionState.AUTHENTICATED)
+                    self._connected.set()
+            elif self._local_binding and is_bind_reply and authenticating:
                 await self._check_auth(packet)
                 self._connection_attempt = 0
                 self._reconnect_attempt = 0
                 processed = True
-                self._logger.info("Auth completed, everything is fine")
+                self._logger.info("Device bound successfully (first-time binding)")
                 self._set_state(ConnectionState.AUTHENTICATED)
                 self._connected.set()
             else:
-                if authenticating and not is_auth_reply:
+                if authenticating:
                     self._connection_attempt = 0
                     self._reconnect_attempt = 0
                     self._logger.info("Auth completed - first data packet received")

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -258,6 +258,7 @@ class DeviceBase(abc.ABC):
         self,
         user_id: str | None = None,
         max_attempts: int | None = None,
+        local_binding: bool = False,
     ):
         if self._conn is None:
             self._conn = (
@@ -270,6 +271,7 @@ class DeviceBase(abc.ABC):
                     packet_version=self.packet_version,
                     encrypt_type=self.scan_record.encrypt_type,
                     auth_header_dst=self.auth_header_dst,
+                    local_binding=local_binding,
                 )
                 .with_logging_options(self._logger.options)
                 .with_disabled_reconnect(self._reconnect_disabled)

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import DeviceConfigEntry
-from .const import CONF_EXTRA_BATTERY, DOMAIN
+from .const import CONF_EXTRA_BATTERY, CONF_LOCAL_BINDING, CONF_USER_ID, DOMAIN
 from .eflib import DeviceBase
 from .eflib.devices import (
     _delta3_base,
@@ -891,6 +891,11 @@ async def async_setup_entry(
         if hasattr(device, sensor)
     ]
 
+    if config_entry.data.get(CONF_LOCAL_BINDING) and (
+        user_id := config_entry.data.get(CONF_USER_ID)
+    ):
+        new_sensors.append(EcoflowUserIdSensor(device, user_id))
+
     if new_sensors:
         async_add_entities(new_sensors)
 
@@ -1009,6 +1014,29 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
         """Entity being removed from hass."""
         await super().async_will_remove_from_hass()
         self._device.remove_callback(self.async_write_ha_state, self._sensor)
+
+
+class EcoflowUserIdSensor(EcoflowEntity, SensorEntity):
+    """
+    Diagnostic sensor exposing the locally-bound user_id.
+
+    The value comes from the config entry rather than the device so the
+    sensor stays available even when the BLE link is down - this is the
+    key the user needs to copy into other tools.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "user_id"
+    _attr_icon = "mdi:key-variant"
+
+    def __init__(self, device: DeviceBase, user_id: str):
+        super().__init__(device)
+        self._attr_unique_id = f"ef_{device.serial_number}_user_id"
+        self._attr_native_value = user_id
+
+    @property
+    def available(self) -> bool:
+        return True
 
 
 class EcoflowBatteryAddonSensor(EcoflowBatteryAddonEntity, SensorEntity):

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -28,6 +28,13 @@
       "error_try_refresh_unsupported": "Device disconnected before it could authenticate - try changing packet version. If that does not help and resubmitting after reloading does not work, this device probably uses different auth procedure and has to be reverse engineered."
     },
     "step": {
+      "auth_mode": {
+        "title": "Choose how to authenticate",
+        "description": "Pick how this device's user ID will be sourced. The user ID becomes the device's binding key (MD5 of `user_id` + serial number) and must be reused by any other tool that talks to the device after setup.",
+        "data": {
+          "auth_mode": "Authentication mode"
+        }
+      },
       "bluetooth_confirm": {
         "title": "Discovered Device Configuration",
         "data": {

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -384,6 +384,9 @@
       "collecting_data": {
         "name": "Collecting diagnostics data"
       },
+      "user_id": {
+        "name": "User ID (local binding)"
+      },
       "battery_level": {
         "name": "Battery Level"
       },

--- a/tests/eflib/test_connection_local_binding.py
+++ b/tests/eflib/test_connection_local_binding.py
@@ -1,0 +1,126 @@
+"""Tests for the opt-in local-binding auth path in Connection."""
+
+import hashlib
+
+import pytest
+from pytest_mock import MockerFixture
+
+from custom_components.ef_ble.eflib.connection import Connection, ConnectionState
+from custom_components.ef_ble.eflib.exceptions import AuthErrors
+from custom_components.ef_ble.eflib.packet import Packet
+
+USER_ID = "1234567890"
+DEV_SN = "R655TEST1234"
+
+
+@pytest.fixture
+def make_connection(mocker: MockerFixture):
+    """Factory for a Connection with the BLE-side dependencies stubbed out."""
+
+    def _factory(local_binding: bool = False) -> Connection:
+        ble_dev = mocker.Mock()
+        ble_dev.address = "AA:BB:CC:DD:EE:FF"
+
+        conn = Connection(
+            ble_dev=ble_dev,
+            dev_sn=DEV_SN,
+            user_id=USER_ID,
+            data_parse=mocker.AsyncMock(return_value=False),
+            packet_parse=mocker.AsyncMock(),
+            local_binding=local_binding,
+        )
+        mocker.patch.object(conn, "sendPacket", new=mocker.AsyncMock())
+        return conn
+
+    return _factory
+
+
+async def test_set_authentication_sends_md5_payload_as_0x85(make_connection):
+    """`_set_authentication` builds a 0x85 packet with hex(MD5(user_id + sn))."""
+    conn = make_connection(local_binding=True)
+
+    await conn._set_authentication()
+
+    conn.sendPacket.assert_awaited_once()
+    packet: Packet = conn.sendPacket.call_args.args[0]
+    assert packet.cmd_set == 0x35
+    assert packet.cmd_id == 0x85
+    assert packet.src == 0x21
+    assert packet.dst == conn._auth_header_dst
+
+    expected = hashlib.md5((USER_ID + DEV_SN).encode("ASCII")).hexdigest().upper()
+    assert packet.payload == expected.encode("ASCII")
+
+
+async def test_handler_sends_bind_on_need_bind_install_first_when_local_binding(
+    make_connection, mocker: MockerFixture
+):
+    """0x86 + payload 0x04 + local_binding=True -> send 0x85, stay AUTHENTICATING."""
+    conn = make_connection(local_binding=True)
+    conn._connection_state = ConnectionState.AUTHENTICATING
+
+    reply = Packet(
+        src=conn._auth_header_dst,
+        dst=0x21,
+        cmd_set=0x35,
+        cmd_id=0x86,
+        payload=b"\x04",
+    )
+    mocker.patch.object(conn, "parseEncPackets", return_value=[reply])
+    set_auth_spy = mocker.patch.object(
+        conn, "_set_authentication", new=mocker.AsyncMock()
+    )
+
+    await conn.listenForDataHandler(mocker.Mock(), bytearray(b"ignored"))
+
+    set_auth_spy.assert_awaited_once()
+    assert conn._state == ConnectionState.AUTHENTICATING
+    assert not conn._connected.is_set()
+
+
+async def test_handler_raises_on_need_bind_install_first_when_local_binding_disabled(
+    make_connection, mocker: MockerFixture
+):
+    """Regression guard: with the flag off the existing error path still fires."""
+    conn = make_connection(local_binding=False)
+    conn._connection_state = ConnectionState.AUTHENTICATING
+
+    reply = Packet(
+        src=conn._auth_header_dst,
+        dst=0x21,
+        cmd_set=0x35,
+        cmd_id=0x86,
+        payload=b"\x04",
+    )
+    mocker.patch.object(conn, "parseEncPackets", return_value=[reply])
+    set_auth_spy = mocker.patch.object(
+        conn, "_set_authentication", new=mocker.AsyncMock()
+    )
+
+    with pytest.raises(AuthErrors.NeedBindInstallFirst):
+        await conn.listenForDataHandler(mocker.Mock(), bytearray(b"ignored"))
+
+    set_auth_spy.assert_not_awaited()
+    assert conn._state == ConnectionState.ERROR_AUTH_FAILED
+
+
+async def test_handler_transitions_to_authenticated_on_bind_reply(
+    make_connection, mocker: MockerFixture
+):
+    """0x85 success reply during AUTHENTICATING completes the bind."""
+    conn = make_connection(local_binding=True)
+    conn._connection_state = ConnectionState.AUTHENTICATING
+
+    reply = Packet(
+        src=conn._auth_header_dst,
+        dst=0x21,
+        cmd_set=0x35,
+        cmd_id=0x85,
+        payload=b"\x00",
+    )
+    mocker.patch.object(conn, "parseEncPackets", return_value=[reply])
+
+    await conn.listenForDataHandler(mocker.Mock(), bytearray(b"ignored"))
+
+    assert conn._state == ConnectionState.AUTHENTICATED
+    assert conn._connected.is_set()


### PR DESCRIPTION
This allows users to bind to their battery without creating an account with EcoFlow.

It was developed with the help of Claude Code.