### PR TITLE
Fix Delta 2 AC Ports switch stuck unavailable while AC output is off

### DIFF
--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -1,3 +1,7 @@
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+from ..connection import ConnectionState
 from ..devicebase import DeviceBase
 from ..entity import controls
 from ..entity.base import dynamic
@@ -85,6 +89,26 @@ class Delta2Base(DeviceBase, RawDataProps):
     dc_12v_port = raw_field(pb_pd.car_state, lambda x: x == 1)
     dc12v_output_voltage = raw_field(pb_mppt.car_out_vol, pdiv(1000, 2))
     dc12v_output_current = raw_field(pb_mppt.car_out_amp, pdiv(1000, 2))
+
+    def __init__(
+        self, ble_dev: BLEDevice, adv_data: AdvertisementData, sn: str
+    ) -> None:
+        super().__init__(ble_dev, adv_data, sn)
+        self.on_connection_state_change(self._default_ac_ports_off_when_missing)
+
+    def _default_ac_ports_off_when_missing(self, state: ConnectionState) -> None:
+        # The inverter stops sending its heartbeat entirely while AC output is off, so
+        # `ac_ports` never gets a value after a fresh connect and the switch stays
+        # `unavailable`. Default it to off if nothing arrives within 10s - a real
+        # heartbeat afterwards still overrides this.
+        if state != ConnectionState.AUTHENTICATED:
+            return
+
+        def _set_off_if_unknown() -> None:
+            if self.ac_ports is None:
+                self.notify_field(Delta2Base.ac_ports, False)
+
+        self.call_later(10, _set_off_if_unknown, key="default_ac_ports_off")
 
     @property
     def pd_heart_type(self):


### PR DESCRIPTION
The inverter heartbeat is the only message that carries `cfg_ac_enabled` (which drives the `ac_ports` field), and the firmware stops sending it entirely while AC output is off. After a fresh connect with AC off, `ac_ports` is therefore never populated, the switch reports unavailable (its value stays `None`), and HA blocks `turn_on` on unavailable entities - so the AC ports can't be enabled from HA at all until the inverter is turned on physically or via the app.

`Delta2Base` now arms a 10 second fallback when the device authenticates: if no inverter heartbeat arrives within the window, `ac_ports` falls back to off so the switch becomes controllable. It is deliberately left unavailable during the grace period instead of defaulting immediately, so we never assume off (and send an `on` command) for a port that is actually on but slow to report. A real heartbeat at any point still overrides the fallback.

Resolves #351, resolves #334
