### PR TITLE
Fix spurious SHP2 error logging, clean up packet parsing

### DIFF
--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -8,8 +8,8 @@ from ..entity.base import dynamic
 from ..packet import Packet
 from ..pb import pd303_pb2
 from ..props import (
-    Field,
     ProtobufProps,
+    computed_field,
     field_group,
     pb_field,
     pb_group,
@@ -203,8 +203,14 @@ class Device(DeviceBase, ProtobufProps):
     ac_charging_speed = pb_field(pb_push_set.charge_watt_power)
 
     errors = pb_field(pb_push_set.backup_incre_info.errcode, _errors)
-    error_count = Field[int]()
-    error_happened = Field[bool]()
+
+    @computed_field
+    def error_count(self) -> int | None:
+        return len(self.errors) if self.errors is not None else None
+
+    @computed_field
+    def error_happened(self) -> bool:
+        return bool(self.errors)
 
     @staticmethod
     def check(sn: bytes):
@@ -224,67 +230,45 @@ class Device(DeviceBase, ProtobufProps):
 
         prev_error_count = self.error_count
 
-        if packet.src == 0x0B and packet.cmd_set == 0x0C:
-            if (
-                packet.cmd_id == 0x01
-            ):  # master_info, load_info, backup_info, watt_info, master_ver_info
+        match packet.src, packet.cmd_set, packet.cmd_id:
+            case 0x0B, 0x0C, 0x01:
+                # master_info, load_info, backup_info, watt_info, master_ver_info
                 self._logger.debug("Parsed data: %r", packet)
-
                 await self._conn.replyPacket(packet)
                 self.update_from_bytes(pd303_pb2.ProtoTime, packet.payload)
                 processed = True
-            elif packet.cmd_id == 0x20:  # backup_incre_info
-                self._logger.debug("Parsed data: %r", packet)
 
+            case 0x0B, 0x0C, 0x20:  # backup_incre_info
+                self._logger.debug("Parsed data: %r", packet)
                 await self._conn.replyPacket(packet)
                 self.update_from_bytes(pd303_pb2.ProtoPushAndSet, packet.payload)
-
                 processed = True
 
-            elif packet.cmd_id == 0x21:  # is_get_cfg_flag
+            case 0x0B, 0x0C, 0x21:  # is_get_cfg_flag
                 self._logger.debug("Parsed data: %r", packet)
                 self.update_from_bytes(pd303_pb2.ProtoPushAndSet, packet.payload)
                 processed = True
 
-        elif packet.src == 0x35 and packet.cmd_set == 0x35 and packet.cmd_id == 0x20:
-            self._logger.debug("Ping received: %r", packet)
-            processed = True
+            case 0x35, 0x35, 0x20:
+                self._logger.debug("Ping received: %r", packet)
+                processed = True
 
-        elif (
-            packet.src == 0x35
-            and packet.cmd_set == 0x01
-            and packet.cmd_id == Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME
-        ):
-            # Device requested for time and timezone offset, so responding with that
-            # otherwise it will not be able to send us predictions and config data
-            if len(packet.payload) == 0:
-                self._time_commands.async_send_all()
-            processed = True
+            case 0x35, 0x01, Packet.NET_BLE_COMMAND_CMD_SET_RET_TIME:
+                # Device requested for time and timezone offset, so responding with that
+                # otherwise it will not be able to send us predictions and config data
+                if len(packet.payload) == 0:
+                    self._time_commands.async_send_all()
+                processed = True
 
-        elif packet.src == 0x0B and packet.cmd_set == 0x01 and packet.cmd_id == 0x55:
-            # Device reply that it's online and ready
-            self._conn._add_task(self.set_config_flag(True))
-            processed = True
+            case 0x0B, 0x01, 0x55:
+                # Device reply that it's online and ready
+                self._conn._add_task(self.set_config_flag(True))
+                processed = True
 
-        self.error_count = len(self.errors) if self.errors is not None else None
-
-        if (
-            self.error_count is not None
-            and prev_error_count is not None
-            and self.error_count > prev_error_count
-        ) or (self.error_count is not None and prev_error_count is None):
-            self.error_happened = True
+        if self.error_count and self.error_count > (prev_error_count or 0):
             self._logger.warning("Error happened on device: %s", self.errors)
 
-        for field_name in self.updated_fields:
-            try:
-                self.update_callback(field_name)
-                self.update_state(field_name, getattr(self, field_name))
-            except Exception as e:  # noqa: BLE001
-                self._logger.warning(
-                    "Error happened while updating field %s: %s", field_name, e
-                )
-
+        self._notify_updated()
         return processed
 
     async def _send_config_packet(self, message):

--- a/tests/eflib/test_shp2.py
+++ b/tests/eflib/test_shp2.py
@@ -1,7 +1,11 @@
+import logging
+
 import pytest
 from pytest_mock import MockerFixture
 
 from custom_components.ef_ble.eflib.devices.shp2 import Device
+from custom_components.ef_ble.eflib.packet import Packet
+from custom_components.ef_ble.eflib.pb import pd303_pb2
 from custom_components.ef_ble.eflib.props import FieldGroup
 
 
@@ -112,6 +116,46 @@ async def test_shp2_handles_zero_values_correctly(device, packet_sequence):
         assert isinstance(error_count, int)
 
 
+def _backup_incre_packet(*err_codes: bytes) -> Packet:
+    """A backup_incre_info (0x0B/0x0C/0x20) packet carrying the given errcodes."""
+    message = pd303_pb2.ProtoPushAndSet()
+    message.backup_incre_info.errcode.err_code.extend(err_codes)
+    return Packet(0x0B, 0x21, 0x0C, 0x20, message.SerializeToString())
+
+
+async def test_shp2_empty_errcode_is_not_an_error(device, caplog):
+    zero = b"\x00" * 8
+    with caplog.at_level(logging.WARNING):
+        await device.data_parse(_backup_incre_packet(zero))
+
+    assert device.error_count == 0
+    assert device.error_happened is False
+    assert "Error happened on device" not in caplog.text
+
+
+async def test_shp2_real_error_warns_then_clears(device, caplog):
+    err = b"\x01\x00\x00\x00\x00\x00\x00\x00"
+
+    pushed: list[bool] = []
+    device.register_state_update_callback(pushed.append, "error_happened")
+
+    with caplog.at_level(logging.WARNING):
+        await device.data_parse(_backup_incre_packet(err))
+    assert device.error_count == 1
+    assert device.error_happened is True
+    assert "Error happened on device" in caplog.text
+
+    # error clears -> problem turns off and no new warning is logged
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        await device.data_parse(_backup_incre_packet(b"\x00" * 8))
+    assert device.error_count == 0
+    assert device.error_happened is False
+    assert "Error happened on device" not in caplog.text
+
+    assert pushed == [True, False]
+
+
 async def test_shp2_field_types_are_consistent(device, packet_sequence):
     for hex_packet in packet_sequence:
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
@@ -153,7 +197,7 @@ async def test_shp2_exact_values_from_known_packets(device, packet_sequence):
         Device.in_use_power: 677.0,
         Device.storm_mode: False,
         Device.error_count: 0,
-        Device.error_happened: True,
+        Device.error_happened: False,
         Device.channel_power[1]: 0.0,
         Device.channel_power[2]: -344.08,
         Device.channel_power[3]: -294.92,


### PR DESCRIPTION
SHP2 logged a `WARNING` "Error happened on device: []" even when the device reported no errors. `error_count` transitions `None -> 0` the first time an errcode list is parsed - an all-zero errcode filters to `[]`, so the count is `0` - and the `prev_error_count is None` branch fired regardless of whether the list was empty, also flipping the `error_happened` problem sensor on.

Now we warn only when the error count actually grows beyond the snapshot taken before the packet updated `errors`; an empty errcode list is never treated as an error.

`error_count` and `error_happened` are now computed fields derived from `errors`, so they share a single source of truth and can't drift out of sync. This also fixes a latent issue where `error_happened` was set `True` and never reset - leaving the problem binary sensor stuck "on" forever after any error - it now reflects the current state (on iff the device currently reports errors).

While here, `data_parse` packet routing is aligned with the other devices by replacing the nested `if/elif` chain with a `match (src, cmd_set, cmd_id)` block.

Resolves #340.
