### PR TITLE
Fix integration stuck initializing on stray BLE bytes or link loss during auth

### DIFF
--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -1,5 +1,6 @@
 """The unofficial EcoFlow BLE devices integration"""
 
+import asyncio
 import logging
 from collections.abc import Callable
 from functools import partial
@@ -130,8 +131,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
                 max_attempts=0 if eflib.is_solar_only(device) else None,
             )
         )
-        state = await device.wait_until_authenticated_or_error(raise_on_error=True)
+        async with asyncio.timeout(timeout):
+            state = await device.wait_until_authenticated_or_error(raise_on_error=True)
     except (ConnectionTimeout, BleakError, TimeoutError) as e:
+        await device.disconnect()
         raise ConfigEntryNotReady(
             translation_key="could_not_connect",
             translation_placeholders={"time": str(timeout), "error_msg": str(e)},

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -809,6 +809,17 @@ class Connection:
             try:
                 await self._sendRequest(send_data, response_handler)
             except Exception as e:  # noqa: BLE001
+                if self._client is None or not self._client.is_connected:
+                    # The BLE link dropped mid-request - e.g. BlueZ raising "Remote peer
+                    # disconnected" synchronously from start_notify. bleak does not
+                    # always fire its disconnected callback for a synchronous GATT
+                    # failure, so nothing else would drive a reconnect and
+                    # `wait_until_authenticated_or_error` hangs forever.
+                    self._logger.warning(
+                        "BLE link lost while sending request (%s); reconnecting", e
+                    )
+                    self.disconnected()
+                    return
                 self._logger.log_filtered(
                     LogOptions.CONNECTION_DEBUG,
                     (

--- a/custom_components/ef_ble/eflib/frame_assembler.py
+++ b/custom_components/ef_ble/eflib/frame_assembler.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from .crc import crc8, crc16
 from .encpacket import EncPacket
 from .encryption import EncryptionStrategy
-from .exceptions import PacketParseError
 from .packet import Packet
 
 
@@ -244,10 +243,12 @@ class SimplePacketAssembler:
         """
         Extract the payload from one EncPacket frame, scanning for the prefix
 
-        Returns the payload when a complete valid frame is found, or None if the data is
-        incomplete and another BLE notification is expected to arrive. Raises
-        PacketParseError only when the data is clearly unrecoverable (no prefix found,
-        or only CRC-invalid candidates with nothing left to scan).
+        Returns the payload when a complete valid frame is found, or None when no frame
+        is available yet and another BLE notification is expected to arrive: incomplete
+        data, stale/foreign notification bytes with no frame prefix, or only CRC-invalid
+        candidates. This assembler runs only during the auth handshake, where the right
+        response to unparseable data is to wait for the next notification (and let the
+        connection timeout bound a truly stuck device) rather than abort the handshake.
         """
         if self._buffer:
             data = self._buffer + data
@@ -256,9 +257,7 @@ class SimplePacketAssembler:
         while data:
             start = data.find(EncPacket.PREFIX)
             if start < 0:
-                raise PacketParseError(
-                    f"SimplePacketAssembler: no prefix found in: {data.hex()}"
-                )
+                return None
             if start > 0:
                 data = data[start:]
 
@@ -287,6 +286,6 @@ class SimplePacketAssembler:
 
             return payload_data
 
-        raise PacketParseError(
-            f"SimplePacketAssembler: no valid frame found in: {data.hex()}"
-        )
+        # Loop only exits here when the data was fully consumed without yielding a frame
+        # (all candidates were false prefixes / CRC failures). Wait for more data.
+        return None


### PR DESCRIPTION
This PR fixes the integration getting stuck "initializing" indefinitely when the BLE auth handshake hit an unrecoverable state during the ECDH key exchange and never reached a terminal state, leaving `async_setup_entry` waiting forever. Three separate gaps each let a transient BLE hiccup wedge setup:

- **Stray notification bytes aborted the handshake.** `SimplePacketAssembler.parse` raised `PacketParseError` on a notification with no `\x5a\x5a` prefix or only CRC-invalid candidates - typically leftover bytes from the previous encrypted session on a freshly reconnected link. It now returns `None` ("wait for the next notification") like the encrypted `EncPacketAssembler` already does, so a stray notification can't abort auth and spin the reconnect loop.
- **Retrying a dead transport hung auth.** When the link dropped mid-request (BlueZ `Remote peer disconnected` from `start_notify`), `sendRequest` retried on a transport that was already gone, and bleak doesn't always fire its `disconnected` callback for a synchronous GATT failure. It now detects the lost link and drives `disconnected()` itself - scheduling a reconnect, idempotent with bleak's callback.
- **The setup auth wait had no deadline.** `async_setup_entry` is now bounded by `asyncio.timeout(timeout)` (the same connection timeout, matching the config flow) and disconnects on failure, so a stalled handshake surfaces as `ConfigEntryNotReady` and HA retries cleanly.

Should resolve #367 and also #366