### PR TITLE
Fix crash on BLE packets received after disconnect, throttle repeated time-sync requests

### DIFF
--- a/custom_components/ef_ble/eflib/commands.py
+++ b/custom_components/ef_ble/eflib/commands.py
@@ -1,7 +1,7 @@
 import logging
 import struct
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .devicebase import DeviceBase
 from .packet import Packet
@@ -9,10 +9,17 @@ from .pb import utc_sys_pb2
 
 _LOGGER = logging.getLogger(__name__)
 
+# Some devices (e.g. River 3 Plus) re-request the time in a tight loop when they don't
+# accept the response, which would have us flood the link with time-sync packets. The
+# device only needs the time set occasionally, so collapse repeated requests within this
+# window into a single send.
+_MIN_RESEND_INTERVAL = 30.0
+
 
 @dataclass
 class TimeCommands:
     device: DeviceBase
+    _last_sent: float | None = field(default=None, init=False)
 
     async def sendUtcTime(self):
         """Send UTC time as unix timestamp seconds through PB"""
@@ -94,6 +101,15 @@ class TimeCommands:
         await self.device._conn.sendPacket(packet)
 
     def async_send_all(self):
+        now = time.monotonic()
+        if self._last_sent is not None and now - self._last_sent < _MIN_RESEND_INTERVAL:
+            _LOGGER.debug(
+                "%s: throttling repeated time-sync request (last sent %.1fs ago)",
+                self.device.address,
+                now - self._last_sent,
+            )
+            return
+        self._last_sent = now
         self.device._conn._add_task(self.sendUtcTime())
         self.device._conn._add_task(self.sendRTCRespond())
         self.device._conn._add_task(self.sendRTCCheck())

--- a/custom_components/ef_ble/eflib/commands.py
+++ b/custom_components/ef_ble/eflib/commands.py
@@ -9,10 +9,10 @@ from .pb import utc_sys_pb2
 
 _LOGGER = logging.getLogger(__name__)
 
-# Some devices (e.g. River 3 Plus) re-request the time in a tight loop when they don't
-# accept the response, which would have us flood the link with time-sync packets. The
-# device only needs the time set occasionally, so collapse repeated requests within this
-# window into a single send.
+# Some devices re-request the time in a tight loop when they don't accept the response,
+# which would have us flood the link with time-sync packets. The device only needs the
+# time set occasionally, so collapse repeated requests within this window into a single
+# send.
 _MIN_RESEND_INTERVAL = 30.0
 
 

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -1127,6 +1127,14 @@ class Connection:
         self._reset_error_counter()
 
         for packet in packets:
+            if self._client is None:
+                self._logger.log_filtered(
+                    LogOptions.CONNECTION_DEBUG,
+                    "Dropping buffered packet after disconnect: %r",
+                    packet,
+                )
+                return
+
             processed = False
 
             is_auth_reply = (


### PR DESCRIPTION
This PR fixes two independent BLE connection-lifecycle issues that surfaced as repeated reconnect flapping and noisy error logs on long-running setups.

- **`'NoneType' object has no attribute 'replyPacket'` after disconnect.** `listenForDataHandler` is registered directly as the bleak notify callback, so it isn't tracked in `_tasks` and `_cancel_tasks()` never cancels it on teardown. bleak can still hand us notifications buffered before the drop *after* `Connection.disconnect()` has cleared `_client` and the device has cleared its `_conn`. The handler now bails out of the packet loop as soon as `_client` is `None` - guarding the central choke point covers every device and every reply path, and replying on a dead link is pointless anyway. This could've been the cause for #375.

- **Repeated time-sync requests flooded the link.** Some devices (e.g. River 3 Plus in #367) re-request the time in a tight loop when they don't accept the response, which had us fire a fresh `sendUtcTime` / `sendRTCRespond` / `sendRTCCheck` burst on every request.  The device only needs the time set occasionally, so `TimeCommands.async_send_all` now collapses repeated requests within a 30s window into a single send