### PR TITLE
Refresh extra battery serial number and model in the device registry

### DIFF
--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Mapping
 from typing import Any, Protocol, runtime_checkable
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
@@ -87,10 +88,11 @@ class EcoflowBatteryAddonEntity(EcoflowEntity):
     ) -> None:
         super().__init__(device)
         self._battery_index = battery_index
+        self._sn_prop = f"battery_{battery_index}_sn"
 
     @property
     def device_info(self) -> DeviceInfo:
-        battery_sn = getattr(self._device, f"battery_{self._battery_index}_sn", None)
+        battery_sn = getattr(self._device, self._sn_prop, None)
         battery_model = battery_name_from_device(self._device, self._battery_index)
 
         return DeviceInfo(
@@ -102,6 +104,41 @@ class EcoflowBatteryAddonEntity(EcoflowEntity):
             model=battery_model,
             serial_number=battery_sn,
             via_device=(DOMAIN, self._device.address),
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._device.register_state_update_callback(
+            self._refresh_device_registry, self._sn_prop
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._device.remove_state_update_callback(
+            self._refresh_device_registry, self._sn_prop
+        )
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _refresh_device_registry(self, battery_sn: str | None) -> None:
+        """Push a late-arriving battery serial number into the device registry"""
+        if not battery_sn:
+            return
+
+        registry = dr.async_get(self.hass)
+        identifier = (DOMAIN, f"{self._device.address}_battery_{self._battery_index}")
+        device_entry = registry.async_get_device(identifiers={identifier})
+        if device_entry is None:
+            return
+
+        battery_model = battery_name_from_device(self._device, self._battery_index)
+        if (
+            device_entry.serial_number == battery_sn
+            and device_entry.model == battery_model
+        ):
+            return
+
+        registry.async_update_device(
+            device_entry.id, serial_number=battery_sn, model=battery_model
         )
 
 


### PR DESCRIPTION
The serial number of an extra battery rides in only about half of the device's `DisplayPropertyUpload` messages, so it can arrive *after* the extra-battery entity - and its device registry entry - were first created. `EcoflowBatteryAddonEntity.device_info` exposes `serial_number` (and the model name derived from it via `battery_name_from_device`), but HA reads `device_info` only once when the entity is added. If no SN-bearing message had landed before platform setup, the registry entry was written with `serial_number=None` and a fallback `"Extra Battery"` model and then never refreshed - so the serial number was missing "in some cases" depending on timing.

This PR makes `EcoflowBatteryAddonEntity` register a state-update callback on `battery_{index}_sn` and pushes the value into the device registry (`async_update_device`) once it is known, updating both the serial number and the model. It is a no-op when the SN is empty, the registry entry is missing, or the entry is already current.

Should address discussion in #362 