### PR TITLE
Restore PowerStream battery level field, expose the other SoC fields as diagnostics

### DIFF
--- a/custom_components/ef_ble/eflib/devices/powerstream.py
+++ b/custom_components/ef_ble/eflib/devices/powerstream.py
@@ -34,7 +34,9 @@ class Device(DeviceBase, ProtobufProps):
     pv_current_2 = pb_field(pb.pv2_input_cur, pdiv(10, 1))
     pv_temperature_2 = pb_field(pb.pv2_temp, pdiv(10, 1))
 
-    battery_level = pb_field(pb_inv2.new_psdr_heartbeat.f32_lcd_show_soc, pround(2))
+    battery_level = pb_field(pb_inv2.new_psdr_heartbeat.f32_show_soc, pround(2))
+    lcd_battery_level = pb_field(pb_inv2.new_psdr_heartbeat.f32_lcd_show_soc, pround(2))
+    bms_battery_level = pb_field(pb.bat_soc)
     battery_power = pb_field(pb.bat_input_watts, pdiv(10, 1))
     battery_temperature = pb_field(pb.bat_temp, pdiv(10, 1))
 

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -843,6 +843,12 @@ _SENSORS: Final[dict[str, SensorEntityDescription]] = {
     "power_mppt": power(precision=0),
     "water_level": enum(options=wave2.WaterLevel),
     # PowerStream
+    "lcd_battery_level": battery(
+        enabled=False, entity_category=EntityCategory.DIAGNOSTIC
+    ),
+    "bms_battery_level": battery(
+        enabled=False, entity_category=EntityCategory.DIAGNOSTIC
+    ),
     "battery_power": power(precision=1),
     "inverter_temperature": temperature(),
     "inverter_current": current(precision=2),

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -380,6 +380,12 @@
       "battery_level": {
         "name": "Battery Level"
       },
+      "lcd_battery_level": {
+        "name": "LCD Battery Level"
+      },
+      "bms_battery_level": {
+        "name": "BMS Battery Level"
+      },
       "battery_time_remaining": {
         "name": "Battery Time Remaining"
       },

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -380,6 +380,12 @@
       "battery_level": {
         "name": "Рівень заряду батареї"
       },
+      "lcd_battery_level": {
+        "name": "Рівень заряду батареї LCD"
+      },
+      "bms_battery_level": {
+        "name": "Рівень заряду батареї BMS"
+      },
       "battery_time_remaining": {
         "name": "Залишок часу роботи батареї"
       },

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -380,6 +380,12 @@
       "battery_level": {
         "name": "电池电量"
       },
+      "lcd_battery_level": {
+        "name": "LCD 电池电量"
+      },
+      "bms_battery_level": {
+        "name": "BMS 电池电量"
+      },
       "battery_time_remaining": {
         "name": "电池剩余时间"
       },

--- a/tests/eflib/test_powerstream.py
+++ b/tests/eflib/test_powerstream.py
@@ -163,7 +163,9 @@ async def test_powerstream_exact_values_from_known_packets(device, packet_sequen
         await device.data_parse(await device.packet_parse(bytes.fromhex(packet)))
 
     expected = {
-        Device.battery_level: 31.02,
+        Device.battery_level: 46.15,
+        Device.lcd_battery_level: 31.02,
+        Device.bms_battery_level: 31,
         Device.battery_power: 0.0,
         Device.battery_temperature: 21.0,
         Device.pv_power_1: 6.0,


### PR DESCRIPTION
#337 switched the PowerStream `battery_level` to `new_psdr_heartbeat.f32_lcd_show_soc` because it tracked the cloud / Delta 2 Max SoC most closely. That field turns out not to be reported by every PowerStream (e.g. the 600W on FW 1.0.1.288), so for those devices the battery level has been showing `Unknown` ever since - even though every other value is reported fine over BLE and the SoC is available via the cloud.

This restores the default `battery_level` to `f32_show_soc` (the field used before 0.9.1), which is present on all PowerStreams, and exposes the other SoC readings as diagnostic, disabled-by-default sensors so the value some users preferred isn't lost and the alternatives stay available for debugging:
- `lcd_battery_level` - `new_psdr_heartbeat.f32_lcd_show_soc` (what 0.9.1 used)
- `bms_battery_level` - `bat_soc`

Resolves #369
