### PR TITLE
Add support for EcoFlow E980 (Delta 2 Black)

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Click on any device below to see available sensors, switches, and controls:
 </details>
 
 <details>
-<summary><b>Delta 2</b> <i>(Max, Delta 3 1500)</i></summary>
+<summary><b>Delta 2</b> <i>(Max, Black (E980), Delta 3 1500)</i></summary>
 
 <br>
 

--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -116,6 +116,8 @@ class Delta2Base(DeviceBase, RawDataProps):
                 model = "3 1500"
             case "R351" | "R354":
                 model = "2 Max"
+            case "R701":
+                model = "2 Black"
 
         return f"Delta {model}"
 

--- a/custom_components/ef_ble/eflib/devices/delta2_black.py
+++ b/custom_components/ef_ble/eflib/devices/delta2_black.py
@@ -1,0 +1,8 @@
+from . import delta2
+
+
+class Device(delta2.Device):
+    """Delta 2 Black (E980)"""
+
+    SN_PREFIX = (b"R701",)
+    NAME_PREFIX = "EF-R70"

--- a/custom_components/ef_ble/manifest.json
+++ b/custom_components/ef_ble/manifest.json
@@ -190,6 +190,12 @@
             "manufacturer_id": 46517,
             "manufacturer_data_start": [19, 80, 49, 48],
             "connectable": true
+        },
+        {
+            "local_name": "EF-R70*",
+            "manufacturer_id": 46517,
+            "manufacturer_data_start": [19, 82, 55, 48],
+            "connectable": true
         }
     ],
 


### PR DESCRIPTION
This PR adds support for Delta 2 Black (E980) variant of the Delta 2.

Resolves #386