### PR TITLE
Performance: Reuse table-based CRC Calculators

### DIFF
--- a/custom_components/ef_ble/eflib/crc.py
+++ b/custom_components/ef_ble/eflib/crc.py
@@ -12,9 +12,13 @@ crc16_arc = Configuration(
 )
 
 
+_crc8_calculator = Calculator(Crc8.CCITT, optimized=True)
+_crc16_calculator = Calculator(crc16_arc, optimized=True)
+
+
 def crc8(data: bytes):
-    return Calculator(Crc8.CCITT).checksum(data)
+    return _crc8_calculator.checksum(data)
 
 
 def crc16(data: bytes):
-    return Calculator(crc16_arc).checksum(data)
+    return _crc16_calculator.checksum(data)


### PR DESCRIPTION
Reuse table-based CRC Calculators Instead of rebuilding a bit-by-bit one per call

crc8()/crc16() constructed a fresh Calculator on every call, defaulting to the slow bit-by-bit Register. These run once per candidate frame during BLE frame reassembly (EncPacketAssembler/PassthroughAssembler/RawHeaderAssembler) and per packet parsed in Packet.from_bytes/to_bytes and PacketV4, all on listenForDataHandler's hot path for every BLE notification.

Use module-level Calculator(optimized=True) singletons instead - same output, ~2.4x faster for a 256-byte buffer in a local microbenchmark, no per-call allocation.

Performance improvement was tested with two DPUs, an SHP2, and a Wave 2 device on the same bluetooth USB dongle. HA average CPU usage went from ~50% down to ~22%.