### PR TITLE
Add EPS mode switch for SHP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Click on any device below to see available sensors, switches, and controls:
 | Battery Level                       | Circuit On/Off (Each Circuit) | Charge Limit         | Operating Mode |
 | Battery Power                       | Channel On/Off (Each Channel) | Discharge Limit      |                |
 | System Load                         | Storm Guard                   | Backup Reserve Level |                |
-| Load From Grid                      |                               | AC Charging Speed    |                |
+| Load From Grid                      | EPS Mode                      | AC Charging Speed    |                |
 | PV Power Total                      |                               |                      |                |
 | Grid Connection Status              |                               |                      |                |
 | Grid Energized                      |                               |                      |                |

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -251,7 +251,7 @@ class Device(DeviceBase, ProtobufProps):
     _mode_generic = pb_field(
         pb.energy_strategy_operate_mode, _operating_mode_from_message
     )
-    _eps_mode = pb_field(
+    eps_mode = pb_field(
         pb.panle_energy_strategy_operate_mode.operate_eps_mode,
         TransformIfMissing(bool),
     )
@@ -440,7 +440,7 @@ class Device(DeviceBase, ProtobufProps):
         message.operate_intelligent_schedule_mode_open = (
             mode is OperatingMode.INTELLIGENT
         )
-        message.operate_eps_mode = bool(self._eps_mode)
+        message.operate_eps_mode = bool(self.eps_mode)
         message.operate_mix_scheduled_open = bool(self._mix_scheduled)
 
         await self._send_config_packet(config)
@@ -449,6 +449,28 @@ class Device(DeviceBase, ProtobufProps):
     async def set_storm_guard(self, enable: bool):
         config = dev_apl_comm_pb2.ConfigWrite()
         config.cfg_storm_pattern.storm_pattern_enable = enable
+        await self._send_config_packet(config)
+
+    @controls.switch(eps_mode)
+    async def set_eps_mode(self, enable: bool):
+        """
+        Toggle EPS (fast-cutover) mode.
+
+        The panel applies `cfg_panle_energy_strategy_operate_mode` as a whole, so
+        the current operating mode and mix-scheduled flag are written back
+        alongside the new EPS value to avoid clearing the operating mode
+        (mirrors `set_operating_mode`, which preserves EPS the same way).
+        """
+        config = dev_apl_comm_pb2.ConfigWrite()
+        message = config.cfg_panle_energy_strategy_operate_mode
+        mode = self.operating_mode_select
+        message.operate_self_powered_open = mode is OperatingMode.SELF_POWERED
+        message.operate_scheduled_open = mode is OperatingMode.SCHEDULED
+        message.operate_intelligent_schedule_mode_open = (
+            mode is OperatingMode.INTELLIGENT
+        )
+        message.operate_eps_mode = enable
+        message.operate_mix_scheduled_open = bool(self._mix_scheduled)
         await self._send_config_packet(config)
 
     @controls.for_each(

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -428,11 +428,15 @@ class Device(DeviceBase, ProtobufProps):
         await self._send_config_packet(config)
         return True
 
-    @controls.select(operating_mode_select, options=OperatingMode)
-    async def set_operating_mode(self, mode: OperatingMode):
-        if mode is OperatingMode.UNKNOWN:
-            return
+    async def _write_energy_strategy(
+        self, mode: OperatingMode | None, eps_enable: bool
+    ):
+        """
+        Write the full `cfg_panle_energy_strategy_operate_mode` message.
 
+        The panel applies the message as a whole, so operating mode, EPS and
+        mix-scheduled are always written together to avoid clearing each other.
+        """
         config = dev_apl_comm_pb2.ConfigWrite()
         message = config.cfg_panle_energy_strategy_operate_mode
         message.operate_self_powered_open = mode is OperatingMode.SELF_POWERED
@@ -440,10 +444,16 @@ class Device(DeviceBase, ProtobufProps):
         message.operate_intelligent_schedule_mode_open = (
             mode is OperatingMode.INTELLIGENT
         )
-        message.operate_eps_mode = bool(self.eps_mode)
+        message.operate_eps_mode = eps_enable
         message.operate_mix_scheduled_open = bool(self._mix_scheduled)
-
         await self._send_config_packet(config)
+
+    @controls.select(operating_mode_select, options=OperatingMode)
+    async def set_operating_mode(self, mode: OperatingMode):
+        if mode is OperatingMode.UNKNOWN:
+            return
+
+        await self._write_energy_strategy(mode, bool(self.eps_mode))
 
     @controls.switch(storm_guard)
     async def set_storm_guard(self, enable: bool):
@@ -453,25 +463,8 @@ class Device(DeviceBase, ProtobufProps):
 
     @controls.switch(eps_mode)
     async def set_eps_mode(self, enable: bool):
-        """
-        Toggle EPS (fast-cutover) mode.
-
-        The panel applies `cfg_panle_energy_strategy_operate_mode` as a whole, so
-        the current operating mode and mix-scheduled flag are written back
-        alongside the new EPS value to avoid clearing the operating mode
-        (mirrors `set_operating_mode`, which preserves EPS the same way).
-        """
-        config = dev_apl_comm_pb2.ConfigWrite()
-        message = config.cfg_panle_energy_strategy_operate_mode
-        mode = self.operating_mode_select
-        message.operate_self_powered_open = mode is OperatingMode.SELF_POWERED
-        message.operate_scheduled_open = mode is OperatingMode.SCHEDULED
-        message.operate_intelligent_schedule_mode_open = (
-            mode is OperatingMode.INTELLIGENT
-        )
-        message.operate_eps_mode = enable
-        message.operate_mix_scheduled_open = bool(self._mix_scheduled)
-        await self._send_config_packet(config)
+        """Toggle EPS (fast-cutover) mode, preserving the operating mode."""
+        await self._write_energy_strategy(self.operating_mode_select, enable)
 
     @controls.for_each(
         channel_is_enabled,

--- a/tests/eflib/test_shp3.py
+++ b/tests/eflib/test_shp3.py
@@ -382,7 +382,9 @@ async def test_shp3_set_eps_mode_preserves_operating_mode_and_mix(device):
     msg = dev_apl_comm_pb2.DisplayPropertyUpload()
     msg.panle_energy_strategy_operate_mode.operate_scheduled_open = True
     msg.panle_energy_strategy_operate_mode.operate_mix_scheduled_open = True
-    device.update_from_bytes(dev_apl_comm_pb2.DisplayPropertyUpload, msg.SerializeToString())
+    device.update_from_bytes(
+        dev_apl_comm_pb2.DisplayPropertyUpload, msg.SerializeToString()
+    )
 
     await device.set_eps_mode(True)
 

--- a/tests/eflib/test_shp3.py
+++ b/tests/eflib/test_shp3.py
@@ -244,7 +244,7 @@ async def test_shp3_set_ac_charging_speed_rounds_to_step(device):
 
 
 async def test_shp3_set_operating_mode_preserves_eps_and_mix(device):
-    device.set_value("_eps_mode", True)
+    device.set_value("eps_mode", True)
 
     await device.set_operating_mode(OperatingMode.SELF_POWERED)
 
@@ -376,3 +376,20 @@ async def test_shp3_echoes_liveness_ping(device):
     processed = await device.data_parse(ping)
     assert processed is True
     device._conn.replyPacket.assert_awaited_once()
+
+
+async def test_shp3_set_eps_mode_preserves_operating_mode_and_mix(device):
+    msg = dev_apl_comm_pb2.DisplayPropertyUpload()
+    msg.panle_energy_strategy_operate_mode.operate_scheduled_open = True
+    msg.panle_energy_strategy_operate_mode.operate_mix_scheduled_open = True
+    device.update_from_bytes(dev_apl_comm_pb2.DisplayPropertyUpload, msg.SerializeToString())
+
+    await device.set_eps_mode(True)
+
+    packet = device._conn.sendPacket.await_args.args[0]
+    mode = _config_write(device, packet).cfg_panle_energy_strategy_operate_mode
+    assert mode.operate_eps_mode is True
+    assert mode.operate_scheduled_open is True
+    assert mode.operate_self_powered_open is False
+    assert mode.operate_intelligent_schedule_mode_open is False
+    assert mode.operate_mix_scheduled_open is True


### PR DESCRIPTION
Exposes the SHP3 EPS (fast-cutover) flag as a switch entity.

What

- Makes the already-parsed _eps_mode field public as eps_mode and adds a @controls.switch for it.
- The setter writes the full cfg_panle_energy_strategy_operate_mode message with the current operating mode and mix-scheduled flag carried over, mirroring how set_operating_mode preserves EPS in the other direction — so neither control can clear the other's state.
- No translation changes needed: the eps_mode switch key already exists in en.json (used by other devices).
- Adds a test (test_shp3_set_eps_mode_preserves_operating_mode_and_mix) decoding the write frame and asserting mode/mix preservation, alongside the existing test_shp3_set_operating_mode_preserves_eps_and_mix.


Why

EPS controls whether the panel does fast cutover on grid loss. The SHP3 firmware
couples it to the operating-mode message (and auto-clears it when entering
Self-Powered), so HA users running TOU/mode automations want to read and set it
without round-tripping through the EcoFlow app. The field was already decoded —
this just exposes the write path that #389's notes identified and #394's message
construction already preserves.

Testing

- Tested live on an HR63 panel over BLE via an ESPHome proxy: switch state tracks the panel, toggling writes take effect, and mode flips from a running TOU scheduler (Backup → Scheduled → Self-Powered daily) don't clear EPS and vice versa. I've been running this switch (in earlier form) on the GnoX fork since late June alongside the #111 write-path testing.
- pytest tests/eflib/ — 105 passed.


Disclosure

AI-assisted (Claude), per CONTRIBUTING.md: I've read the diff, it follows the
existing storm_guard / set_operating_mode patterns, and I can respond to
review feedback. Happy to adjust naming or approach.