### PR TITLE
Replace crc library with hand-rolled table-based CRC8/CRC16

### DIFF
--- a/custom_components/ef_ble/eflib/crc.py
+++ b/custom_components/ef_ble/eflib/crc.py
@@ -1,24 +1,53 @@
-"""Utils for simple use of crc"""
+"""
+Table-based CRC8/CRC16 for the BLE receive path
 
-from crc import Calculator, Configuration, Crc8
+Hand-rolled instead of relying on the `crc` package: that library re-derives its
+lookup table via a bit-by-bit register on every `Calculator` construction and, even
+when using its table-based register, still processes each byte through a Python-level
+`Byte` wrapper object (plus an extra bit-reversal pass per byte for CRC16, since our
+config uses reflected input). This runs once per candidate frame while scanning for a
+BLE notification's frame boundary and once per packet parsed, so the per-byte overhead
+adds up. The tables below are precomputed once at import time; encoding/decoding a byte
+is then a single list lookup and XOR - no per-byte object wrapping.
 
-crc16_arc = Configuration(
-    width=16,
-    polynomial=0x8005,
-    init_value=0x0000,
-    final_xor_value=0x0000,
-    reverse_input=True,
-    reverse_output=True,
-)
-
-
-_crc8_calculator = Calculator(Crc8.CCITT, optimized=True)
-_crc16_calculator = Calculator(crc16_arc, optimized=True)
-
-
-def crc8(data: bytes):
-    return _crc8_calculator.checksum(data)
+crc8: width=8, poly=0x07, init=0x00, no reflection (matches `crc.Crc8.CCITT`)
+crc16: width=16, poly=0x8005, init=0x0000, reflected in/out (matches CRC-16/ARC)
+"""
 
 
-def crc16(data: bytes):
-    return _crc16_calculator.checksum(data)
+def _build_crc8_table() -> list[int]:
+    table = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x07) & 0xFF if crc & 0x80 else (crc << 1) & 0xFF
+        table.append(crc)
+    return table
+
+
+def _build_crc16_table() -> list[int]:
+    table = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xA001 if crc & 1 else crc >> 1
+        table.append(crc)
+    return table
+
+
+_CRC8_TABLE = _build_crc8_table()
+_CRC16_TABLE = _build_crc16_table()
+
+
+def crc8(data: bytes) -> int:
+    crc = 0x00
+    for b in data:
+        crc = _CRC8_TABLE[crc ^ b]
+    return crc
+
+
+def crc16(data: bytes) -> int:
+    crc = 0x0000
+    for b in data:
+        crc = _CRC16_TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc

--- a/custom_components/ef_ble/manifest.json
+++ b/custom_components/ef_ble/manifest.json
@@ -228,7 +228,6 @@
 
     "requirements": [
         "ecdsa~=0.19",
-        "crc~=7.1",
         "PyCryptodome~=3.23",
         "protobuf~=6.30"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
   "bleak",
   "bleak-retry-connector",
   "bluetooth-adapters",
-  "crc~=7.1",
   "ecdsa~=0.19",
   "protobuf~=6.30",
   "pycryptodome~=3.23",


### PR DESCRIPTION
Even though I'd much rather use an established library, the performance of the CRC functions still remain the highest CPU drag when doing any profiling on Home Assistant core... especially with four EcoFlow devices connected. I have 50+ other integrations with 300+ other entities and the next highest thing for CPU utilization isn't even close. By rolling our own, we optimize a highly repeated code path so that CRC calculation in `listenForDataHandler` moves from 39.91s cumulative time (over 60s sample) to 4.997s... an almost 8x reduction. All these cycles matter greatly on small embedded devices like the Raspberry Pis (or previously retired hardware that get recommissioned to run HA).

## Summary
- Even with a cached, table-based `Calculator` (merged previously in #392), the `crc` package still processes each byte through a Python-level `Byte` wrapper object, plus an extra bit-reversal pass per byte for `crc16` (our config uses reflected input `reverse_input=True`). Profiling showed `crc16` for a 244-byte payload still took ~500us/call - roughly two orders of magnitude slower than the AES decrypt (~6us) applied to that same payload, on `Connection.listenForDataHandler`'s receive path.
- Replaced `crc8()`/`crc16()` in [`crc.py`](custom_components/ef_ble/eflib/crc.py) with hand-rolled table-based implementations: two 256-entry lookup tables precomputed once at import time, then a tight per-byte loop with no object wrapping.
- Dropped the `crc~=7.1` dependency from [`manifest.json`](custom_components/ef_ble/manifest.json) and [`pyproject.toml`](pyproject.toml), since it's no longer used anywhere in the codebase.

## Why
CRC checksums run once per candidate frame while scanning for a BLE notification's frame boundary, and once per packet parsed - all on `listenForDataHandler`'s hot path. Removing the third-party library's per-byte object overhead in favor of a minimal, standard table-based implementation (CRC-8/CCITT, CRC-16/ARC - both well-known, easily verifiable algorithms) gives a large additional speedup with no behavior change, and removes a dependency as a bonus.

## Test plan
- [x] `pytest tests/` — 104 passed
- [x] Fuzzed the new implementation against the original `crc` library across 5000 random buffers (0-600B) — byte-identical output for both `crc8` and `crc16`
- [x] Isolated benchmark: 18-25x faster for `crc8`, 36-42x faster for `crc16`, on top of the caching fix from #392
- [x] End-to-end `EncPacketAssembler.reassemble()` benchmark with real encrypted frames, vs. the original (pre-#392) `crc` library:
  - 1 small packet (~20B payload): 2.3x speedup measured
  - 1 typical packet (~120B payload): 5.8x speedup measured
  - 5 packets batched in one notification: 12.3x speedup measured
- [x] Function verified on HAOS 18.1, Core 2026.7.1, with 2 DPUs, SHP2, and Wave 2 connected on a single USB BLE dongle.