### PR TITLE
Add per-channel force charge (Charge Now) switch for SHP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Click on any device below to see available sensors, switches, and controls:
 | Circuit Status (Each Circuit)       |                               |                      |                |
 | Channel Type (Each Channel)         |                               |                      |                |
 | Channel Signal Line (Each Channel)  |                               |                      |                |
-| Channel Force Charge (Each Channel) |                               |                      |                |
+|                                     | Channel Force Charge (Each Channel) |                      |                |
 
 > **📝 Note:** Using an ESPHome bluetooth proxy connection with a Smart Home Panel 3 can
 > result in slow performance and dropped packets at this time. Please see the

--- a/README.md
+++ b/README.md
@@ -77,26 +77,26 @@ Click on any device below to see available sensors, switches, and controls:
 
 <br>
 
-| *Sensors*                           | *Switches*                    | *Sliders*            | *Selects*      |
-|-------------------------------------|-------------------------------|----------------------|----------------|
-| Battery Level                       | Circuit On/Off (Each Circuit) | Charge Limit         | Operating Mode |
-| Battery Power                       | Channel On/Off (Each Channel) | Discharge Limit      |                |
-| System Load                         | Storm Guard                   | Backup Reserve Level |                |
-| Load From Grid                      | EPS Mode                      | AC Charging Speed    |                |
-| PV Power Total                      | Channel Force Charge (Each Channel) |                      |                |
-| Grid Connection Status              |                               |                      |                |
-| Grid Energized                      |                               |                      |                |
-| Charge Time Remaining               |                               |                      |                |
-| Discharge Time Remaining            |                               |                      |                |
-| L1 / L2 / L3 Power                  |                               |                      |                |
-| L1 / L2 / L3 Voltage                |                               |                      |                |
-| L1 / L2 / L3 Current                |                               |                      |                |
-| Circuit Power (Each Circuit)        |                               |                      |                |
-| Circuit Current (Each Circuit)      |                               |                      |                |
-| Circuit Voltage (Each Circuit)      |                               |                      |                |
-| Circuit Status (Each Circuit)       |                               |                      |                |
-| Channel Type (Each Channel)         |                               |                      |                |
-| Channel Signal Line (Each Channel)  |                               |                      |                |
+| *Sensors*                          | *Switches*                          | *Sliders*            | *Selects*      |
+|------------------------------------|-------------------------------------|----------------------|----------------|
+| Battery Level                      | Circuit On/Off (Each Circuit)       | Charge Limit         | Operating Mode |
+| Battery Power                      | Channel On/Off (Each Channel)       | Discharge Limit      |                |
+| System Load                        | Storm Guard                         | Backup Reserve Level |                |
+| Load From Grid                     | EPS Mode                            | AC Charging Speed    |                |
+| PV Power Total                     | Channel Force Charge (Each Channel) |                      |                |
+| Grid Connection Status             |                                     |                      |                |
+| Grid Energized                     |                                     |                      |                |
+| Charge Time Remaining              |                                     |                      |                |
+| Discharge Time Remaining           |                                     |                      |                |
+| L1 / L2 / L3 Power                 |                                     |                      |                |
+| L1 / L2 / L3 Voltage               |                                     |                      |                |
+| L1 / L2 / L3 Current               |                                     |                      |                |
+| Circuit Power (Each Circuit)       |                                     |                      |                |
+| Circuit Current (Each Circuit)     |                                     |                      |                |
+| Circuit Voltage (Each Circuit)     |                                     |                      |                |
+| Circuit Status (Each Circuit)      |                                     |                      |                |
+| Channel Type (Each Channel)        |                                     |                      |                |
+| Channel Signal Line (Each Channel) |                                     |                      |                |
 
 > **📝 Note:** Using an ESPHome bluetooth proxy connection with a Smart Home Panel 3 can
 > result in slow performance and dropped packets at this time. Please see the

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Click on any device below to see available sensors, switches, and controls:
 | Battery Power                       | Channel On/Off (Each Channel) | Discharge Limit      |                |
 | System Load                         | Storm Guard                   | Backup Reserve Level |                |
 | Load From Grid                      | EPS Mode                      | AC Charging Speed    |                |
-| PV Power Total                      |                               |                      |                |
+| PV Power Total                      | Channel Force Charge (Each Channel) |                      |                |
 | Grid Connection Status              |                               |                      |                |
 | Grid Energized                      |                               |                      |                |
 | Charge Time Remaining               |                               |                      |                |
@@ -97,7 +97,6 @@ Click on any device below to see available sensors, switches, and controls:
 | Circuit Status (Each Circuit)       |                               |                      |                |
 | Channel Type (Each Channel)         |                               |                      |                |
 | Channel Signal Line (Each Channel)  |                               |                      |                |
-|                                     | Channel Force Charge (Each Channel) |                      |                |
 
 > **📝 Note:** Using an ESPHome bluetooth proxy connection with a Smart Home Panel 3 can
 > result in slow performance and dropped packets at this time. Please see the

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -470,8 +470,10 @@ class Device(DeviceBase, ProtobufProps):
         self, channel_id: int, *, enable: bool, force_charge: bool
     ):
         """
-        Write a backup channel's `BackupCtrl` - the panel applies ctrl_en and
-        ctrl_force_chg together, so both are always sent (on = 1, off = 2)
+        Write a backup channel's `BackupCtrl`
+
+        The panel applies ctrl_en and ctrl_force_chg together, so both are
+        always sent (on = 1, off = 2).
         """
         config = dev_apl_comm_pb2.ConfigWrite()
         ctrl = pb_indexed_attr(

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -432,7 +432,7 @@ class Device(DeviceBase, ProtobufProps):
         self, mode: OperatingMode | None, eps_enable: bool
     ):
         """
-        Write the full `cfg_panle_energy_strategy_operate_mode` message.
+        Write the full `cfg_panle_energy_strategy_operate_mode` message
 
         The panel applies the message as a whole, so operating mode, EPS and
         mix-scheduled are always written together to avoid clearing each other.
@@ -463,8 +463,24 @@ class Device(DeviceBase, ProtobufProps):
 
     @controls.switch(eps_mode)
     async def set_eps_mode(self, enable: bool):
-        """Toggle EPS (fast-cutover) mode, preserving the operating mode."""
+        """Toggle EPS (fast-cutover) mode, preserving the operating mode"""
         await self._write_energy_strategy(self.operating_mode_select, enable)
+
+    async def _write_backup_channel_ctrl(
+        self, channel_id: int, *, enable: bool, force_charge: bool
+    ):
+        """
+        Write a backup channel's `BackupCtrl` - the panel applies ctrl_en and
+        ctrl_force_chg together, so both are always sent (on = 1, off = 2)
+        """
+        config = dev_apl_comm_pb2.ConfigWrite()
+        ctrl = pb_indexed_attr(
+            config, pb_cfg.cfg_panel_backup_ch1_ctrl, "cfg_panel_backup_ch{n}_ctrl"
+        )
+        backup = ctrl[channel_id]
+        backup.ctrl_en = 1 if enable else 2
+        backup.ctrl_force_chg = 1 if force_charge else 2
+        await self._send_config_packet(config)
 
     @controls.for_each(
         channel_force_charge,
@@ -473,22 +489,12 @@ class Device(DeviceBase, ProtobufProps):
         translation_placeholders=lambda i: {"channel": str(i)},
     )
     async def set_channel_force_charge(self, channel_id: int, enable: bool):
-        """
-        Force-charge (Charge Now) a backup channel via `cfg_panel_backup_ch{N}_ctrl`.
-
-        `BackupCtrl` carries both the channel enable (ctrl_en) and the force-charge
-        toggle (ctrl_force_chg) and the panel applies them together, so the current
-        enable state is written back alongside the new force-charge value
-        (on = 1, off = 2), mirroring `set_channel_enable`.
-        """
-        config = dev_apl_comm_pb2.ConfigWrite()
-        ctrl = pb_indexed_attr(
-            config, pb_cfg.cfg_panel_backup_ch1_ctrl, "cfg_panel_backup_ch{n}_ctrl"
+        """Force-charge (Charge Now in the EcoFlow app) a backup channel"""
+        await self._write_backup_channel_ctrl(
+            channel_id,
+            enable=bool(self.channel_is_enabled[channel_id]),
+            force_charge=enable,
         )
-        backup = ctrl[channel_id]
-        backup.ctrl_en = 1 if self.channel_is_enabled[channel_id] else 2
-        backup.ctrl_force_chg = 1 if enable else 2
-        await self._send_config_packet(config)
 
     @controls.for_each(
         channel_is_enabled,
@@ -497,21 +503,11 @@ class Device(DeviceBase, ProtobufProps):
         translation_placeholders=lambda i: {"channel": str(i)},
     )
     async def set_channel_enable(self, channel_id: int, enable: bool):
-        """
-        Enable / disable a backup channel via `cfg_panel_backup_ch{N}_ctrl`.
-
-        `BackupCtrl` carries both the channel enable (ctrl_en) and the force-charge
-        toggle (ctrl_force_chg), and the panel applies them together, so we send the
-        current force-charge state alongside the new enable value (on = 1, off = 2).
-        """
-        config = dev_apl_comm_pb2.ConfigWrite()
-        ctrl = pb_indexed_attr(
-            config, pb_cfg.cfg_panel_backup_ch1_ctrl, "cfg_panel_backup_ch{n}_ctrl"
+        await self._write_backup_channel_ctrl(
+            channel_id,
+            enable=enable,
+            force_charge=bool(self.channel_force_charge[channel_id]),
         )
-        backup = ctrl[channel_id]
-        backup.ctrl_en = 1 if enable else 2
-        backup.ctrl_force_chg = 1 if self.channel_force_charge[channel_id] else 2
-        await self._send_config_packet(config)
 
 
 class _StandardProtocolRouting:

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -467,6 +467,30 @@ class Device(DeviceBase, ProtobufProps):
         await self._write_energy_strategy(self.operating_mode_select, enable)
 
     @controls.for_each(
+        channel_force_charge,
+        control=controls.switch,
+        translation_key="ch_force_charge",
+        translation_placeholders=lambda i: {"channel": str(i)},
+    )
+    async def set_channel_force_charge(self, channel_id: int, enable: bool):
+        """
+        Force-charge (Charge Now) a backup channel via `cfg_panel_backup_ch{N}_ctrl`.
+
+        `BackupCtrl` carries both the channel enable (ctrl_en) and the force-charge
+        toggle (ctrl_force_chg) and the panel applies them together, so the current
+        enable state is written back alongside the new force-charge value
+        (on = 1, off = 2), mirroring `set_channel_enable`.
+        """
+        config = dev_apl_comm_pb2.ConfigWrite()
+        ctrl = pb_indexed_attr(
+            config, pb_cfg.cfg_panel_backup_ch1_ctrl, "cfg_panel_backup_ch{n}_ctrl"
+        )
+        backup = ctrl[channel_id]
+        backup.ctrl_en = 1 if self.channel_is_enabled[channel_id] else 2
+        backup.ctrl_force_chg = 1 if enable else 2
+        await self._send_config_packet(config)
+
+    @controls.for_each(
         channel_is_enabled,
         control=controls.switch,
         translation_key="channel_is_enabled",

--- a/tests/eflib/test_shp3.py
+++ b/tests/eflib/test_shp3.py
@@ -395,3 +395,35 @@ async def test_shp3_set_eps_mode_preserves_operating_mode_and_mix(device):
     assert mode.operate_self_powered_open is False
     assert mode.operate_intelligent_schedule_mode_open is False
     assert mode.operate_mix_scheduled_open is True
+
+
+async def test_shp3_set_channel_force_charge_preserves_enable(device):
+    msg = dev_apl_comm_pb2.DisplayPropertyUpload()
+    msg.panel_backup_ch1_Info.ch_dev_type = 1
+    msg.panel_backup_ch1_Info.ch_sta = 1
+    device.update_from_bytes(
+        dev_apl_comm_pb2.DisplayPropertyUpload, msg.SerializeToString()
+    )
+
+    await device.set_channel_force_charge(1, True)
+
+    packet = device._conn.sendPacket.await_args.args[0]
+    ctrl = _config_write(device, packet).cfg_panel_backup_ch1_ctrl
+    assert ctrl.ctrl_force_chg == 1
+    assert ctrl.ctrl_en == 1
+
+
+async def test_shp3_set_channel_force_charge_off_on_disabled_channel(device):
+    msg = dev_apl_comm_pb2.DisplayPropertyUpload()
+    msg.panel_backup_ch2_Info.ch_dev_type = 1
+    msg.panel_backup_ch2_Info.ch_sta = 2
+    device.update_from_bytes(
+        dev_apl_comm_pb2.DisplayPropertyUpload, msg.SerializeToString()
+    )
+
+    await device.set_channel_force_charge(2, False)
+
+    packet = device._conn.sendPacket.await_args.args[0]
+    ctrl = _config_write(device, packet).cfg_panel_backup_ch2_ctrl
+    assert ctrl.ctrl_force_chg == 2
+    assert ctrl.ctrl_en == 2


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="6:1-8:63;102-316">Exposes the SHP3 per-channel force-charge control (Charge Now in the EcoFlow app) as switch entities. #394 already parses the force-charge state and preserves ctrl_force_chg on channel-enable writes; this adds the control itself, as in the original community implementation in #389, now that the behavior has been validated on hardware.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="10:1-10:8;318-325">What</h2>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="12:1-21:17;327-1004">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="12:1-13:75;327-477">Adds a <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@controls.for_each</code> switch over <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">channel_force_charge</code> (state was
already parsed), reusing the existing <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ch_force_charge</code> translation key.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="14:1-17:52;478-754">The setter writes <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ctrl_force_chg</code> via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">cfg_panel_backup_ch{N}_ctrl</code>,
writing the current enable state back alongside it since the panel applies
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">BackupCtrl</code> as a whole — mirroring <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">set_channel_enable</code>, which preserves
force-charge the same way in the other direction.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="18:1-18:79;755-833">README: moves Channel Force Charge from the SHP3 Sensors column to Switches.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="19:1-21:17;834-1004">Adds two tests decoding the write frame: force-charge on an enabled channel
preserves <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ctrl_en = 1</code>; force-charge off on a disabled channel preserves
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ctrl_en = 2</code>.</li>
</ul>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="23:1-23:68;1006-1073">Live hardware validation (HR63; DPU on ch1, DPU X on ch2)</h2>

<div class="overflow-x-auto w-full px-2 mb-6" data-sourcepos="25:1-33:119;1075-1678">
Check | Result
-- | --
Write accepted | Panel echoes force_chg_sta within ~2 s
Charge rate | Honors the AC Charging Speed slider (4,004 W measured vs 4,000 W set) — not a full-rate override
Per-channel isolation | Forcing ch1 charged only the ch1 batteries; ch2 stayed at 0 W throughout
Enable preservation | Channel remained enabled through toggle on/off
Stop latency | Seconds; clean return to baseline
Empty slot (ch3) | Switch correctly unavailable
Energy accounting | Grid draw = house load + charge power, consistent across SHP3 aggregate and per-unit telemetry

</div>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="35:1-37:22;1680-1849">Note: the shared <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ch{n}_force_charge</code> binary sensor mapping (disabled by
default) still matches these fields — happy to remove or keep it for SHP3,
whichever you prefer.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="39:1-39:11;1851-1861">Testing</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="41:1-41:63;1863-1925"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pytest tests/eflib/</code> — 107 passed. ruff check / format clean.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="43:1-43:14;1927-1940">Disclosure</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="45:1-47:10;1942-2100">AI-assisted (Claude), per CONTRIBUTING.md — same workflow as #396: I've read
the diff, validated the behavior on my panel, and can respond to review
feedback.</p><!--EndFragment-->
</body>
</html>