### PR TITLE
Add power off button for River 3 and Delta 3 series

### DIFF
--- a/custom_components/ef_ble/button.py
+++ b/custom_components/ef_ble/button.py
@@ -20,14 +20,8 @@ from .entity import EcoflowEntity
 
 @dataclass(frozen=True, kw_only=True)
 class EcoflowButtonEntityDescription(ButtonEntityDescription):
-    press_func: Callable[[DeviceBase], Awaitable] | None = None
+    press_func: Callable[[DeviceBase], Awaitable]
     availability_prop: str | None = None
-
-
-BUTTON_TYPES = [
-    # DPU
-    EcoflowButtonEntityDescription(key="unpause_solar"),
-]
 
 
 @dataclass(init=False)
@@ -62,19 +56,10 @@ async def async_setup_entry(
     """Add buttons for passed config_entry in HA."""
     device = config_entry.runtime_data
 
-    # New controls system (devices migrated to @controls decorators)
     descriptions = [
         (ButtonBuilder.from_entity(button).press_func(button.press_func).build())
         for button in get_controls(device, controls.button)
     ]
-
-    if not descriptions:
-        # Deprecated: old hardcoded list (for devices not yet migrated)
-        descriptions = [
-            button_desc
-            for button_desc in BUTTON_TYPES
-            if isinstance(getattr(device, button_desc.key, None), Callable)
-        ]
 
     new_buttons = [EcoflowButton(device, desc) for desc in descriptions]
     if new_buttons:
@@ -82,14 +67,15 @@ async def async_setup_entry(
 
 
 class EcoflowButton(EcoflowEntity, ButtonEntity):
-    def __init__(self, device: DeviceBase, entity_description: ButtonEntityDescription):
+    def __init__(
+        self, device: DeviceBase, entity_description: EcoflowButtonEntityDescription
+    ):
         super().__init__(device)
 
         self._attr_unique_id = f"ef_{device.serial_number}_{entity_description.key}"
         self._prop_name = entity_description.key
-        self._press = getattr(device, f"{self._prop_name}", None)
         self.entity_description = entity_description
-        self._availability_prop = getattr(entity_description, "availability_prop", None)
+        self._availability_prop = entity_description.availability_prop
 
         if entity_description.translation_key is None:
             self._attr_translation_key = self.entity_description.key
@@ -100,9 +86,7 @@ class EcoflowButton(EcoflowEntity, ButtonEntity):
             get_state=lambda state: state if state is not None else self.SkipWrite,
         )
 
-        custom_press = getattr(entity_description, "press_func", None)
-        if isinstance(custom_press, Callable):
-            self._press = partial(custom_press, device)
+        self._press = partial(entity_description.press_func, device)
 
     @callback
     def availability_updated(self, state: bool):
@@ -111,5 +95,4 @@ class EcoflowButton(EcoflowEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle the button press."""
-        if isinstance(self._press, Callable):
-            await self._press()
+        await self._press()

--- a/custom_components/ef_ble/button.py
+++ b/custom_components/ef_ble/button.py
@@ -1,7 +1,8 @@
 """EcoFlow BLE Button"""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from functools import partial
 
 from homeassistant.components.button import (
     ButtonEntity,
@@ -11,12 +12,15 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DeviceConfigEntry
-from .eflib import DeviceBase
+from .description_builder import EntityDescriptionBuilder
+from .eflib import DeviceBase, get_controls
+from .eflib.entity import controls
 from .entity import EcoflowEntity
 
 
 @dataclass(frozen=True, kw_only=True)
 class EcoflowButtonEntityDescription(ButtonEntityDescription):
+    press_func: Callable[[DeviceBase], Awaitable] | None = None
     availability_prop: str | None = None
 
 
@@ -24,6 +28,30 @@ BUTTON_TYPES = [
     # DPU
     EcoflowButtonEntityDescription(key="unpause_solar"),
 ]
+
+
+@dataclass(init=False)
+class ButtonBuilder(EntityDescriptionBuilder):
+    _press_func: Callable[[DeviceBase], Awaitable] | None = None
+
+    def press_func(self, func: Callable[[DeviceBase], Awaitable]):
+        self._press_func = func
+        return self
+
+    def build(self):
+        if self._press_func is None:
+            raise ValueError("Cannot build button entity without press func")
+        return EcoflowButtonEntityDescription(
+            key=self._entity_key,
+            name=self._entity_name,
+            entity_category=self._entity_category,
+            press_func=self._press_func,
+            entity_registry_enabled_default=self._entity_registry_enabled_default,
+            translation_key=self._entity_translation_key,
+            translation_placeholders=self._translation_placeholders,
+            availability_prop=self._availability_prop,
+            icon=self._icon,
+        )
 
 
 async def async_setup_entry(
@@ -34,12 +62,21 @@ async def async_setup_entry(
     """Add buttons for passed config_entry in HA."""
     device = config_entry.runtime_data
 
-    new_buttons = [
-        EcoflowButton(device, button_desc)
-        for button_desc in BUTTON_TYPES
-        if isinstance(getattr(device, button_desc.key, None), Callable)
+    # New controls system (devices migrated to @controls decorators)
+    descriptions = [
+        (ButtonBuilder.from_entity(button).press_func(button.press_func).build())
+        for button in get_controls(device, controls.button)
     ]
 
+    if not descriptions:
+        # Deprecated: old hardcoded list (for devices not yet migrated)
+        descriptions = [
+            button_desc
+            for button_desc in BUTTON_TYPES
+            if isinstance(getattr(device, button_desc.key, None), Callable)
+        ]
+
+    new_buttons = [EcoflowButton(device, desc) for desc in descriptions]
     if new_buttons:
         async_add_entities(new_buttons)
 
@@ -62,6 +99,10 @@ class EcoflowButton(EcoflowEntity, ButtonEntity):
             prop_name=self._availability_prop,
             get_state=lambda state: state if state is not None else self.SkipWrite,
         )
+
+        custom_press = getattr(entity_description, "press_func", None)
+        if isinstance(custom_press, Callable):
+            self._press = partial(custom_press, device)
 
     @callback
     def availability_updated(self, state: bool):

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -166,6 +166,10 @@ class Delta3Base(DeviceBase, ProtobufProps):
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self._conn.sendPacket(packet)
 
+    @controls.button(enabled=False)
+    async def power_off(self) -> None:
+        await self._send_config_packet(pd335_sys_pb2.ConfigWrite(cfg_power_off=True))
+
     @controls.outlet(ac_ports)
     async def enable_ac_ports(self, enabled: bool):
         await self._send_config_packet(

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -468,6 +468,7 @@ class Device(DeviceBase, ProtobufProps):
         )
         return True
 
+    @controls.button()
     async def unpause_solar(self):
         """Send command to clear weak PV source flag"""
         self._logger.debug("unlock_pv_weak")

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -182,6 +182,10 @@ class Device(DeviceBase, ProtobufProps):
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self._conn.sendPacket(packet)
 
+    @controls.button(enabled=False)
+    async def power_off(self) -> None:
+        await self._send_config_packet(pr705_pb2.ConfigWrite(cfg_power_off=True))
+
     @controls.battery(
         energy_backup_battery_level,
         min=dynamic(battery_charge_limit_min),

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -2,9 +2,11 @@ import dataclasses
 import enum
 import inspect
 from collections.abc import Awaitable, Callable, Iterable
+from types import MethodType
 from typing import TYPE_CHECKING, Any, cast, get_type_hints
 
 from ..props.enums import IntFieldValue
+from ..props.updatable_props import Field
 from . import DynamicValue, EntityType, units
 
 if TYPE_CHECKING:
@@ -60,6 +62,53 @@ class outlet(toggle):
 
 class switch(toggle):
     pass
+
+
+class _ButtonField(Field[None]):
+    """
+    Stateless placeholder field backing a `button` control
+
+    Exists only so the control is registered for discovery like any other field;
+    reading it from a device instance returns the bound press method, keeping the
+    decorated function directly callable.
+    """
+
+    def __init__(self, press_func: Callable[..., Awaitable[Any]]) -> None:
+        self._press_func = press_func
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return MethodType(self._press_func, instance)
+
+
+class button(ControlType):
+    """
+    Stateless action control mapped to a HA button entity
+
+    Unlike other controls, a button is not tied to an existing state field. The
+    decorator replaces the method with an internal field named after it, so the
+    entity key matches the method name and the method stays callable on the device:
+
+        @controls.button()
+        async def power_off(self) -> None: ...
+    """
+
+    type PressFunc[D: "DeviceBase"] = Callable[[D], Awaitable[Any]]
+
+    field: Any = None
+    press_func: PressFunc = dataclasses.field(
+        default=cast("PressFunc", None),
+        repr=False,
+        init=False,
+    )
+
+    def __call__[D: "DeviceBase"](
+        self,
+        func: Callable[[D], Awaitable[Any]],
+    ) -> _ButtonField:
+        self.press_func = func
+        return _ButtonField(func).sensor(self)
 
 
 class NumberType(ControlType):

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "button": {
+      "power_off": {
+        "default": "mdi:power"
+      }
+    },
     "binary_sensor": {
       "fan_running": {
         "default": "mdi:fan",

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -295,6 +295,9 @@
   },
   "entity": {
     "button": {
+      "power_off": {
+        "name": "Power Off"
+      },
       "unpause_solar": {
         "name": "Unpause Solar"
       }

--- a/tests/eflib/test_dpu.py
+++ b/tests/eflib/test_dpu.py
@@ -2,6 +2,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 from custom_components.ef_ble.eflib.devices.dpu import Device
+from custom_components.ef_ble.eflib.entity import controls
+from custom_components.ef_ble.eflib.pb import yj751_sys_pb2
 
 
 @pytest.fixture
@@ -182,3 +184,23 @@ async def test_dpu_exact_values_from_known_packets(device, packet_sequence):
         assert actual_value == expected_value, (
             f"{field_name}: expected {expected_value}, got {actual_value}"
         )
+
+
+async def test_dpu_unpause_solar_registered_as_button_control(device):
+    buttons = device.get_controls(controls.button)
+
+    assert len(buttons) == 1
+    assert buttons[0].key == "unpause_solar"
+
+
+async def test_dpu_unpause_solar_sends_unlock_pv_weak(device):
+    await device.unpause_solar()
+
+    device._conn.sendPacket.assert_awaited_once()
+    packet = device._conn.sendPacket.await_args.args[0]
+    assert (packet.src, packet.dst) == (0x21, 0x02)
+    assert (packet.cmd_set, packet.cmd_id) == (0xFE, 0x11)
+
+    config = yj751_sys_pb2.ConfigWrite()
+    config.ParseFromString(packet.payload)
+    assert config.unlock_pv_weak is True


### PR DESCRIPTION
This PR adds a button for Delta 3 and River 3 series that shuts off the device using `cfg_power_off` config option (disabled by default).

Buttons had no place in the controls system (they're stateless, and every existing control type hangs off a state field), so this adds one:

- New `@controls.button()` control type: the decorator registers an internal field named after the method, so the entity key derives from the method name and the method stays directly callable on the device.
- The button platform is ported to the same auto-discovery pattern as switches/numbers/selects (`ButtonBuilder` + `get_controls`), replacing the hardcoded `BUTTON_TYPES` list.
- `power_off` is added to the Delta 3 base (covers Delta 3, Plus, Air, Max, Ultra variants) and River 3 (covers Plus). The entity is **disabled by default** since it's a hard shutdown - users opt in from the entity registry.
- DPU's `unpause_solar` is migrated to the new control type, removing the deprecated button list entirely. The entity key is unchanged, so existing registrations keep working.

Resolves #384