### PR TITLE
Add energy monitoring mode select for STREAM devices

### DIFF
--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -126,6 +126,13 @@ class EnergyStrategy(IntFieldValue):
         return operate_mode
 
 
+class EnergyMonitoringMode(IntFieldValue):
+    SEMI_AUTOMATED = 1
+    SMART_METER = 2
+
+    UNKNOWN = -1
+
+
 class Device(DeviceBase, ProtobufProps):
     """STREAM AC"""
 
@@ -162,6 +169,10 @@ class Device(DeviceBase, ProtobufProps):
         EnergyStrategy.from_pb,
     )
     energy_backup_battery_level = pb_field(pb.backup_reverse_soc)
+    energy_monitoring_mode = pb_field(
+        pb.pow_consumption_measurement,
+        EnergyMonitoringMode.from_value,
+    )
 
     grid_in_power_limit = pb_field(pb.sys_grid_in_pwr_limit)
     max_ac_in_power = pb_field(pb.pow_sys_ac_in_max)
@@ -313,6 +324,15 @@ class Device(DeviceBase, ProtobufProps):
         cfg = bk_series_pb2.ConfigWrite()
         strategy.as_pb(cfg.cfg_energy_strategy_operate_mode)
         await self._send_config_packet(cfg)
+
+    @controls.select(energy_monitoring_mode, options=EnergyMonitoringMode)
+    async def set_energy_monitoring_mode(self, mode: EnergyMonitoringMode):
+        if mode is EnergyMonitoringMode.UNKNOWN:
+            return
+
+        await self._send_config_packet(
+            bk_series_pb2.ConfigWrite(cfg_pow_consumption_measurement=mode.value)
+        )
 
     @controls.power(
         base_load_power,

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -385,6 +385,13 @@
           "power_storage": "mdi:battery-charging"
         }
       },
+      "energy_monitoring_mode": {
+        "default": "mdi:meter-electric",
+        "state": {
+          "semi_automated": "mdi:home-lightning-bolt",
+          "smart_meter": "mdi:meter-electric"
+        }
+      },
       "operating_submode": {
         "default": "mdi:tune-variant",
         "state": {

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -1037,6 +1037,13 @@
           "intelligent_schedule": "Intelligent Schedule"
         }
       },
+      "energy_monitoring_mode": {
+        "name": "Energy Monitoring",
+        "state": {
+          "semi_automated": "Semi-Automated Monitoring",
+          "smart_meter": "Smart Meter Monitoring"
+        }
+      },
       "operating_submode": {
         "name": "Operating Submode",
         "state": {


### PR DESCRIPTION
This PR adds switch for the STREAM system's energy delivery strategy between "Smart Meter Monitoring (zero feed-in)" and "Semi-Automated Monitoring" from Home Assistant, e.g. to allow grid export when the batteries are full without reaching for the app.

Full list of changes:
- New `EnergyMonitoringMode` enum and `energy_monitoring_mode` select on the STREAM AC base, inherited by all BK-series variants (AC / Pro / Max / Ultra / AC Pro).  The write reuses the existing `_send_config_packet` framing shared by the other STREAM config writes.
- Devices that were never configured report `0`; that maps to `UNKNOWN`, which is excluded from the select options and ignored as a set target.

Resolves #393
