### PR TITLE
Close stale BLE connections before connecting

### DIFF
--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -21,6 +21,7 @@ from bleak.exc import BleakError
 from bleak_retry_connector import (
     MAX_CONNECT_ATTEMPTS,
     BleakNotFoundError,
+    close_stale_connections_by_address,
     establish_connection,
 )
 
@@ -368,6 +369,10 @@ class Connection:
 
             self._set_state(ConnectionState.ESTABLISHING_CONNECTION)
             self._logger.info("Connecting to device")
+            # Clear any ghost connection BlueZ is still holding for this
+            # device (e.g. left over from a bad disconnect); otherwise new
+            # connection attempts can be refused until the adapter is reset.
+            await close_stale_connections_by_address(self.ble_dev().address)
             # max_attempts=0 means unlimited at Connection level, but
             # establish_connection needs a real retry count for BLE-level
             # attempts (e.g. when adapter slots are contested).


### PR DESCRIPTION
## What changed

`Connection.connect()` now calls `bleak_retry_connector.close_stale_connections_by_address()` right before `establish_connection()`.

## Why

Setup can fail with:

```
Config entry 'EF-YJ0254' for ef_ble integration not ready yet: Device connected but did not get to auth procedure, last state: error_bleak; Retrying in 5 seconds
```

This happens when BlueZ is still holding a ghost/stale connection to the device (left over from a previous bad disconnect), which causes a generic `BleakError` during `establish_connection()` — recorded as `ConnectionState.ERROR_BLEAK` — and blocks new connection attempts. Previously the only known fix was rebooting the host or unplugging/replugging the USB Bluetooth adapter.

`close_stale_connections_by_address()` asks BlueZ for any device it thinks is still connected and force-disconnects it before we try again, achieving the same effect as a reboot without one. It's a no-op on non-Linux backends, so it's safe to call unconditionally on every connect/reconnect attempt.

## Notes for reviewers

- Existing `tests/eflib` suite passes (113 passed) after this change.
- No new tests added — the failure mode is a BlueZ/adapter-level condition that isn't practical to reproduce in the current test setup (no mocking of `bleak_retry_connector` in place).