### PR TITLE
Fix Wave 2 Fahrenheit handling and drain controls, add climate entity

### DIFF
--- a/custom_components/ef_ble/climate.py
+++ b/custom_components/ef_ble/climate.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import DeviceConfigEntry
-from .description_builder import EntityDescriptionBuilder
+from .description_builder import EntityDescriptionBuilder, unit_to_hassunit
 from .eflib import DeviceBase, controls, get_controls
 from .entity import EcoflowEntity
 
@@ -41,6 +41,8 @@ class EcoflowClimateEntityDescription(ClimateEntityDescription):
 
     min_temp: float | None = None
     max_temp: float | None = None
+    min_temp_prop: str | None = None
+    max_temp_prop: str | None = None
     target_temperature_step: float = 1.0
     min_range_temp: float | None = None
     max_range_temp: float | None = None
@@ -48,6 +50,7 @@ class EcoflowClimateEntityDescription(ClimateEntityDescription):
     min_humidity: int | None = None
     max_humidity: int | None = None
     temperature_unit: str = UnitOfTemperature.CELSIUS
+    temperature_unit_prop: str | None = None
 
     set_power_func: Any = None
     set_operating_mode_func: Any = None
@@ -74,6 +77,8 @@ class ClimateBuilder(EntityDescriptionBuilder):
     _fan_speed_hvac_modes: frozenset[HVACMode] | None = None
     _min_temp: float | None = None
     _max_temp: float | None = None
+    _min_temp_prop: str | None = None
+    _max_temp_prop: str | None = None
     _target_temperature_step: float = 1.0
     _min_range_temp: float | None = None
     _max_range_temp: float | None = None
@@ -81,6 +86,7 @@ class ClimateBuilder(EntityDescriptionBuilder):
     _min_humidity: int | None = None
     _max_humidity: int | None = None
     _temperature_unit: str = UnitOfTemperature.CELSIUS
+    _temperature_unit_prop: str | None = None
     _set_power_func: Any = None
     _set_operating_mode_func: Any = None
     _set_target_temp_func: Any = None
@@ -169,12 +175,18 @@ class ClimateBuilder(EntityDescriptionBuilder):
             self._fan_speed_prop = prop
         return self
 
-    def min_temp(self, value: float | None):
-        self._min_temp = value
+    def min_temp(self, value):
+        if field := self._get_field(value):
+            self._min_temp_prop = field.public_name
+        else:
+            self._min_temp = value
         return self
 
-    def max_temp(self, value: float | None):
-        self._max_temp = value
+    def max_temp(self, value):
+        if field := self._get_field(value):
+            self._max_temp_prop = field.public_name
+        else:
+            self._max_temp = value
         return self
 
     def min_range_temp(self, value: float | None):
@@ -193,8 +205,11 @@ class ClimateBuilder(EntityDescriptionBuilder):
         self._target_temperature_range_step = value
         return self
 
-    def temperature_unit(self, value: str):
-        self._temperature_unit = value
+    def temperature_unit(self, value):
+        if field := self._get_field(value):
+            self._temperature_unit_prop = field.public_name
+        else:
+            self._temperature_unit = value
         return self
 
     def set_power_func(self, func: Any):
@@ -243,6 +258,8 @@ class ClimateBuilder(EntityDescriptionBuilder):
             fan_speed_hvac_modes=self._fan_speed_hvac_modes,
             min_temp=self._min_temp,
             max_temp=self._max_temp,
+            min_temp_prop=self._min_temp_prop,
+            max_temp_prop=self._max_temp_prop,
             target_temperature_step=self._target_temperature_step,
             min_range_temp=self._min_range_temp,
             max_range_temp=self._max_range_temp,
@@ -250,6 +267,7 @@ class ClimateBuilder(EntityDescriptionBuilder):
             min_humidity=self._min_humidity,
             max_humidity=self._max_humidity,
             temperature_unit=self._temperature_unit,
+            temperature_unit_prop=self._temperature_unit_prop,
             set_power_func=self._set_power_func,
             set_operating_mode_func=self._set_operating_mode_func,
             set_target_temp_func=self._set_target_temp_func,
@@ -436,6 +454,23 @@ class EcoflowClimateEntity(EcoflowEntity, ClimateEntity):
             "_attr_fan_mode",
             description.fan_speed_prop,
             get_state=self._speed_to_fan.get,
+        )
+        self._register_update_callback(
+            "_attr_min_temp",
+            description.min_temp_prop,
+            get_state=lambda state: state if state is not None else self.SkipWrite,
+        )
+        self._register_update_callback(
+            "_attr_max_temp",
+            description.max_temp_prop,
+            get_state=lambda state: state if state is not None else self.SkipWrite,
+        )
+        self._register_update_callback(
+            "_attr_temperature_unit",
+            description.temperature_unit_prop,
+            get_state=lambda state: (
+                unit_to_hassunit(state) if state is not None else self.SkipWrite
+            ),
         )
 
         self._update_supported_features()

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -1,6 +1,7 @@
 from ..devicebase import DeviceBase
 from ..entity import controls, units
 from ..entity.base import dynamic
+from ..entity.controls import HvacMode
 from ..model.kt210_sac import KT210SAC
 from ..packet import Packet
 from ..props import Field, computed_field
@@ -88,6 +89,7 @@ class Device(DeviceBase, RawDataProps):
 
     target_temperature = raw_field(pb.set_temp)
     power_mode = raw_field(pb.power_mode, PowerMode.from_value)
+    power = raw_field(pb.power_mode, lambda x: PowerMode.from_value(x) is PowerMode.ON)
     _temp_sys = raw_field(pb.temp_sys)
 
     @computed_field
@@ -135,10 +137,7 @@ class Device(DeviceBase, RawDataProps):
         # elif packet.src == 0x06 and packet.cmd_set == 0x20 and packet.cmd_id == 0x32:
         #     processed = False
 
-        for field_name in self.updated_fields:
-            self.update_callback(field_name)
-            self.update_state(field_name, getattr(self, field_name))
-
+        self._notify_updated()
         return processed
 
     async def _send_config_packet(self, cmd_id: int, payload: bytes):
@@ -152,6 +151,30 @@ class Device(DeviceBase, RawDataProps):
         )
 
         await self._conn.sendPacket(packet)
+
+    @computed_field
+    def _climate_main_mode(self) -> MainMode | None:
+        return self.main_mode
+
+    _climate = controls.climate(
+        _climate_main_mode,
+        translation_key="climate",
+        hvac_modes={
+            HvacMode.COOL: MainMode.COLD,
+            HvacMode.HEAT: MainMode.WARM,
+            HvacMode.FAN_ONLY: MainMode.FAN,
+        },
+        fan_modes={
+            "low": FanGear.LOW,
+            "medium": FanGear.MEDIUM,
+            "high": FanGear.HIGH,
+        },
+        current_temperature_field=ambient_temperature,
+    )
+
+    @_climate.power(power)
+    async def enable_power(self, enabled: bool):
+        await self.set_power_mode(PowerMode.ON if enabled else PowerMode.STANDBY)
 
     @controls.switch(ambient_light)
     async def enable_ambient_light(self, enabled: bool):
@@ -184,10 +207,15 @@ class Device(DeviceBase, RawDataProps):
             payload = 0 if mode is DrainMode.EXTERNAL else 1
         await self._send_config_packet(0x59, payload.to_bytes())
 
+    @_climate.fan(
+        fan_speed,
+        modes={HvacMode.COOL, HvacMode.HEAT, HvacMode.FAN_ONLY},
+    )
     @controls.select(fan_speed, options=FanGear)
     async def set_fan_speed(self, fan_gear: FanGear):
         await self._send_config_packet(0x5E, fan_gear.to_bytes())
 
+    @_climate.mode()
     @controls.select(main_mode, options=MainMode)
     async def set_main_mode(self, mode: MainMode):
         set_drain_mode = False
@@ -209,6 +237,14 @@ class Device(DeviceBase, RawDataProps):
     async def set_power_mode(self, mode: PowerMode):
         await self._send_config_packet(0x5B, mode.to_bytes())
 
+    @_climate.target_temp(
+        target_temperature,
+        modes={HvacMode.COOL, HvacMode.HEAT},
+        step=1,
+        min=dynamic(target_temperature_min),
+        max=dynamic(target_temperature_max),
+        unit=dynamic(temp_unit),
+    )
     @controls.temperature(
         target_temperature,
         min=dynamic(target_temperature_min),

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -1,7 +1,9 @@
 from ..devicebase import DeviceBase
+from ..entity import controls, units
+from ..entity.base import dynamic
 from ..model.kt210_sac import KT210SAC
 from ..packet import Packet
-from ..props import Field
+from ..props import Field, computed_field
 from ..props.enums import IntFieldValue
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ..props.raw_data_props import RawDataProps
@@ -47,10 +49,10 @@ class DrainMode(IntFieldValue):
     DRAIN_FREE = 1
 
     @classmethod
-    def from_wte(cls, main_mode: MainMode, value: int) -> "DrainMode":
-        if main_mode is MainMode.COLD:
-            return cls.DRAIN_FREE if value in (1, 3) else cls.EXTERNAL
-        return cls.DRAIN_FREE if value == 3 else cls.EXTERNAL
+    def from_wte(cls, value: int) -> "DrainMode":
+        # bit 0 of wte_fth_en encodes the user's drain-mode preference;
+        # bit 1 encodes the auto-drain master switch (handled separately).
+        return cls.DRAIN_FREE if value & 1 else cls.EXTERNAL
 
 
 class Device(DeviceBase, RawDataProps):
@@ -86,6 +88,25 @@ class Device(DeviceBase, RawDataProps):
 
     target_temperature = raw_field(pb.set_temp)
     power_mode = raw_field(pb.power_mode, PowerMode.from_value)
+    _temp_sys = raw_field(pb.temp_sys)
+
+    @computed_field
+    def temp_unit(self) -> units.Temperature:
+        return units.Temperature.F if self._temp_sys == 1 else units.Temperature.C
+
+    @computed_field
+    def target_temperature_min(self) -> int:
+        return {
+            units.Temperature.F: 60,
+            units.Temperature.C: 16,
+        }.get(self.temp_unit, 16)
+
+    @computed_field
+    def target_temperature_max(self) -> int:
+        return {
+            units.Temperature.F: 86,
+            units.Temperature.C: 30,
+        }.get(self.temp_unit, 30)
 
     # power_src looks like a bitmask, observations:
     # bit 0 - battery
@@ -109,13 +130,8 @@ class Device(DeviceBase, RawDataProps):
             self.update_from_bytes(KT210SAC, packet.payload)
             processed = True
 
-            if self.wte_fth_en is not None and self.main_mode is not None:
-                self.drain_mode = DrainMode.from_wte(self.main_mode, self.wte_fth_en)
-                # NOTE(gnox): for some reason, drain mode gets removed from updated
-                # fields if updated like this so we just update it manually here
-                self.update_callback("drain_mode")
-                self.update_state("drain_mode", self.drain_mode)
-
+            if self.wte_fth_en is not None:
+                self.drain_mode = DrainMode.from_wte(self.wte_fth_en)
         # elif packet.src == 0x06 and packet.cmd_set == 0x20 and packet.cmd_id == 0x32:
         #     processed = False
 
@@ -137,9 +153,11 @@ class Device(DeviceBase, RawDataProps):
 
         await self._conn.sendPacket(packet)
 
+    @controls.switch(ambient_light)
     async def enable_ambient_light(self, enabled: bool):
         await self._send_config_packet(0x5C, (0x01 if enabled else 0x02).to_bytes())
 
+    @controls.switch(automatic_drain)
     async def enable_automatic_drain(self, enabled: bool):
         drain_mode = (
             self.drain_mode if self.drain_mode is not None else DrainMode.EXTERNAL
@@ -156,6 +174,7 @@ class Device(DeviceBase, RawDataProps):
 
         await self._send_config_packet(0x59, payload.to_bytes())
 
+    @controls.select(drain_mode, options=DrainMode)
     async def set_drain_mode(self, mode: DrainMode):
         if not self.automatic_drain:
             payload = 2 if mode is DrainMode.EXTERNAL else 3
@@ -165,9 +184,11 @@ class Device(DeviceBase, RawDataProps):
             payload = 0 if mode is DrainMode.EXTERNAL else 1
         await self._send_config_packet(0x59, payload.to_bytes())
 
+    @controls.select(fan_speed, options=FanGear)
     async def set_fan_speed(self, fan_gear: FanGear):
         await self._send_config_packet(0x5E, fan_gear.to_bytes())
 
+    @controls.select(main_mode, options=MainMode)
     async def set_main_mode(self, mode: MainMode):
         set_drain_mode = False
         if (
@@ -184,12 +205,20 @@ class Device(DeviceBase, RawDataProps):
             await self._send_config_packet(0x59, payload.to_bytes())
             self.drain_mode = DrainMode.EXTERNAL
 
+    @controls.select(power_mode, options=PowerMode)
     async def set_power_mode(self, mode: PowerMode):
         await self._send_config_packet(0x5B, mode.to_bytes())
 
-    async def set_temperature(self, temperature: int):
-        await self._send_config_packet(0x58, temperature.to_bytes())
+    @controls.temperature(
+        target_temperature,
+        min=dynamic(target_temperature_min),
+        max=dynamic(target_temperature_max),
+        unit=dynamic(temp_unit),
+    )
+    async def set_temperature(self, temperature: float):
+        await self._send_config_packet(0x58, int(temperature).to_bytes())
         return True
 
+    @controls.select(sub_mode, options=SubMode)
     async def set_sub_mode(self, sub_mode: SubMode):
         await self._send_config_packet(0x52, sub_mode.to_bytes())

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -4,7 +4,7 @@ from ..entity.base import dynamic
 from ..entity.controls import HvacMode
 from ..model.kt210_sac import KT210SAC
 from ..packet import Packet
-from ..props import Field, computed_field
+from ..props import computed_field
 from ..props.enums import IntFieldValue
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ..props.raw_data_props import RawDataProps
@@ -79,10 +79,7 @@ class Device(DeviceBase, RawDataProps):
     power_psdr = raw_field(pb.psdr_pwr_watt)
     power_mppt = raw_field(pb.mptt_pwr_watt)
 
-    automatic_drain = raw_field(pb.wte_fth_en, lambda x: x in (0, 1))
     wte_fth_en = raw_field(pb.wte_fth_en)
-    drain_mode = Field[DrainMode]()
-
     water_level = raw_field(pb.water_value, WaterLevel.from_value)
 
     ambient_light = raw_field(pb.rgb_state, lambda x: x == 0x01)
@@ -110,6 +107,22 @@ class Device(DeviceBase, RawDataProps):
             units.Temperature.C: 30,
         }.get(self.temp_unit, 30)
 
+    @computed_field
+    def automatic_drain(self) -> bool | None:
+        if self.wte_fth_en is None:
+            return None
+        if self.main_mode in (MainMode.WARM, MainMode.FAN):
+            return self.wte_fth_en == 1
+        return self.wte_fth_en & 0b10 == 0
+
+    @computed_field
+    def drain_mode(self) -> DrainMode | None:
+        if self.wte_fth_en is None:
+            return None
+        if self.main_mode in (MainMode.WARM, MainMode.FAN):
+            return DrainMode.EXTERNAL
+        return DrainMode.from_wte(self.wte_fth_en)
+
     # power_src looks like a bitmask, observations:
     # bit 0 - battery
     # bits 1-2 - optional internal power sources?
@@ -131,11 +144,6 @@ class Device(DeviceBase, RawDataProps):
         if packet.src == 0x42 and packet.cmd_set == 0x42 and packet.cmd_id == 0x50:
             self.update_from_bytes(KT210SAC, packet.payload)
             processed = True
-
-            if self.wte_fth_en is not None:
-                self.drain_mode = DrainMode.from_wte(self.wte_fth_en)
-        # elif packet.src == 0x06 and packet.cmd_set == 0x20 and packet.cmd_id == 0x32:
-        #     processed = False
 
         self._notify_updated()
         return processed
@@ -182,29 +190,28 @@ class Device(DeviceBase, RawDataProps):
 
     @controls.switch(automatic_drain)
     async def enable_automatic_drain(self, enabled: bool):
-        drain_mode = (
-            self.drain_mode if self.drain_mode is not None else DrainMode.EXTERNAL
-        )
-
+        preference = (self.wte_fth_en or 0) & 1
         if not enabled:
-            payload = 2 if drain_mode is DrainMode.EXTERNAL else 3
-        elif self.main_mode is not MainMode.COLD:
+            payload = 0b10 | preference
+        elif self.main_mode in (MainMode.WARM, MainMode.FAN):
+            # drain-free is unsupported outside Cool mode; the app always sends 1 (auto
+            # drain on, external drainage) here
             payload = 1
         else:
-            payload = 0 if drain_mode is DrainMode.EXTERNAL else 1
-
-        payload = (0 if enabled else 0b10) | drain_mode.value
-
+            payload = preference
         await self._send_config_packet(0x59, payload.to_bytes())
 
     @controls.select(drain_mode, options=DrainMode)
     async def set_drain_mode(self, mode: DrainMode):
-        if not self.automatic_drain:
-            payload = 2 if mode is DrainMode.EXTERNAL else 3
-        elif self.main_mode is not MainMode.COLD:
-            payload = 1
-        else:
-            payload = 0 if mode is DrainMode.EXTERNAL else 1
+        main_mode = self.main_mode
+        if main_mode is MainMode.WARM or main_mode is MainMode.FAN:
+            if mode is DrainMode.DRAIN_FREE:
+                self._logger.warning(
+                    "Drain-free mode is not supported in %s mode, ignoring",
+                    main_mode.state_name,
+                )
+            return
+        payload = mode.value if self.automatic_drain else 0b10 | mode.value
         await self._send_config_packet(0x59, payload.to_bytes())
 
     @_climate.fan(
@@ -218,22 +225,9 @@ class Device(DeviceBase, RawDataProps):
     @_climate.mode()
     @controls.select(main_mode, options=MainMode)
     async def set_main_mode(self, mode: MainMode):
-        set_drain_mode = False
-        if (
-            self.automatic_drain
-            and self.drain_mode != DrainMode.EXTERNAL
-            and mode != MainMode.COLD
-        ):
-            set_drain_mode = True
-
         await self._send_config_packet(0x51, mode.to_bytes())
 
-        if set_drain_mode:
-            payload = 1
-            await self._send_config_packet(0x59, payload.to_bytes())
-            self.drain_mode = DrainMode.EXTERNAL
-
-    @controls.select(power_mode, options=PowerMode)
+    @controls.select(power_mode, options=PowerMode, exclude=[PowerMode.INIT])
     async def set_power_mode(self, mode: PowerMode):
         await self._send_config_packet(0x5B, mode.to_bytes())
 

--- a/custom_components/ef_ble/eflib/entity/base.py
+++ b/custom_components/ef_ble/eflib/entity/base.py
@@ -46,6 +46,12 @@ class DynamicValue[F, T]:
     field: "updatable_props.Field[F]"
     transform: Callable[[F], T] | None = None
 
+    def resolve(self, instance) -> T | None:
+        raw = getattr(instance, self.field.public_name, None)
+        if raw is None:
+            return None
+        return self.transform(raw) if self.transform is not None else raw  # type: ignore[return-value]
+
 
 def dynamic[F, T](
     field: "updatable_props.Field[F]", transform: Callable[[F], T] | None = None

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -176,6 +176,7 @@ class select[E: IntFieldValue](ControlType):
     type SetFunc = Callable[[DeviceBase, E], Awaitable[None]]
 
     options: type[E] | list[str]
+    exclude: list[E] = dataclasses.field(default_factory=list, kw_only=True)
     set_value_func: SetFunc = dataclasses.field(
         repr=False,
         init=False,
@@ -186,7 +187,9 @@ class select[E: IntFieldValue](ControlType):
             self._value_type: type[E] | None = None
         else:
             self._value_type = self.options
-            self.options = self.options.options(include_unknown=False)
+            self.options = self.options.options(
+                include_unknown=False, exclude=self.exclude
+            )
 
     @property
     def options_str(self) -> list[str]:

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -1,5 +1,6 @@
 import dataclasses
 import enum
+import functools
 import inspect
 from collections.abc import Awaitable, Callable, Iterable
 from types import MethodType
@@ -131,6 +132,7 @@ class NumberType(ControlType):
 
         control = self
 
+        @functools.wraps(func)
         async def _check_limits(
             device: "DeviceBase", value: float, *args, **kwargs
         ) -> bool:
@@ -203,6 +205,7 @@ class select[E: IntFieldValue](ControlType):
 
         value_type = self._value_type
 
+        @functools.wraps(func)
         async def _func(device: D, value: E | str) -> None:
             if isinstance(value, str) and value_type is not None:
                 value = value_type[value.upper()]
@@ -263,10 +266,10 @@ def for_each(
 
 type _PowerSetter = Callable[[Any, bool], Awaitable[None]]
 type _ModeSetter = Callable[[Any, Any], Awaitable[None]]
-type _TargetTempSetter = Callable[[Any, float], Awaitable[None]]
-type _TargetTempRangeSetter = Callable[[Any, float, float], Awaitable[None]]
-type _HumiditySetter = Callable[[Any, int], Awaitable[None]]
-type _FanSpeedSetter = Callable[[Any, Any], Awaitable[None]]
+type _TargetTempSetter = Callable[[Any, float], Awaitable[Any]]
+type _TargetTempRangeSetter = Callable[[Any, float, float], Awaitable[Any]]
+type _HumiditySetter = Callable[[Any, int], Awaitable[Any]]
+type _FanSpeedSetter = Callable[[Any, Any], Awaitable[Any]]
 type _Decorator[F] = Callable[[F], F]
 
 
@@ -386,6 +389,7 @@ class climate(ControlType):
         step: float | None = None,
         min: float | None = None,
         max: float | None = None,
+        unit: units.Temperature | None = None,
     ) -> _Decorator[_TargetTempSetter]:
         def bind(f: _TargetTempSetter) -> _TargetTempSetter:
             self.set_target_temperature = _virtual_dispatch(f, notify_fields=[field])
@@ -399,6 +403,8 @@ class climate(ControlType):
                 self.min_temp = min
             if max is not None:
                 self.max_temp = max
+            if unit is not None:
+                self.temperature_unit = unit
             return f
 
         return bind

--- a/custom_components/ef_ble/eflib/packet.py
+++ b/custom_components/ef_ble/eflib/packet.py
@@ -61,7 +61,7 @@ class Packet:
 
         # Sentinel-format frames (high-nibble bit set, e.g. 0x13) carry a 0xBB sentinel
         # inside the payload instead of a trailing CRC16.
-        if version in (2, 3) and not sentinel_format:
+        if version in (2, 3) and not sentinel_format and not data.endswith(b"\xbb\xbb"):
             if crc16(data[:-2]) != struct.unpack("<H", data[-2:])[0]:
                 error_msg = "Unable to parse packet - incorrect CRC16: %s"
                 _LOGGER.error(error_msg, bytearray(data).hex())

--- a/custom_components/ef_ble/number.py
+++ b/custom_components/ef_ble/number.py
@@ -19,6 +19,7 @@ from .deprecated.numbers import NUMBER_TYPES
 from .description_builder import EntityDescriptionBuilder, unit_to_hassunit
 from .eflib import DeviceBase, controls, get_controls
 from .eflib.devices import smart_generator
+from .eflib.entity import DynamicValue
 from .eflib.props import Field
 from .entity import EcoflowEntity
 
@@ -52,7 +53,11 @@ class NumberSensorBuilder(EntityDescriptionBuilder):
         self._device_class = device_class
         return self
 
-    def native_unit_of_measurement(self, unit: str):
+    def native_unit_of_measurement(self, unit):
+        if isinstance(unit, DynamicValue):
+            return self.native_unit_of_measurement_field(
+                lambda dev: unit_to_hassunit(unit.resolve(dev)) or ""
+            )
         self._native_unit_of_measurement = unit_to_hassunit(unit)
         return self
 

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -43,6 +43,7 @@ from .eflib.devices import (
     wave2,
     wave3,
 )
+from .eflib.entity import units
 from .eflib.props.enums import IntFieldValue
 from .entity import (
     EcoflowBatteryAddonEntity,
@@ -213,15 +214,12 @@ def temperature(
     )
 
 
-def _wave_unit(dev: wave3.Device):
-    match dev:
-        case wave3.Device:
-            return (
-                UnitOfTemperature.FAHRENHEIT
-                if dev.temp_unit is wave3.TemperatureUnit.FAHRENHEIT
-                else UnitOfTemperature.CELSIUS
-            )
-    return UnitOfTemperature.CELSIUS
+def _wave_unit(dev: "wave2.Device | wave3.Device"):
+    return (
+        UnitOfTemperature.FAHRENHEIT
+        if dev.temp_unit in (units.Temperature.F, wave3.TemperatureUnit.FAHRENHEIT)
+        else UnitOfTemperature.CELSIUS
+    )
 
 
 def wave_temperature(
@@ -859,7 +857,7 @@ _SENSORS: Final[dict[str, SensorEntityDescription]] = {
         enabled=False,
     ),
     # Wave 2
-    "outlet_temperature": temperature(),
+    "outlet_temperature": wave_temperature(),
     "power_battery": power(precision=0),
     "power_psdr": power(precision=0),
     "power_mppt": power(precision=0),

--- a/tests/eflib/test_wave2.py
+++ b/tests/eflib/test_wave2.py
@@ -1,0 +1,271 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from custom_components.ef_ble.eflib import controls, units
+from custom_components.ef_ble.eflib.devices.wave2 import (
+    Device,
+    DrainMode,
+    FanGear,
+    MainMode,
+    PowerMode,
+    SubMode,
+    WaterLevel,
+)
+
+PACKETS = {
+    "fan_celsius_target_30": "aa026c00bc2de6b30200012d42214250e4e5f8e45a3990a7e6ece6e7e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e4e7e7e7e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e66d8b9fa7e6e6e4e6e6e6e7e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e671a6",
+    "heat_celsius_target_30": "aa026c00bc2df8b30200012d42214250f9fbe6fa176d8fb9f8f2f8f9f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8faf9f9f9f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f40681b9f8f8faf8f8f8f9f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8b664",
+    "heat_celsius_target_16": "aa026c00bc2d2db40200012d422142502c2e3d2f2200ad6c2d272d2c2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2f2c2c2c682d2d2d2d2d2d2d2d2d2d2d2d2d2d2d6b9f576c2d2d2f2d2d2d2c2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d1cd3",
+    "fan_fahrenheit_target_86": "aa026c00bc2d7bb40200012d4221425079782d794ab40c397a717b7a7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b797a7a7a7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b63470f397b7b797b7b7b7a7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7bc4ac",
+    "heat_fahrenheit_target_86": "aa026c00bc2d91b40200012d422142509092c79361a6e8d3909b91909191919191919191919191919191919191919191919191919191919191919191919191919191919191919191919390909091919191919191919191919191919191fb14e2d391919391919190919191919191919191919191919191919191919158e2",
+    "heat_drain_off_external": "aa026c00bc2dadb40200012d42214250acae91af6df8d7efaca7adacadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadafacacacacadadadadadadadadadadadadadadad5ff9d9efadadafadadadacadadadadadadadadadadadadadadadadadadadad8c09",
+    "fan_fahrenheit_target_60": "aa026c00bc2de7b40200012d42214250e5e4dbe591069da5e6ede7e6e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e5e6e6e6e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7fd3e93a5e7e7e5e7e7e7e6e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e793e2",
+    "heat_drain_wte_zero": "aa026c00bc2d18b50200012d42214250191b241a57fd645a19121819181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181919191a18181818181818181818181818181828156f5a18181a1818181918181818181818181818181818181818181818181fdd",
+    "heat_drain_on": "aa026c00bc2d2fb50200012d422142502e2c132de488526d2e252f2e2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2e2e2e2e2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f1f22586d2f2f2d2f2f2f2e2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2fa354",
+    "heat_drain_off_drain_free": "aa026c00bc2d66b50200012d4221425067655a6486c91b24676c6667666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666656767676666666666666666666666666666666663da10246666646666666766666666666666666666666666666666666666668151",
+    "heat_fahrenheit_standby": "aa026c00bc2da5b50200012d42214250a4a699a7e7dcdbe7a4afa5a4a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a7a4a7a4a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5550bd2e7a5a5a7a5a5a5a4a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5f338",
+}
+
+
+@pytest.fixture
+def packet_sequence():
+    return list(PACKETS.values())
+
+
+@pytest.fixture
+def device(mocker: MockerFixture):
+    ble_dev = mocker.Mock()
+    ble_dev.address = "AA:BB:CC:DD:EE:FF"
+    adv_data = mocker.MagicMock()
+    device = Device(ble_dev, adv_data, "KT21TEST1234")
+    device._conn = mocker.AsyncMock()
+    return device
+
+
+async def _process(device: Device, hex_packet: str) -> bool:
+    packet = await device.packet_parse(bytes.fromhex(hex_packet))
+    assert packet is not None
+    return await device.data_parse(packet)
+
+
+def _sent_drain_payload(device: Device) -> bytes:
+    packet = device._conn.sendPacket.call_args.args[0]
+    assert packet.cmd_id == 0x59
+    return packet.payload
+
+
+async def test_wave2_parses_all_packets_successfully(device, packet_sequence):
+    for i, hex_packet in enumerate(packet_sequence):
+        packet = await device.packet_parse(bytes.fromhex(hex_packet))
+
+        assert packet is not None, f"Packet {i} failed to parse"
+        assert packet.src == 0x42, f"Packet {i} has unexpected src: {packet.src:#04x}"
+        assert packet.cmd_set == 0x42, (
+            f"Packet {i} has unexpected cmd_set: {packet.cmd_set:#04x}"
+        )
+        assert packet.cmd_id == 0x50, (
+            f"Packet {i} has unexpected cmd_id: {packet.cmd_id:#04x}"
+        )
+
+
+async def test_wave2_processes_all_packets_successfully(device, packet_sequence):
+    for i, hex_packet in enumerate(packet_sequence):
+        processed = await _process(device, hex_packet)
+        assert processed is True, f"Packet {i} was not processed"
+
+
+async def test_wave2_exact_values_from_known_packets(device, packet_sequence):
+    for hex_packet in packet_sequence:
+        await _process(device, hex_packet)
+
+    expected = {
+        Device.main_mode: MainMode.WARM,
+        Device.sub_mode: SubMode.NORMAL,
+        Device.fan_speed: FanGear.HIGH,
+        Device.power_mode: PowerMode.STANDBY,
+        Device.power: False,
+        Device.target_temperature: 60,
+        Device.temp_unit: units.Temperature.F,
+        Device.target_temperature_min: 60,
+        Device.target_temperature_max: 86,
+        Device.ambient_temperature: 63.62,
+        Device.outlet_temperature: 61.92,
+        Device.wte_fth_en: 2,
+        Device.automatic_drain: False,
+        Device.drain_mode: DrainMode.EXTERNAL,
+        Device.water_level: WaterLevel.LOW,
+        Device.ambient_light: False,
+        Device.battery_level: 0,
+        Device.power_battery: 0,
+        Device.power_psdr: 0,
+        Device.power_mppt: 0,
+    }
+
+    for field_name, expected_value in expected.items():
+        actual_value = device.get_value(field_name)
+        assert actual_value == expected_value, (
+            f"{field_name}: expected {expected_value}, got {actual_value}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("packet_name", "expected_unit", "expected_min", "expected_max", "expected_temp"),
+    [
+        ("heat_celsius_target_16", units.Temperature.C, 16, 30, 16),
+        ("heat_celsius_target_30", units.Temperature.C, 16, 30, 30),
+        ("fan_fahrenheit_target_60", units.Temperature.F, 60, 86, 60),
+        ("heat_fahrenheit_target_86", units.Temperature.F, 60, 86, 86),
+    ],
+)
+async def test_temperature_unit_and_limits_follow_device_temp_sys(
+    device, packet_name, expected_unit, expected_min, expected_max, expected_temp
+):
+    await _process(device, PACKETS[packet_name])
+
+    assert device.temp_unit is expected_unit
+    assert device.target_temperature_min == expected_min
+    assert device.target_temperature_max == expected_max
+    assert device.target_temperature == expected_temp
+
+
+@pytest.mark.parametrize(
+    ("packet_name", "expected_mode"),
+    [
+        ("fan_celsius_target_30", MainMode.FAN),
+        ("heat_celsius_target_30", MainMode.WARM),
+    ],
+)
+async def test_main_mode_is_decoded_from_heartbeat(device, packet_name, expected_mode):
+    await _process(device, PACKETS[packet_name])
+
+    assert device.main_mode is expected_mode
+
+
+@pytest.mark.parametrize(
+    ("packet_name", "expected_auto"),
+    [
+        # in Heat mode only wte_fth_en == 1 means auto drain is active
+        ("heat_drain_wte_zero", False),
+        ("heat_drain_on", True),
+        ("heat_drain_off_external", False),
+        ("heat_drain_off_drain_free", False),
+    ],
+)
+async def test_heat_mode_drain_state_is_decoded_from_wte_fth_en(
+    device, packet_name, expected_auto
+):
+    await _process(device, PACKETS[packet_name])
+
+    assert device.automatic_drain is expected_auto
+    assert device.drain_mode is DrainMode.EXTERNAL
+
+
+def test_drain_state_is_unknown_before_first_heartbeat(device):
+    assert device.automatic_drain is None
+    assert device.drain_mode is None
+
+
+@pytest.mark.parametrize(
+    ("packet_name", "enabled", "expected_payload"),
+    [
+        # drain-free is unsupported in Heat/Fan; enabling always sends 1 and
+        # disabling preserves the drain-mode preference bit
+        ("heat_drain_wte_zero", True, 1),
+        ("heat_drain_off_external", True, 1),
+        ("heat_drain_on", False, 3),
+        ("fan_fahrenheit_target_60", True, 1),
+    ],
+)
+async def test_enable_automatic_drain_outside_cool_mode(
+    device, packet_name, enabled, expected_payload
+):
+    await _process(device, PACKETS[packet_name])
+
+    await device.enable_automatic_drain(enabled)
+
+    assert _sent_drain_payload(device) == expected_payload.to_bytes()
+
+
+# No Cool-mode heartbeats exist in the available captures, so Cool-mode drain
+# behavior is exercised by setting the decoded fields directly.
+def _force_cool_mode(device: Device, wte_fth_en: int):
+    device.main_mode = MainMode.COLD.value
+    device.wte_fth_en = wte_fth_en
+
+
+@pytest.mark.parametrize(
+    ("wte_fth_en", "expected_auto", "expected_mode"),
+    [
+        (0, True, DrainMode.EXTERNAL),
+        (1, True, DrainMode.DRAIN_FREE),
+        (2, False, DrainMode.EXTERNAL),
+        (3, False, DrainMode.DRAIN_FREE),
+    ],
+)
+def test_cool_mode_drain_state_is_decoded_from_wte_fth_en(
+    device, wte_fth_en, expected_auto, expected_mode
+):
+    _force_cool_mode(device, wte_fth_en)
+
+    assert device.automatic_drain is expected_auto
+    assert device.drain_mode is expected_mode
+
+
+@pytest.mark.parametrize(
+    ("wte_fth_en", "enabled", "expected_payload"),
+    [
+        (2, True, 0),
+        (3, True, 1),
+        (0, False, 2),
+        (1, False, 3),
+    ],
+)
+async def test_enable_automatic_drain_in_cool_mode_preserves_preference(
+    device, wte_fth_en, enabled, expected_payload
+):
+    _force_cool_mode(device, wte_fth_en)
+
+    await device.enable_automatic_drain(enabled)
+
+    assert _sent_drain_payload(device) == expected_payload.to_bytes()
+
+
+@pytest.mark.parametrize(
+    ("wte_fth_en", "mode", "expected_payload"),
+    [
+        (0, DrainMode.DRAIN_FREE, 1),
+        (1, DrainMode.EXTERNAL, 0),
+        # with auto drain off only the preference bit is stored
+        (2, DrainMode.DRAIN_FREE, 3),
+        (3, DrainMode.EXTERNAL, 2),
+    ],
+)
+async def test_set_drain_mode_in_cool_mode_sends_new_wte_value(
+    device, wte_fth_en, mode, expected_payload
+):
+    _force_cool_mode(device, wte_fth_en)
+
+    await device.set_drain_mode(mode)
+
+    assert _sent_drain_payload(device) == expected_payload.to_bytes()
+
+
+@pytest.mark.parametrize("packet_name", ["heat_drain_on", "fan_fahrenheit_target_60"])
+@pytest.mark.parametrize("mode", [DrainMode.DRAIN_FREE, DrainMode.EXTERNAL])
+async def test_set_drain_mode_is_a_noop_outside_cool_mode(device, packet_name, mode):
+    await _process(device, PACKETS[packet_name])
+    device._conn.sendPacket.reset_mock()
+
+    await device.set_drain_mode(mode)
+
+    device._conn.sendPacket.assert_not_called()
+
+
+def test_power_mode_select_hides_internal_init_state(device):
+    select = next(
+        c
+        for c in device.get_controls(control_type=controls.select)
+        if c.key == "power_mode"
+    )
+
+    assert select.options_str == ["on", "standby", "off"]


### PR DESCRIPTION
This PR fixes three Wave 2 problems: target temperature was garbled when the unit is switched to Fahrenheit on the device, the drain mode/automatic drain controls neither reflected nor reliably controlled the actual drain state, and an internal "init" power mode leaked into the power mode select after the controls-system migration.

Full list of changes:
- **Temperature unit follows the device.** `temp_sys` is decoded into a `temp_unit` computed field, and the target temperature control gets `dynamic()` min/max/unit (16-30 °C or 60-86 °F). The number builder and climate entity learned to resolve dynamic units and limits per device, and the Wave 2 temperature sensors reuse the Wave 3 unit-switching helper.
- **Some Wave 2 frames carry a `0xBBBB` placeholder instead of a valid CRC16**; the packet parser now accepts that sentinel instead of dropping the frame.
- **Drain state is decoded mode-aware** (`automatic_drain`/`drain_mode` are computed from `wte_fth_en` + `main_mode`) and the writes mirror the app exactly: disabling always preserves the preference bit (`0b10 | bit0`), enabling in Heat/Fan always sends `1`, and selecting drain-free outside Cool mode is refused with a warning, matching the app's toast. A redundant drain write in `set_main_mode` (it always re-sent the value the device already had) was dropped.
- **`controls.select` gained an `exclude` parameter**, used to hide `PowerMode.INIT` from the power mode select the same way the pre-migration hardcoded select did. HA renders the state as unknown if the device ever reports it.
- **New climate entity for the Wave 2** (cool/heat/fan-only, low/medium/high fan, power mapped to `PowerMode.ON`/`STANDBY`), reusing the climate control introduced for Wave 3. Stacking a climate decorator over `@controls.select` on the same method previously lost the function name and broke dispatch; the control wrappers now use `functools.wraps`.
- Adds `tests/eflib/test_wave2.py` (first tests for this device) built on real captured heartbeats covering Heat/Fan modes, both temperature units and all four `wte_fth_en` values, plus exact command payloads for every drain write path.

Resolves #327
