### PR TITLE
Add some Delta Pro 3 properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ Click on any device below to see available sensors, switches, and controls:
 | Battery Level                       | DC Ports       | Max Charge Limit     |
 | Extra Battery Level ¹               | USB Ports      | Min Discharge Limit  |
 | Extra Battery Temperature ¹         | Backup Reserve | AC Charging Speed    |
-| AC Input Power                      | Beeper         |                      |
-| AC LV Output Power                  | X-Boost        |                      |
+| AC Input Power                      |                |                      |
+| AC LV Output Power                  |                |                      |
 | AC HV Output Power                  |                |                      |
 | DC 12V Output Power                 |                |                      |
 | DC LV Input Power                   |                |                      |
@@ -364,15 +364,12 @@ Click on any device below to see available sensors, switches, and controls:
 | USB C (2) Output Power              |                |                      |
 | AC Plugged In                       |                |                      |
 | Cell Temperature (disabled)         |                |                      |
-| Min Cell Temperature (disabled)     |                |                      |
 | State of Health (disabled)          |                |                      |
-| Battery Capacity (disabled)         |                |                      |
-| Battery Charge State (disabled)     |                |                      |
 | Battery Input Power (disabled)      |                |                      |
 | Battery Output Power (disabled)     |                |                      |
-| Power In/Out Port Power (disabled)  |                |                      |
+| AC 5P8 In Power                     |                |                      |
+| AC 5P8 Out Power                    |                |                      |
 | AC LV TT-30 Output Power (disabled) |                |                      |
-| AC Output Frequency (disabled)      |                |                      |
 | Charge Time Remaining (disabled)    |                |                      |
 | Discharge Time Remaining (disabled) |                |                      |
 | Error Occurred (disabled) ²         |                |                      |

--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ Click on any device below to see available sensors, switches, and controls:
 |-------------------------------------|----------------|----------------------|
 | Main Battery Level                  | AC Ports       | Backup Reserve Level |
 | Battery Level                       | DC Ports       | Max Charge Limit     |
-| Extra Battery Level ¹               | Backup Reserve | Min Discharge Limit  |
-| Extra Battery Temperature ¹         |                | AC Charging Speed    |
-| AC Input Power                      |                |                      |
-| AC LV Output Power                  |                |                      |
+| Extra Battery Level ¹               | USB Ports      | Min Discharge Limit  |
+| Extra Battery Temperature ¹         | Backup Reserve | AC Charging Speed    |
+| AC Input Power                      | Beeper         |                      |
+| AC LV Output Power                  | X-Boost        |                      |
 | AC HV Output Power                  |                |                      |
 | DC 12V Output Power                 |                |                      |
 | DC LV Input Power                   |                |                      |
@@ -364,10 +364,20 @@ Click on any device below to see available sensors, switches, and controls:
 | USB C (2) Output Power              |                |                      |
 | AC Plugged In                       |                |                      |
 | Cell Temperature (disabled)         |                |                      |
+| Min Cell Temperature (disabled)     |                |                      |
+| State of Health (disabled)          |                |                      |
+| Battery Capacity (disabled)         |                |                      |
+| Battery Charge State (disabled)     |                |                      |
+| Battery Input Power (disabled)      |                |                      |
+| Battery Output Power (disabled)     |                |                      |
+| Power In/Out Port Power (disabled)  |                |                      |
+| AC LV TT-30 Output Power (disabled) |                |                      |
+| AC Output Frequency (disabled)      |                |                      |
 | Charge Time Remaining (disabled)    |                |                      |
 | Discharge Time Remaining (disabled) |                |                      |
 | Error Occurred (disabled) ²         |                |                      |
 | BMS Run State (disabled)            |                |                      |
+| Fan Running (disabled)              |                |                      |
 
 <sup>¹ Per extra battery (up to 2)</sup>
 <sup>² Includes error code as an extra attribute</sup>

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -32,6 +32,14 @@ class DCPortState(IntFieldValue):
     STATE_5_UNKNOWN = 5
 
 
+class ChargeDischargeState(IntFieldValue):
+    UNKNOWN = -1
+
+    IDLE = 0
+    DISCHARGING = 1
+    CHARGING = 2
+
+
 class Device(DeviceBase, ProtobufProps):
     """Delta Pro 3"""
 
@@ -40,10 +48,17 @@ class Device(DeviceBase, ProtobufProps):
 
     battery_level = pb_field(pb.cms_batt_soc, pround(2))
     battery_level_main = pb_field(pb.bms_batt_soc, pround(2))
+    state_of_health = pb_field(pb.cms_batt_soh)
+    battery_full_energy = pb_field(pb.cms_batt_full_energy)
+    battery_charge_state = pb_field(
+        pb.cms_chg_dsg_state, ChargeDischargeState.from_value
+    )
 
     ac_input_power = pb_field(pb.pow_get_ac_in)
     ac_lv_output_power = pb_field(pb.pow_get_ac_lv_out, out_power)
     ac_hv_output_power = pb_field(pb.pow_get_ac_hv_out, out_power)
+    ac_lv_tt30_output_power = pb_field(pb.pow_get_ac_lv_tt30_out, out_power)
+    ac_output_frequency = pb_field(pb.ac_out_freq)
 
     input_power = pb_field(pb.pow_in_sum_w)
     output_power = pb_field(pb.pow_out_sum_w)
@@ -67,6 +82,9 @@ class Device(DeviceBase, ProtobufProps):
     plugged_in_ac = pb_field(pb.plug_in_info_ac_charger_flag)
     energy_backup = pb_field(pb.energy_backup_en)
     energy_backup_battery_level = pb_field(pb.energy_backup_start_soc)
+    battery_input_power = pb_field(pb.pow_get_bms, lambda value: max(0, value))
+    battery_output_power = pb_field(pb.pow_get_bms, lambda value: -min(0, value))
+    power_io_port_power = pb_field(pb.pow_get_5p8)
 
     battery_charge_limit_min = pb_field(pb.cms_min_dsg_soc)
     battery_charge_limit_max = pb_field(pb.cms_max_chg_soc)
@@ -75,13 +93,19 @@ class Device(DeviceBase, ProtobufProps):
     remaining_time_discharging = pb_field(pb.cms_dsg_rem_time)
 
     cell_temperature = pb_field(pb.bms_max_cell_temp)
+    min_cell_temperature = pb_field(pb.bms_min_cell_temp)
 
     error_code = pb_field(pb.errcode)
     bms_run_state = pb_field(pb.cms_bms_run_state, bool)
+    _pcs_fan_level = pb_field(pb.pcs_fan_level)
+
+    beeper = pb_field(pb.en_beep)
+    xboost = pb_field(pb.xboost_en)
 
     dc_12v_port = pb_field(pb.flow_info_12v, flow_is_on)
     ac_lv_port = pb_field(pb.flow_info_ac_lv_out, flow_is_on)
     ac_hv_port = pb_field(pb.flow_info_ac_hv_out, flow_is_on)
+    usb_ports = pb_field(pb.flow_info_qcusb1, flow_is_on)
 
     battery_1_enabled = pb_field(pb.plug_in_info_4p8_1_in_flag, bool)
     battery_1_battery_level = pb_field(pb.plug_in_info_4p8_1_resv, resv_soc)
@@ -141,6 +165,12 @@ class Device(DeviceBase, ProtobufProps):
     def error_occurred(self) -> bool:
         return bool(self.error_code)
 
+    @computed_field
+    def fan_running(self) -> bool | None:
+        if self._pcs_fan_level is None:
+            return None
+        return self._pcs_fan_level > 0
+
     def _get_solar_power(self, power: float | None, state: DCPortState | None):
         return (
             round(power, 2) if state == DCPortState.SOLAR and power is not None else 0
@@ -191,6 +221,18 @@ class Device(DeviceBase, ProtobufProps):
         await self._send_config_packet(
             mr521_pb2.ConfigWrite(cfg_lv_ac_out_open=enabled)
         )
+
+    @controls.switch(usb_ports)
+    async def enable_usb_ports(self, enabled: bool):
+        await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_usb_open=enabled))
+
+    @controls.switch(beeper)
+    async def enable_beeper(self, enabled: bool):
+        await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_beep_en=enabled))
+
+    @controls.switch(xboost)
+    async def enable_xboost(self, enabled: bool):
+        await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_xboost_en=enabled))
 
     @controls.battery(
         battery_charge_limit_min,

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -32,14 +32,6 @@ class DCPortState(IntFieldValue):
     STATE_5_UNKNOWN = 5
 
 
-class ChargeDischargeState(IntFieldValue):
-    UNKNOWN = -1
-
-    IDLE = 0
-    DISCHARGING = 1
-    CHARGING = 2
-
-
 class Device(DeviceBase, ProtobufProps):
     """Delta Pro 3"""
 
@@ -49,16 +41,11 @@ class Device(DeviceBase, ProtobufProps):
     battery_level = pb_field(pb.cms_batt_soc, pround(2))
     battery_level_main = pb_field(pb.bms_batt_soc, pround(2))
     state_of_health = pb_field(pb.cms_batt_soh)
-    battery_full_energy = pb_field(pb.cms_batt_full_energy)
-    battery_charge_state = pb_field(
-        pb.cms_chg_dsg_state, ChargeDischargeState.from_value
-    )
 
     ac_input_power = pb_field(pb.pow_get_ac_in)
     ac_lv_output_power = pb_field(pb.pow_get_ac_lv_out, out_power)
     ac_hv_output_power = pb_field(pb.pow_get_ac_hv_out, out_power)
     ac_lv_tt30_output_power = pb_field(pb.pow_get_ac_lv_tt30_out, out_power)
-    ac_output_frequency = pb_field(pb.ac_out_freq)
 
     input_power = pb_field(pb.pow_in_sum_w)
     output_power = pb_field(pb.pow_out_sum_w)
@@ -84,7 +71,8 @@ class Device(DeviceBase, ProtobufProps):
     energy_backup_battery_level = pb_field(pb.energy_backup_start_soc)
     battery_input_power = pb_field(pb.pow_get_bms, lambda value: max(0, value))
     battery_output_power = pb_field(pb.pow_get_bms, lambda value: -min(0, value))
-    power_io_port_power = pb_field(pb.pow_get_5p8)
+    ac_5p8_in_power = pb_field(pb.pow_get_5p8, lambda value: max(0, value))
+    ac_5p8_out_power = pb_field(pb.pow_get_5p8, lambda value: -min(0, value))
 
     battery_charge_limit_min = pb_field(pb.cms_min_dsg_soc)
     battery_charge_limit_max = pb_field(pb.cms_max_chg_soc)
@@ -93,14 +81,10 @@ class Device(DeviceBase, ProtobufProps):
     remaining_time_discharging = pb_field(pb.cms_dsg_rem_time)
 
     cell_temperature = pb_field(pb.bms_max_cell_temp)
-    min_cell_temperature = pb_field(pb.bms_min_cell_temp)
 
     error_code = pb_field(pb.errcode)
     bms_run_state = pb_field(pb.cms_bms_run_state, bool)
     _pcs_fan_level = pb_field(pb.pcs_fan_level)
-
-    beeper = pb_field(pb.en_beep)
-    xboost = pb_field(pb.xboost_en)
 
     dc_12v_port = pb_field(pb.flow_info_12v, flow_is_on)
     ac_lv_port = pb_field(pb.flow_info_ac_lv_out, flow_is_on)
@@ -225,14 +209,6 @@ class Device(DeviceBase, ProtobufProps):
     @controls.switch(usb_ports)
     async def enable_usb_ports(self, enabled: bool):
         await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_usb_open=enabled))
-
-    @controls.switch(beeper)
-    async def enable_beeper(self, enabled: bool):
-        await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_beep_en=enabled))
-
-    @controls.switch(xboost)
-    async def enable_xboost(self, enabled: bool):
-        await self._send_config_packet(mr521_pb2.ConfigWrite(cfg_xboost_en=enabled))
 
     @controls.battery(
         battery_charge_limit_min,

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -217,13 +217,6 @@
       },
       "state_of_health": {
         "default": "mdi:battery-heart"
-      },
-      "battery_charge_state": {
-        "default": "mdi:battery",
-        "state": {
-          "charging": "mdi:battery-charging",
-          "discharging": "mdi:battery-arrow-down"
-        }
       }
     },
     "switch": {
@@ -348,12 +341,6 @@
         "default": "mdi:battery-arrow-down",
         "state": {
           "off": "mdi:battery-off-outline"
-        }
-      },
-      "beeper": {
-        "default": "mdi:volume-high",
-        "state": {
-          "off": "mdi:volume-off"
         }
       }
     },

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -214,6 +214,16 @@
           "emergency_stop": "mdi:alert-octagon",
           "off_power": "mdi:power-off"
         }
+      },
+      "state_of_health": {
+        "default": "mdi:battery-heart"
+      },
+      "battery_charge_state": {
+        "default": "mdi:battery",
+        "state": {
+          "charging": "mdi:battery-charging",
+          "discharging": "mdi:battery-arrow-down"
+        }
       }
     },
     "switch": {
@@ -338,6 +348,12 @@
         "default": "mdi:battery-arrow-down",
         "state": {
           "off": "mdi:battery-off-outline"
+        }
+      },
+      "beeper": {
+        "default": "mdi:volume-high",
+        "state": {
+          "off": "mdi:volume-off"
         }
       }
     },

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -759,12 +759,25 @@ _SENSORS: Final[dict[str, SensorEntityDescription]] = {
     # DP3
     "ac_lv_output_power": power(precision=2),
     "ac_hv_output_power": power(precision=2),
+    "ac_lv_tt30_output_power": power(precision=2, enabled=False),
+    "ac_output_frequency": frequency(precision=0, enabled=False),
     "solar_lv_power": power("input_power_solar_lv", enabled=False),
     "solar_hv_power": power("input_power_solar_hv", enabled=False),
     "dc_lv_input_power": power(precision=2),
     "dc_hv_input_power": power(precision=2),
     "dc_lv_input_state": enum(options=delta_pro_3.DCPortState),
     "dc_hv_input_state": enum(options=delta_pro_3.DCPortState),
+    "power_io_port_power": power(precision=2, enabled=False),
+    "state_of_health": percentage(
+        enabled=False, entity_category=EntityCategory.DIAGNOSTIC
+    ),
+    "battery_full_energy": energy_storage(
+        enabled=False, entity_category=EntityCategory.DIAGNOSTIC
+    ),
+    "battery_charge_state": enum(
+        options=delta_pro_3.ChargeDischargeState, enabled=False
+    ),
+    "min_cell_temperature": temperature(enabled=False),
     # Smart Generator
     "xt150_battery_level": battery(),
     "engine_state": enum(options=smart_generator.EngineOpen),

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -760,24 +760,15 @@ _SENSORS: Final[dict[str, SensorEntityDescription]] = {
     "ac_lv_output_power": power(precision=2),
     "ac_hv_output_power": power(precision=2),
     "ac_lv_tt30_output_power": power(precision=2, enabled=False),
-    "ac_output_frequency": frequency(precision=0, enabled=False),
     "solar_lv_power": power("input_power_solar_lv", enabled=False),
     "solar_hv_power": power("input_power_solar_hv", enabled=False),
     "dc_lv_input_power": power(precision=2),
     "dc_hv_input_power": power(precision=2),
     "dc_lv_input_state": enum(options=delta_pro_3.DCPortState),
     "dc_hv_input_state": enum(options=delta_pro_3.DCPortState),
-    "power_io_port_power": power(precision=2, enabled=False),
     "state_of_health": percentage(
         enabled=False, entity_category=EntityCategory.DIAGNOSTIC
     ),
-    "battery_full_energy": energy_storage(
-        enabled=False, entity_category=EntityCategory.DIAGNOSTIC
-    ),
-    "battery_charge_state": enum(
-        options=delta_pro_3.ChargeDischargeState, enabled=False
-    ),
-    "min_cell_temperature": temperature(enabled=False),
     # Smart Generator
     "xt150_battery_level": battery(),
     "engine_state": enum(options=smart_generator.EngineOpen),

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -670,6 +670,27 @@
       "dc_hv_input_state": {
         "name": "HV DC Input Port State"
       },
+      "ac_lv_tt30_output_power": {
+        "name": "AC LV TT-30 Output Power"
+      },
+      "ac_output_frequency": {
+        "name": "AC Output Frequency"
+      },
+      "power_io_port_power": {
+        "name": "Power In/Out Port Power"
+      },
+      "state_of_health": {
+        "name": "State of Health"
+      },
+      "battery_full_energy": {
+        "name": "Battery Capacity"
+      },
+      "battery_charge_state": {
+        "name": "Battery Charge State"
+      },
+      "min_cell_temperature": {
+        "name": "Min Cell Temperature"
+      },
       "engine_state": {
         "name": "Engine State",
         "state": {
@@ -1141,6 +1162,12 @@
       },
       "usb_ports": {
         "name": "USB Ports"
+      },
+      "beeper": {
+        "name": "Beeper"
+      },
+      "xboost": {
+        "name": "X-Boost"
       },
       "ac_ports_2": {
         "name": "AC Ports (2)"

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -673,23 +673,8 @@
       "ac_lv_tt30_output_power": {
         "name": "AC LV TT-30 Output Power"
       },
-      "ac_output_frequency": {
-        "name": "AC Output Frequency"
-      },
-      "power_io_port_power": {
-        "name": "Power In/Out Port Power"
-      },
       "state_of_health": {
         "name": "State of Health"
-      },
-      "battery_full_energy": {
-        "name": "Battery Capacity"
-      },
-      "battery_charge_state": {
-        "name": "Battery Charge State"
-      },
-      "min_cell_temperature": {
-        "name": "Min Cell Temperature"
       },
       "engine_state": {
         "name": "Engine State",
@@ -1162,12 +1147,6 @@
       },
       "usb_ports": {
         "name": "USB Ports"
-      },
-      "beeper": {
-        "name": "Beeper"
-      },
-      "xboost": {
-        "name": "X-Boost"
       },
       "ac_ports_2": {
         "name": "AC Ports (2)"

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -644,6 +644,27 @@
       "dc_hv_input_state": {
         "name": "Стан вхідного порту DC HV"
       },
+      "ac_lv_tt30_output_power": {
+        "name": "Вихідна потужність AC LV TT-30"
+      },
+      "ac_output_frequency": {
+        "name": "Частота виходу змінного струму (AC)"
+      },
+      "power_io_port_power": {
+        "name": "Потужність порту Power In/Out"
+      },
+      "state_of_health": {
+        "name": "Стан здоров'я батареї"
+      },
+      "battery_full_energy": {
+        "name": "Ємність батареї"
+      },
+      "battery_charge_state": {
+        "name": "Стан заряду батареї"
+      },
+      "min_cell_temperature": {
+        "name": "Мінімальна температура елементів"
+      },
       "engine_state": {
         "name": "Стан двигуна",
         "state": {
@@ -1138,6 +1159,12 @@
       },
       "usb_ports": {
         "name": "Порти USB"
+      },
+      "beeper": {
+        "name": "Звуковий сигнал"
+      },
+      "xboost": {
+        "name": "X-Boost"
       },
       "ac_ports_2": {
         "name": "Порти AC (2)"

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -647,23 +647,8 @@
       "ac_lv_tt30_output_power": {
         "name": "Вихідна потужність AC LV TT-30"
       },
-      "ac_output_frequency": {
-        "name": "Частота виходу змінного струму (AC)"
-      },
-      "power_io_port_power": {
-        "name": "Потужність порту Power In/Out"
-      },
       "state_of_health": {
         "name": "Стан здоров'я батареї"
-      },
-      "battery_full_energy": {
-        "name": "Ємність батареї"
-      },
-      "battery_charge_state": {
-        "name": "Стан заряду батареї"
-      },
-      "min_cell_temperature": {
-        "name": "Мінімальна температура елементів"
       },
       "engine_state": {
         "name": "Стан двигуна",
@@ -1159,12 +1144,6 @@
       },
       "usb_ports": {
         "name": "Порти USB"
-      },
-      "beeper": {
-        "name": "Звуковий сигнал"
-      },
-      "xboost": {
-        "name": "X-Boost"
       },
       "ac_ports_2": {
         "name": "Порти AC (2)"

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -644,6 +644,27 @@
       "dc_hv_input_state": {
         "name": "高压直流输入端口状态"
       },
+      "ac_lv_tt30_output_power": {
+        "name": "交流 LV TT-30 输出功率"
+      },
+      "ac_output_frequency": {
+        "name": "交流输出频率"
+      },
+      "power_io_port_power": {
+        "name": "Power In/Out 端口功率"
+      },
+      "state_of_health": {
+        "name": "电池健康状态"
+      },
+      "battery_full_energy": {
+        "name": "电池容量"
+      },
+      "battery_charge_state": {
+        "name": "电池充放电状态"
+      },
+      "min_cell_temperature": {
+        "name": "最低电芯温度"
+      },
       "engine_state": {
         "name": "引擎状态",
         "state": {
@@ -1138,6 +1159,12 @@
       },
       "usb_ports": {
         "name": "USB 端口"
+      },
+      "beeper": {
+        "name": "蜂鸣器"
+      },
+      "xboost": {
+        "name": "X-Boost"
       },
       "ac_ports_2": {
         "name": "交流端口 (2)"

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -647,23 +647,8 @@
       "ac_lv_tt30_output_power": {
         "name": "交流 LV TT-30 输出功率"
       },
-      "ac_output_frequency": {
-        "name": "交流输出频率"
-      },
-      "power_io_port_power": {
-        "name": "Power In/Out 端口功率"
-      },
       "state_of_health": {
         "name": "电池健康状态"
-      },
-      "battery_full_energy": {
-        "name": "电池容量"
-      },
-      "battery_charge_state": {
-        "name": "电池充放电状态"
-      },
-      "min_cell_temperature": {
-        "name": "最低电芯温度"
       },
       "engine_state": {
         "name": "引擎状态",
@@ -1159,12 +1144,6 @@
       },
       "usb_ports": {
         "name": "USB 端口"
-      },
-      "beeper": {
-        "name": "蜂鸣器"
-      },
-      "xboost": {
-        "name": "X-Boost"
       },
       "ac_ports_2": {
         "name": "交流端口 (2)"

--- a/tests/eflib/test_delta_pro_3.py
+++ b/tests/eflib/test_delta_pro_3.py
@@ -1,0 +1,135 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from custom_components.ef_ble.eflib.devices.delta_pro_3 import (
+    ChargeDischargeState,
+    DCPortState,
+    Device,
+)
+
+
+@pytest.fixture
+def packet_sequence():
+    """
+    Raw packet sequence captured from a Delta Pro 3 device
+
+    All packets are DisplayPropertyUpload (src=0x02, cmd_set=0xFE, cmd_id=0x15).
+    The device alternates between two incremental upload groups: the first packet
+    carries battery, power and system status, the second carries port plug-in info
+    and flow states.
+    """
+    return [
+        "aa138601b32c078a0502011c02210101fe150f071a0707134422070714442f870637073f0747354a0707070752070707075a0707070762070707076f0977097f098706098f06199706ab059f06d702a706d702cf0607ff06078705078f05079705059a0507070707a20507070707aa0507070707b20507070707ef0507f70507a20407070707aa0407070707b20407071344ba04070714c4c20407070707ca0407070707d20407070707ed000f0d010f0617051f01f50007af0fd905b50f0c46746e662853626f756669bf0f06e70f079f0e06f20e07070707fa0e07070707820d07070707b70c069f0b06c70b079f0a35a70a07af0a07b70a07bf0a079f0905c7090792083a6c6a459a080707cf45c70887f603f708eb46ff08a23497171d9f171aa7171caf1719b2173a6c6a45ba170707cf45e717eb46ef17a234f7173aff17068716138f16349716069f1606cf1607d71607ef1607f716079715971bcd1f07df1f07e71f07ef1f079f1b06a71b57af1b07b71bbf0fbf1b07c71b07df1ba718e71b9704ef1b35f71b87279f1a07a71a07af1a078f19072034",
+        "aa130201512cfb890502011c02210101fe150bfafb43f9fb3bf9fe2bf9fb23f9fe03f9f97bf8f973f8fb6bf8fb63f8fb13f8fb0bf8c903f8fb7bfffb73fffb39fefb3bf2f933f2fb2bf2fb23f2fb1bf2fb13f2fb73f1fb6bf1fb63f1fb5bf1fb53f1fb4bf1fb2bf1fb23f1fb5bf0fd53f0eb43f0fb39f0e9f1ebfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb2bf0fb23f0fb19f0e9f1ebfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb0bf0fb03f0fb79f7e9f1ebfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbfb71f7fb6bf7fb2bf7fa23f7fb1bf7fb13f7fb0bf7fb03f7fb7bf6fb73f66bf86bf657e03bf6fb33f6fb2bf6fb6bf5fb33f5fb2bf5fb23f5f31bf5ef13f55be40bf55be471e0fb33e75be42be72fed7bb4fb73b4fbfa51",
+    ]
+
+
+@pytest.fixture
+def device(mocker: MockerFixture):
+    ble_dev = mocker.Mock()
+    ble_dev.address = "AA:BB:CC:DD:EE:FF"
+    adv_data = mocker.MagicMock()
+    device = Device(ble_dev, adv_data, "MR51TEST12345678")
+    device._conn = mocker.AsyncMock()
+    return device
+
+
+async def test_delta_pro_3_parses_all_packets_successfully(device, packet_sequence):
+    for i, hex_packet in enumerate(packet_sequence):
+        packet = await device.packet_parse(bytes.fromhex(hex_packet))
+
+        assert packet is not None, f"Packet {i} failed to parse"
+        assert packet.src == 0x02, f"Packet {i} has unexpected src: {packet.src:#04x}"
+        assert packet.cmd_set == 0xFE, (
+            f"Packet {i} has unexpected cmd_set: {packet.cmd_set:#04x}"
+        )
+        assert packet.cmd_id == 0x15, (
+            f"Packet {i} has unexpected cmd_id: {packet.cmd_id:#04x}"
+        )
+
+
+async def test_delta_pro_3_processes_all_packets_successfully(
+    device, packet_sequence
+):
+    for i, hex_packet in enumerate(packet_sequence):
+        packet = await device.packet_parse(bytes.fromhex(hex_packet))
+        processed = await device.data_parse(packet)
+        assert processed is True, f"Packet {i} was not processed"
+
+
+async def test_delta_pro_3_exact_values_from_known_packets(device, packet_sequence):
+    """Test that known packet data produces exact expected values"""
+    for hex_packet in packet_sequence:
+        packet = await device.packet_parse(bytes.fromhex(hex_packet))
+        await device.data_parse(packet)
+
+    expected = {
+        Device.battery_level: 59.35,
+        Device.battery_level_main: 59.35,
+        Device.state_of_health: 100.0,
+        Device.battery_full_energy: 4096,
+        Device.battery_charge_state: ChargeDischargeState.IDLE,
+        Device.ac_input_power: 148.0,
+        Device.ac_lv_output_power: 0.0,
+        Device.ac_hv_output_power: 147.0,
+        Device.ac_lv_tt30_output_power: 0.0,
+        Device.ac_output_frequency: 50,
+        Device.input_power: 148.0,
+        Device.output_power: 147.0,
+        Device.dc12v_output_power: 0.0,
+        Device.usbc_output_power: 0.0,
+        Device.usba_output_power: 0.0,
+        Device.battery_input_power: 0,
+        Device.battery_output_power: 0,
+        Device.power_io_port_power: 0.0,
+        Device.cell_temperature: 29,
+        Device.min_cell_temperature: 26,
+        Device.beeper: True,
+        Device.xboost: False,
+        Device.usb_ports: True,
+        Device.dc_12v_port: False,
+        Device.ac_lv_port: False,
+        Device.ac_hv_port: True,
+        Device.plugged_in_ac: True,
+        Device.energy_backup: False,
+        Device.battery_charge_limit_min: 1,
+        Device.battery_charge_limit_max: 61,
+        Device.ac_charging_speed: 400,
+        Device.max_ac_charging_power: 2900,
+        Device.remaining_time_charging: 6565,
+        Device.remaining_time_discharging: 8428,
+        Device.bms_run_state: True,
+        Device.error_code: 0,
+        Device.dc_lv_input_power: 0.0,
+        Device.dc_hv_input_power: 0.0,
+        Device.dc_lv_input_state: DCPortState.STATE_5_UNKNOWN,
+        Device.dc_hv_input_state: DCPortState.STATE_5_UNKNOWN,
+    }
+
+    for field_name, expected_value in expected.items():
+        actual_value = device.get_value(field_name)
+        assert actual_value == expected_value, (
+            f"{field_name}: expected {expected_value}, got {actual_value}"
+        )
+
+
+async def test_delta_pro_3_computed_fields(device, packet_sequence):
+    for hex_packet in packet_sequence:
+        packet = await device.packet_parse(bytes.fromhex(hex_packet))
+        await device.data_parse(packet)
+
+    assert device.error_occurred is False
+    assert device.fan_running is False
+    assert device.solar_lv_power == 0
+    assert device.solar_hv_power == 0
+
+
+async def test_delta_pro_3_battery_soc_values_are_valid(device, packet_sequence):
+    for hex_packet in packet_sequence:
+        packet = await device.packet_parse(bytes.fromhex(hex_packet))
+        await device.data_parse(packet)
+
+    assert device.battery_level is not None
+    assert 0 <= device.battery_level <= 100
+    assert device.state_of_health is not None
+    assert 0 <= device.state_of_health <= 100

--- a/tests/eflib/test_delta_pro_3.py
+++ b/tests/eflib/test_delta_pro_3.py
@@ -1,11 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from custom_components.ef_ble.eflib.devices.delta_pro_3 import (
-    ChargeDischargeState,
-    DCPortState,
-    Device,
-)
+from custom_components.ef_ble.eflib.devices.delta_pro_3 import DCPortState, Device
 
 
 @pytest.fixture
@@ -48,9 +44,7 @@ async def test_delta_pro_3_parses_all_packets_successfully(device, packet_sequen
         )
 
 
-async def test_delta_pro_3_processes_all_packets_successfully(
-    device, packet_sequence
-):
+async def test_delta_pro_3_processes_all_packets_successfully(device, packet_sequence):
     for i, hex_packet in enumerate(packet_sequence):
         packet = await device.packet_parse(bytes.fromhex(hex_packet))
         processed = await device.data_parse(packet)
@@ -67,13 +61,10 @@ async def test_delta_pro_3_exact_values_from_known_packets(device, packet_sequen
         Device.battery_level: 59.35,
         Device.battery_level_main: 59.35,
         Device.state_of_health: 100.0,
-        Device.battery_full_energy: 4096,
-        Device.battery_charge_state: ChargeDischargeState.IDLE,
         Device.ac_input_power: 148.0,
         Device.ac_lv_output_power: 0.0,
         Device.ac_hv_output_power: 147.0,
         Device.ac_lv_tt30_output_power: 0.0,
-        Device.ac_output_frequency: 50,
         Device.input_power: 148.0,
         Device.output_power: 147.0,
         Device.dc12v_output_power: 0.0,
@@ -81,11 +72,9 @@ async def test_delta_pro_3_exact_values_from_known_packets(device, packet_sequen
         Device.usba_output_power: 0.0,
         Device.battery_input_power: 0,
         Device.battery_output_power: 0,
-        Device.power_io_port_power: 0.0,
+        Device.ac_5p8_in_power: 0.0,
+        Device.ac_5p8_out_power: 0.0,
         Device.cell_temperature: 29,
-        Device.min_cell_temperature: 26,
-        Device.beeper: True,
-        Device.xboost: False,
         Device.usb_ports: True,
         Device.dc_12v_port: False,
         Device.ac_lv_port: False,


### PR DESCRIPTION
**The changes in this PR are generated by Claude Fable (max effort). I can confirm these changes are effective on my device.**

Regarding the CONTRIBUTING.md, I can say most of the PR is simple so it's not like I don't understand most of the code, but I also can't claim I understand every single bit. I instructed Claude a bunch on different matters (e.g. just follow project conventions, make minimal changes, look at existing contributions, etc...) and I'm hoping it has done a good enough job. 

Below is what Claude has to say:

##

# Expand Delta Pro 3 support: battery diagnostics, port sensors, and switches

All new fields decode from the `DisplayPropertyUpload` messages already parsed for
the DP3 — no new packet types. Verified on real hardware (MR51, EU unit) by logging
~600 decoded uploads and checking values against the device.

**Sensors** (disabled by default, following #417 conventions):

| Entity | Proto field | Observed |
|---|---|---|
| State of Health | `cms_batt_soh` | 100 % |
| Battery Capacity | `cms_batt_full_energy` | 4096 Wh (nameplate) |
| Battery Charge State | `cms_chg_dsg_state` | see caveats |
| Min Cell Temperature | `bms_min_cell_temp` | 26 °C |
| Battery Input/Output Power | `pow_get_bms` | −18 W trickle → 18 W output; same split and translation keys as River 3 |
| Power In/Out Port Power | `pow_get_5p8` | 0 (port unused) |
| AC LV TT-30 Output Power | `pow_get_ac_lv_tt30_out` | 0 (port unused) |
| AC Output Frequency | `ac_out_freq` | 50 Hz |
| Fan Running (binary) | `pcs_fan_level` | same pattern as `_delta3_base` |

**Switches:** USB Ports (`cfg_usb_open`, mirrors `delta3.py`), Beeper
(`cfg_beep_en`), X-Boost (`cfg_xboost_en`). Beeper verified round-trip on hardware
(device echoed the change; no optimistic state involved). USB/X-Boost readback
matches the device; their writes use the same mechanism but weren't toggled.

**Also:** `icons.json` entries for the device-class-less entities (they rendered as
the eye icon), `en`/`uk`/`zh-Hans` translations, README table, and
`tests/eflib/test_delta_pro_3.py` — raw captured packets with exact-value
assertions. 153 tests pass, `prek run --all-files` green.

## Caveats

- **Battery Charge State** semantics from the official API docs (0 idle /
  1 discharging / 2 charging); our unit reported `0` throughout, even at 18 W
  trickle discharge — values 1/2 never observed. Disabled by default; can drop it
  if you prefer.
- **5P8 sign convention unverified** (nothing attached, constant 0) — exposed raw.
- **TT-30** always 0 on this EU unit; `out_power` transform by analogy with the
  other AC outputs.
- `uk`/`zh-Hans` translations not native-speaker reviewed.

## Deliberately not added

Never seen in any captured upload: `display_statistics_sum` (energy stats —
confirms the README note), `cms_batt_full/design/remain_cap`, `bypass_out_disable`,
`btn_usb_switch`, `cms_batt_temp` — entities would be permanently `unknown`.
Extra-battery port powers (`pow_get_4p8_*`) skipped: no packs here, and #250
suggests they read zero anyway. Volts/amps live in `RuntimePropertyUpload`
(cmd 0x16, unparsed) — possible follow-up.
