### PR TITLE
Fix Delta 3 Max Plus AC2 output power always reading 0 (wrong pow_get_ac_out_list index)

### DIFF
--- a/custom_components/ef_ble/eflib/devices/delta3_max_plus.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_max_plus.py
@@ -24,7 +24,8 @@ class Device(delta3_plus.Device):
     ac_ports_2 = pb_field(pb.flow_info_ac2_out, flow_is_on)
 
     ac_power_1 = _ACPortPower(0)
-    ac_power_2 = _ACPortPower(3)
+    # pow_get_ac_out_list on D3M1 is [AC1, 0, AC2, 0, 0]; index 3 is always 0
+    ac_power_2 = _ACPortPower(2)
 
     usbc3_output_power = pb_field(pb.pow_get_typec3, out_power)
     _max_ac_charging_power = pb_field(pb.plug_in_info_ac_in_chg_hal_pow_max)


### PR DESCRIPTION
## Problem

On the Delta 3 Max Plus (SN prefix `D3M1`), `ac_power_2` always reports 0 even with a substantial load plugged into the AC2 socket group. `ac_output_power` (`pow_get_ac_out`) only covers the AC1 group on this device, so the AC2 wattage is invisible everywhere except the `output_power` sum.

## Cause

`ac_power_2 = _ACPortPower(3)` reads index 3 of `DisplayPropertyUpload.pow_get_ac_out_list`. Captured telemetry from a live D3M1 (firmware as of 2026-07) shows the list layout is:

```
pow_get_ac_out_list = [AC1, 0, AC2, 0, 0]
```

e.g. with ~130 W on AC1 and ~370 W on AC2:

```
ac_out_list=[-131.0, 0.0, -365.0, 0.0, 0.0]  pow_get_ac_out=-131.0  pow_out_sum=496.0
```

Index 3 is a permanently-empty slot, so the sensor parses successfully and reports a genuine 0.0 forever.

## Fix

Read AC2 from index 2.

## Testing

- Captured 100 packets via the integration's diagnostics packet collection from a live D3M1 under load on both AC groups; decoded all `DisplayPropertyUpload` messages with the eflib parser. On all 97 telemetry packets containing the list, `|list[0]| + |list[2]| == pow_out_sum_w` (0 mismatches), while `list[3]` was 0.0 on every packet.
- Deployed the patched file to a live Home Assistant install: `ac_power_2` immediately reported the true AC2 load (−396 W at the time), with `|ac_power_1| + |ac_power_2|` equal to `output_power` exactly. Cross-checked against the EcoFlow app's per-group day statistics (AC1 1.86 kWh / AC2 0.80 kWh), which match the corrected sensors.

Happy to provide the raw captured packets if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDETyocFBm2KoZVudNxiin
