### PR TITLE
Name circuit sensors and switches from the device, sorted and cached across restarts

### DIFF
--- a/custom_components/ef_ble/description_builder.py
+++ b/custom_components/ef_ble/description_builder.py
@@ -28,6 +28,7 @@ class EntityDescriptionBuilder:
     _translation_key: str | None = None
     _translation_placeholders: dict[str, str] | None = None
     _availability_prop: str | None = None
+    _name_field: str | None = None
     _entity_registry_enabled_default: bool = True
 
     @classmethod
@@ -41,6 +42,8 @@ class EntityDescriptionBuilder:
             builder = builder.translation_placeholders(entity.translation_placeholders)
         if entity.availability is not None:
             builder = builder.availability_prop(entity.availability_prop)
+        if entity.name_field is not None:
+            builder = builder.name_field(entity.name_field)
         return builder
 
     def name(self, name: str) -> Self:
@@ -65,6 +68,10 @@ class EntityDescriptionBuilder:
 
     def translation_placeholders(self, placeholders: dict[str, str]) -> Self:
         self._translation_placeholders = placeholders
+        return self
+
+    def name_field(self, name_field: str) -> Self:
+        self._name_field = name_field
         return self
 
     def availability_prop(self, availability_prop: "str | Field | None") -> Self:

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -130,6 +130,7 @@ class Device(DeviceBase, ProtobufProps):
     circuit_current = field_group(lambda n: CircuitCurrentField(n - 1), count=12)
 
     circuit = _circuit_sta_group(_hall1.ch1_sta.load_sta)
+    circuit_name = _circuit_info_group(_hall1.ch1_info.ch_name)
     circuit_split_link = _circuit_info_group(_hall1.ch1_info.splitphase.link_ch)
     circuit_split_info_loaded = _circuit_info_group(
         _hall1.ch1_info.splitphase.link_ch, transform=lambda value: value is not None
@@ -291,7 +292,8 @@ class Device(DeviceBase, ProtobufProps):
         control=controls.outlet,
         availability=circuit_split_info_loaded,
         translation_key="circuit_is_enabled",
-        translation_placeholders=lambda i: {"circuit": str(i)},
+        translation_placeholders=lambda i: {"circuit": f"{i:02d}"},
+        name_field=lambda i: f"circuit_name_{i}",
     )
     async def set_circuit_power(self, circuit_id: int, enable: bool):
         """Send command to power on / off the specific circuit of the panel"""

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -380,7 +380,8 @@ class Device(DeviceBase, ProtobufProps):
         control=controls.outlet,
         availability=circuit_split_info_loaded,
         translation_key="circuit_is_enabled",
-        translation_placeholders=lambda i: {"circuit": str(i)},
+        translation_placeholders=lambda i: {"circuit": f"{i:02d}"},
+        name_field=lambda i: f"circuit_name_{i}",
     )
     async def set_circuit_power(self, circuit_id: int, enable: bool):
         self._logger.debug("set_circuit_power for %d: %s", circuit_id, enable)

--- a/custom_components/ef_ble/eflib/entity/base.py
+++ b/custom_components/ef_ble/eflib/entity/base.py
@@ -18,6 +18,7 @@ class EntityType:
     translation_placeholders: dict[str, str] | None = dataclasses.field(
         default=None, kw_only=True
     )
+    name_field: str | None = dataclasses.field(default=None, kw_only=True)
 
     @property
     def _field(self) -> "updatable_props.Field":

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -227,12 +227,16 @@ def for_each(
     availability: "Iterable[updatable_props.Field | None] | None" = None,
     translation_key: str | None = None,
     translation_placeholders: Callable[[int], dict[str, str]] | None = None,
+    name_field: Callable[[int], str] | None = None,
 ) -> Callable[[Callable], Callable]:
     """
     Decorate a function to register a toggle control for each field in the list
 
     The decorated function must accept (self, index: int, enabled: bool) where
     index is 1-based (i.e. 1 for the first field, 2 for the second, etc.).
+
+    `name_field(idx)` returns the device field whose value names the entity (e.g. a
+    circuit name); the HA platform composes the display name from it.
     """
 
     def decorator(func: Callable) -> Callable:
@@ -250,6 +254,7 @@ def for_each(
                 availability=avail,
                 translation_key=translation_key,
                 translation_placeholders=placeholders,
+                name_field=name_field(idx) if name_field is not None else None,
             )
 
             async def _enable(

--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -6,6 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from .const import DOMAIN, MANUFACTURER
 from .eflib import DeviceBase
@@ -158,6 +159,88 @@ class EcoflowBatteryAddonEntity(EcoflowEntity):
         registry.async_update_device(
             device_entry.id, serial_number=battery_sn, model=battery_model
         )
+
+
+@dataclasses.dataclass
+class _RestoredDeviceName(ExtraStoredData):
+    """Cached last-known device-provided name, persisted across HA restarts"""
+
+    name: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name}
+
+
+class DeviceNamedEntity(RestoreEntity):
+    """
+    Mixin for entities whose display name comes from a device field (e.g. a circuit)
+
+    The device sends these names only in its heartbeat, so they arrive late and can
+    change. We format the localized `... {name} ...` translation template ourselves -
+    HA's own formatter does not know the `{name}` placeholder and would raise - and
+    cache the last value via `RestoreEntity`, so after an HA restart the name survives
+    the reconnect gap instead of briefly dropping the circuit name from every entity.
+
+    Mix in before the concrete entity base, e.g.
+    `class Foo(DeviceNamedEntity, EcoflowSensor)`.
+    """
+
+    entity_description: EntityDescription
+    _device: DeviceBase
+    _restored_name: str | None = None
+
+    @property
+    def _name_field(self) -> str | None:
+        return getattr(self.entity_description, "name_field", None)
+
+    def _localized_name_template(self) -> str | None:
+        """Localized name template for this entity's `translation_key`, if loaded"""
+        if getattr(self, "platform_data", None) is None:
+            return None
+        if (key := self._name_translation_key) is None:
+            return None
+        return self.platform_data.platform_translations.get(key)
+
+    @property
+    def name(self):
+        if (name_field := self._name_field) is None:
+            return super().name
+
+        template = self._localized_name_template()
+        if template is None or "{name}" not in template:
+            return super().name
+
+        device_name = getattr(self._device, name_field, None) or self._restored_name
+        placeholders = {
+            **(self.translation_placeholders or {}),
+            "name": device_name or "",
+        }
+        try:
+            return " ".join(template.format(**placeholders).split())
+        except (KeyError, IndexError, ValueError):
+            return super().name
+
+    @property
+    def extra_restore_state_data(self) -> _RestoredDeviceName | None:
+        if (name_field := self._name_field) is None:
+            return None
+        # Persist the live name, or the restored one when the device has not sent it
+        # yet, so the cache survives a session that never reconnected.
+        name = getattr(self._device, name_field, None) or self._restored_name
+        return _RestoredDeviceName(name)
+
+    async def async_added_to_hass(self) -> None:
+        if (last := await self.async_get_last_extra_data()) is not None:
+            if restored := last.as_dict().get("name"):
+                self._restored_name = restored
+        await super().async_added_to_hass()
+        if (name_field := self._name_field) is not None:
+            self._device.register_callback(self.async_write_ha_state, name_field)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if (name_field := self._name_field) is not None:
+            self._device.remove_callback(self.async_write_ha_state, name_field)
+        await super().async_will_remove_from_hass()
 
 
 @runtime_checkable

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -46,6 +46,7 @@ from .eflib.devices import (
 from .eflib.entity import units
 from .eflib.props.enums import IntFieldValue
 from .entity import (
+    DeviceNamedEntity,
     EcoflowBatteryAddonEntity,
     EcoflowEntity,
     resolve_entity_description_keys,
@@ -931,6 +932,15 @@ _BATTERY_ADDON_SENSORS: Final = {
 }
 
 
+def _sensor_class(sensor: str) -> "type[EcoflowSensor]":
+    description = SENSOR_TYPES[sensor]
+    has_device_name = (
+        isinstance(description, EcoflowSensorEntityDescription)
+        and description.name_field is not None
+    )
+    return EcoflowNamedSensor if has_device_name else EcoflowSensor
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: DeviceConfigEntry,
@@ -940,7 +950,7 @@ async def async_setup_entry(
     device = config_entry.runtime_data
 
     new_sensors = [
-        EcoflowSensor(device, sensor)
+        _sensor_class(sensor)(device, sensor)
         for sensor in SENSOR_TYPES
         if hasattr(device, sensor)
     ]
@@ -1033,24 +1043,6 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
         self._register_update_callback(None, sensor)
         for attribute_field in self._attribute_fields:
             self._register_update_callback(None, attribute_field)
-        # Refresh the entity name when the name source (e.g. circuit name) updates.
-        self._register_update_callback(None, self._name_field)
-
-    @property
-    def _name_field(self) -> str | None:
-        desc = self.entity_description
-        if isinstance(desc, EcoflowSensorEntityDescription):
-            return desc.name_field
-        return None
-
-    @property
-    def name(self):
-        """Use a device-provided name (e.g. circuit name) when available"""
-        if (name_field := self._name_field) is not None:
-            value = getattr(self._device, name_field, None)
-            if value:
-                return value
-        return super().name
 
     @property
     def native_value(self):
@@ -1082,6 +1074,10 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
             for field_name in self._attribute_fields
             if hasattr(self._device, field_name)
         }
+
+
+class EcoflowNamedSensor(DeviceNamedEntity, EcoflowSensor):
+    """Sensor whose display name comes from a device field (see DeviceNamedEntity)"""
 
 
 class EcoflowBatteryAddonSensor(EcoflowBatteryAddonEntity, SensorEntity):

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -17,13 +17,14 @@ from .deprecated.switches import DEPRECATED_SWITCH_TYPES
 from .description_builder import EntityDescriptionBuilder
 from .eflib import DeviceBase, get_controls
 from .eflib.entity import controls
-from .entity import EcoflowEntity
+from .entity import DeviceNamedEntity, EcoflowEntity
 
 
 @dataclass(frozen=True, kw_only=True)
 class EcoflowSwitchEntityDescription[T: DeviceBase](SwitchEntityDescription):
     set_state: Callable[[T, bool], Awaitable] | None = None
     availability_prop: str | None = None
+    name_field: str | None = None
 
 
 @dataclass(init=False)
@@ -52,6 +53,7 @@ class SwitchBuilder(EntityDescriptionBuilder):
             translation_key=self._entity_translation_key,
             translation_placeholders=self._translation_placeholders,
             availability_prop=self._availability_prop,
+            name_field=self._name_field,
             icon=self._icon,
         )
 
@@ -104,7 +106,14 @@ async def async_setup_entry(
             )
         ]
 
-    entities = [EcoflowSwitchEntity(device, desc) for desc in descriptions]
+    entities = [
+        (
+            EcoflowNamedSwitchEntity
+            if getattr(desc, "name_field", None) is not None
+            else EcoflowSwitchEntity
+        )(device, desc)
+        for desc in descriptions
+    ]
     if entities:
         async_add_entities(entities)
 
@@ -173,3 +182,7 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
     @property
     def is_on(self):
         return self._on_off_state if self._on_off_state is not None else False
+
+
+class EcoflowNamedSwitchEntity(DeviceNamedEntity, EcoflowSwitchEntity):
+    """Switch whose display name comes from a device field (see DeviceNamedEntity)"""

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -486,7 +486,7 @@
         "name": "Grid Energy"
       },
       "circuit_power": {
-        "name": "Circuit Power {index}"
+        "name": "C{index} {name} Power"
       },
       "circuit_current": {
         "name": "Circuit Current {index}"
@@ -495,7 +495,7 @@
         "name": "Circuit Voltage {index}"
       },
       "circuit_status": {
-        "name": "Circuit {index} Status",
+        "name": "C{index} {name} Status",
         "state": {
           "unknown": "Unknown",
           "off": "Off",
@@ -1107,7 +1107,7 @@
     },
     "switch": {
       "circuit_is_enabled": {
-        "name": "Circuit {circuit}"
+        "name": "C{circuit} {name}"
       },
       "channel_is_enabled": {
         "name": "Channel {channel}"

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -483,7 +483,7 @@
         "name": "Енергія мережі"
       },
       "circuit_power": {
-        "name": "Потужність контуру {index}"
+        "name": "C{index} {name} Потужність"
       },
       "circuit_current": {
         "name": "Струм контуру {index}"
@@ -940,7 +940,7 @@
         "name": "Тип входу AC C20"
       },
       "circuit_status": {
-        "name": "Стан контуру {index}",
+        "name": "C{index} {name} Стан",
         "state": {
           "unknown": "Невідомо",
           "off": "Вимкнено",
@@ -1104,7 +1104,7 @@
     },
     "switch": {
       "circuit_is_enabled": {
-        "name": "Контур {circuit}"
+        "name": "C{circuit} {name}"
       },
       "channel_is_enabled": {
         "name": "Канал {channel}"

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -483,7 +483,7 @@
         "name": "电网能量"
       },
       "circuit_power": {
-        "name": "电路功率 {index}"
+        "name": "C{index} {name} 功率"
       },
       "circuit_current": {
         "name": "电路电流 {index}"
@@ -940,7 +940,7 @@
         "name": "AC C20 输入类型"
       },
       "circuit_status": {
-        "name": "电路 {index} 状态",
+        "name": "C{index} {name} 状态",
         "state": {
           "unknown": "未知",
           "off": "关闭",
@@ -1104,7 +1104,7 @@
     },
     "switch": {
       "circuit_is_enabled": {
-        "name": "电路 {circuit}"
+        "name": "C{circuit} {name}"
       },
       "channel_is_enabled": {
         "name": "通道 {channel}"

--- a/tests/eflib/test_shp2.py
+++ b/tests/eflib/test_shp2.py
@@ -256,6 +256,7 @@ def test_shp2_field_group_are_expanded_and_renamed():
         *(f"circuit_current_{i}" for i in range(1, 13)),
         *(f"channel_power_{i}" for i in range(1, 4)),
         *(f"circuit_{i}" for i in range(1, 13)),
+        *(f"circuit_name_{i}" for i in range(1, 13)),
         *(f"circuit_split_link_{i}" for i in range(1, 13)),
         *(f"circuit_split_info_loaded_{i}" for i in range(1, 13)),
         *(


### PR DESCRIPTION
This PR makes the circuit power and status sensors and the circuit on/off switches display device reported name name, as C{index} {name} {type} - so the entity reads "C28 Kitchen Power", "C28 Kitchen Status" and, for the switch, "C28 Kitchen". Because that name arrives only after the BLE link is up and can change at runtime, the name is composed by the integration from a {name}-bearing translation template rather than handed to Home Assistant's static name formatter, and the last-known value is cached across restarts.

Full list of changes:

- A shared DeviceNamedEntity mixin owns the whole behavior - reads the localized template, fills placeholders itself, persists via RestoreEntity; used by EcoflowNamedSensor/EcoflowNamedSwitchEntity, auto-selected for any description with a name_field.
- Circuit sensor/switch names became {name} templates in en/uk/zh-Hans, type word localized in place, C{index} leading; integration formats them (HA never sees the {name} slot).
- name_field plumbed through the controls system (for_each -> EntityType -> builder -> switch description).
- SHP2 now exposes circuit names via LoadChInfo.ch_name.
- Names survive a restart (cached per entity; live device name wins).