### PR TITLE
Expose SHP3 attached-battery SOC, power and serial as per-channel sensors

### DIFF
--- a/custom_components/ef_ble/config_flow.py
+++ b/custom_components/ef_ble/config_flow.py
@@ -61,7 +61,7 @@ from .const import (
     LINK_WIKI_SUPPORTING_NEW_DEVICES,
 )
 from .eflib.connection import Connection, ConnectionState
-from .eflib.device_mappings import battery_name_from_device
+from .eflib.device_mappings import battery_name_from_device, extra_battery_indices
 from .eflib.exceptions import AuthErrors
 from .eflib.logging_util import LogOptions
 from .eflib.login import EcoFlowLogin, Region
@@ -394,7 +394,7 @@ class EFBLEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if CONF_EXTRA_BATTERY not in entry_data:
             entry_data[CONF_EXTRA_BATTERY] = _find_enabled_batteries(
-                device, range(1, 6)
+                device, extra_battery_indices(device)
             )
 
         return self.async_create_entry(title=device.name, data=entry_data)
@@ -959,9 +959,7 @@ class _SchemaBuilder:
         self, extra_battery_conf: list[str] | None, device: eflib.DeviceBase
     ):
         available_battery_slots = (
-            [i for i in range(1, 6) if hasattr(device, f"battery_{i}_battery_level")]
-            if device is not None
-            else []
+            extra_battery_indices(device) if device is not None else []
         )
 
         if not available_battery_slots:

--- a/custom_components/ef_ble/description_builder.py
+++ b/custom_components/ef_ble/description_builder.py
@@ -28,6 +28,7 @@ class EntityDescriptionBuilder:
     _translation_key: str | None = None
     _translation_placeholders: dict[str, str] | None = None
     _availability_prop: str | None = None
+    _name_field: str | None = None
     _entity_registry_enabled_default: bool = True
 
     @classmethod
@@ -41,6 +42,8 @@ class EntityDescriptionBuilder:
             builder = builder.translation_placeholders(entity.translation_placeholders)
         if entity.availability is not None:
             builder = builder.availability_prop(entity.availability_prop)
+        if entity.name_field is not None:
+            builder = builder.name_field(entity.name_field)
         return builder
 
     def name(self, name: str) -> Self:
@@ -65,6 +68,10 @@ class EntityDescriptionBuilder:
 
     def translation_placeholders(self, placeholders: dict[str, str]) -> Self:
         self._translation_placeholders = placeholders
+        return self
+
+    def name_field(self, name_field: str) -> Self:
+        self._name_field = name_field
         return self
 
     def availability_prop(self, availability_prop: "str | Field | None") -> Self:

--- a/custom_components/ef_ble/eflib/device_mappings.py
+++ b/custom_components/ef_ble/eflib/device_mappings.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from . import devices as _devices
+
 if TYPE_CHECKING:
     from .devicebase import DeviceBase
 
@@ -39,16 +41,13 @@ def extra_battery_indices(device: "DeviceBase") -> list[int]:
 
 def _supported_device_name(sn: str) -> str | None:
     """Model name of the supported device whose serial prefix matches `sn`, if any"""
-    from .devices import devices as device_modules  # noqa: PLC0415 - avoid import cycle
-    from .devices import unsupported  # noqa: PLC0415
-
     try:
         sn_bytes = sn.encode("ASCII")
     except UnicodeEncodeError:
         return None
-    for item in device_modules:
+    for item in _devices.devices:
         device_cls = getattr(item, "Device", None)
-        if device_cls is None or device_cls is unsupported.UnsupportedDevice:
+        if device_cls is None or device_cls is _devices.unsupported.UnsupportedDevice:
             continue
         try:
             matched = device_cls.check(sn_bytes)

--- a/custom_components/ef_ble/eflib/device_mappings.py
+++ b/custom_components/ef_ble/eflib/device_mappings.py
@@ -25,13 +25,27 @@ ADDON_BATTERY_MAP: dict[str, str] = {
 }
 
 
+MAX_EXTRA_BATTERIES = 10
+
+
+def extra_battery_indices(device: "DeviceBase") -> list[int]:
+    """Slots for which the device declares an extra-battery level field"""
+    return [
+        i
+        for i in range(1, MAX_EXTRA_BATTERIES + 1)
+        if hasattr(device, f"battery_{i}_battery_level")
+    ]
+
+
 def battery_name_from_sn(sn: str | None) -> str:
     if not sn:
         return "Extra Battery"
 
-    for serial_num in [sn[:4], sn[:2]]:
+    for serial_num in [sn[:4], sn[:3], sn[:2]]:
         if name := ADDON_BATTERY_MAP.get(serial_num):
             return name
+        if device := ECOFLOW_DEVICE_LIST.get(serial_num):
+            return device["name"]
     return "Extra Battery"
 
 

--- a/custom_components/ef_ble/eflib/device_mappings.py
+++ b/custom_components/ef_ble/eflib/device_mappings.py
@@ -37,6 +37,28 @@ def extra_battery_indices(device: "DeviceBase") -> list[int]:
     ]
 
 
+def _supported_device_name(sn: str) -> str | None:
+    """Model name of the supported device whose serial prefix matches `sn`, if any"""
+    from .devices import devices as device_modules  # noqa: PLC0415 - avoid import cycle
+    from .devices import unsupported  # noqa: PLC0415
+
+    try:
+        sn_bytes = sn.encode("ASCII")
+    except UnicodeEncodeError:
+        return None
+    for item in device_modules:
+        device_cls = getattr(item, "Device", None)
+        if device_cls is None or device_cls is unsupported.UnsupportedDevice:
+            continue
+        try:
+            matched = device_cls.check(sn_bytes)
+        except Exception:  # noqa: BLE001 - a device check must never break naming
+            matched = False
+        if matched:
+            return (device_cls.__doc__ or "").strip() or None
+    return None
+
+
 def battery_name_from_sn(sn: str | None) -> str:
     if not sn:
         return "Extra Battery"
@@ -44,6 +66,13 @@ def battery_name_from_sn(sn: str | None) -> str:
     for serial_num in [sn[:4], sn[:3], sn[:2]]:
         if name := ADDON_BATTERY_MAP.get(serial_num):
             return name
+
+    # A connected "battery" may actually be a full supported device (e.g. a Delta Pro
+    # Ultra feeding a panel), so fall back to its real model name before the generic one.
+    if name := _supported_device_name(sn):
+        return name
+
+    for serial_num in [sn[:4], sn[:3], sn[:2]]:
         if device := ECOFLOW_DEVICE_LIST.get(serial_num):
             return device["name"]
     return "Extra Battery"

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -130,6 +130,7 @@ class Device(DeviceBase, ProtobufProps):
     circuit_current = field_group(lambda n: CircuitCurrentField(n - 1), count=12)
 
     circuit = _circuit_sta_group(_hall1.ch1_sta.load_sta)
+    circuit_name = _circuit_info_group(_hall1.ch1_info.ch_name)
     circuit_split_link = _circuit_info_group(_hall1.ch1_info.splitphase.link_ch)
     circuit_split_info_loaded = _circuit_info_group(
         _hall1.ch1_info.splitphase.link_ch, transform=lambda value: value is not None
@@ -291,7 +292,8 @@ class Device(DeviceBase, ProtobufProps):
         control=controls.outlet,
         availability=circuit_split_info_loaded,
         translation_key="circuit_is_enabled",
-        translation_placeholders=lambda i: {"circuit": str(i)},
+        translation_placeholders=lambda i: {"circuit": f"{i:02d}"},
+        name_field=lambda i: f"circuit_name_{i}",
     )
     async def set_circuit_power(self, circuit_id: int, enable: bool):
         """Send command to power on / off the specific circuit of the panel"""

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -380,7 +380,8 @@ class Device(DeviceBase, ProtobufProps):
         control=controls.outlet,
         availability=circuit_split_info_loaded,
         translation_key="circuit_is_enabled",
-        translation_placeholders=lambda i: {"circuit": str(i)},
+        translation_placeholders=lambda i: {"circuit": f"{i:02d}"},
+        name_field=lambda i: f"circuit_name_{i}",
     )
     async def set_circuit_power(self, circuit_id: int, enable: bool):
         self._logger.debug("set_circuit_power for %d: %s", circuit_id, enable)

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -1,6 +1,8 @@
 import dataclasses
 import time
+from collections.abc import Callable
 from enum import IntEnum
+from typing import Any
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
@@ -13,8 +15,10 @@ from ..entity.base import dynamic
 from ..packet import Packet, PacketV4
 from ..pb import dev_apl_comm_pb2
 from ..props import (
+    Field,
     ProtobufProps,
     computed_field,
+    field_group,
     pb_field,
     pb_field_group,
     pb_indexed_attr,
@@ -22,7 +26,7 @@ from ..props import (
 )
 from ..props.enums import IntFieldValue
 from ..props.protobuf_field import TransformIfMissing
-from ..props.transforms import pround
+from ..props.transforms import out_power, pround
 
 pb = proto_attr_mapper(dev_apl_comm_pb2.DisplayPropertyUpload)
 pb_cfg = proto_attr_mapper(dev_apl_comm_pb2.ConfigWrite)
@@ -112,12 +116,24 @@ def _channel_signal_connected(info: dev_apl_comm_pb2.BackupChInfo) -> bool | Non
     return info.signal_line_sta == 1
 
 
-def _charging_power(pwr: int | None) -> int | None:
-    return None if pwr is None else max(pwr, 0)
+def _backup_channel_dev_id(info: dev_apl_comm_pb2.BackupChInfo) -> int | None:
+    return info.ch_dev_id or None
 
 
-def _discharging_power(pwr: int | None) -> int | None:
-    return None if pwr is None else max(-pwr, 0)
+def _channel_battery(slot_template: str) -> Callable[[int], Field[Any]]:
+    """Factory resolving a backup channel to its battery info slot via `ch_dev_id`"""
+
+    def factory(channel: int) -> Field[Any]:
+        @computed_field
+        def channel_value(self: "Device") -> Any:
+            dev_id = getattr(self, f"_ch{channel}_dev_id")
+            if dev_id is None or not 1 <= dev_id <= Device.NUM_OF_BATTERIES:
+                return None
+            return getattr(self, slot_template.format(n=dev_id))
+
+        return channel_value
+
+    return factory
 
 
 class Device(DeviceBase, ProtobufProps):
@@ -217,42 +233,53 @@ class Device(DeviceBase, ProtobufProps):
     battery_power = pb_field(pb.pow_get_bp_cms, pround(2))
     pv_power_sum = pb_field(pb.pow_get_pv_sum, pround(2))
 
-    # Batteries attached to the backup channels (`DevieBatteryInfo` slots, pointed at
-    # by `panel_backup_ch{n}_Info.ch_dev_id`), exposed via the extra-battery harness.
-    # `ac_pwr` is signed: negative while the battery discharges into the panel.
-    battery_enabled = pb_field_group(
+    # Batteries attached to the backup channels: `panel_backup_ch{n}_Info.ch_dev_id`
+    # points into the `panel_generate_energy_battery_info_{n}` slots, and the
+    # channel{n}_* fields (named after SHP2's per-channel energy info) resolve
+    # through that indirection. `ac_pwr` is signed: negative while discharging
+    # into the panel, hence `out_power` for the output power reading.
+    _battery_slot_sn = pb_field_group(
         pb.panel_generate_energy_battery_info_1.sn,
         match="panel_generate_energy_battery_info_{n}",
         count=NUM_OF_BATTERIES,
-        transform=bool,
-        name_template="battery_{n}_enabled",
+        name_template="_battery_slot_sn_{n}",
     )
-    battery_sn = pb_field_group(
-        pb.panel_generate_energy_battery_info_1.sn,
-        match="panel_generate_energy_battery_info_{n}",
-        count=NUM_OF_BATTERIES,
-        name_template="battery_{n}_sn",
-    )
-    battery_battery_level = pb_field_group(
+    _battery_slot_soc = pb_field_group(
         pb.panel_generate_energy_battery_info_1.soc_cms,
         match="panel_generate_energy_battery_info_{n}",
         count=NUM_OF_BATTERIES,
         transform=pround(2),
-        name_template="battery_{n}_battery_level",
+        name_template="_battery_slot_soc_{n}",
     )
-    battery_input_power = pb_field_group(
+    _battery_slot_power = pb_field_group(
         pb.panel_generate_energy_battery_info_1.ac_pwr,
         match="panel_generate_energy_battery_info_{n}",
         count=NUM_OF_BATTERIES,
-        transform=_charging_power,
-        name_template="battery_{n}_input_power",
+        transform=out_power,
+        name_template="_battery_slot_power_{n}",
     )
-    battery_output_power = pb_field_group(
-        pb.panel_generate_energy_battery_info_1.ac_pwr,
-        match="panel_generate_energy_battery_info_{n}",
-        count=NUM_OF_BATTERIES,
-        transform=_discharging_power,
-        name_template="battery_{n}_output_power",
+    _channel_dev_id = pb_field_group(
+        pb.panel_backup_ch1_Info,
+        match="panel_backup_ch{n}_Info",
+        count=NUM_OF_CHANNELS,
+        transform=_backup_channel_dev_id,
+        name_template="_ch{n}_dev_id",
+    )
+
+    channel_sn = field_group(
+        _channel_battery("_battery_slot_sn_{n}"),
+        NUM_OF_CHANNELS,
+        name_template="channel{n}_sn",
+    )
+    channel_battery_percentage = field_group(
+        _channel_battery("_battery_slot_soc_{n}"),
+        NUM_OF_CHANNELS,
+        name_template="channel{n}_battery_percentage",
+    )
+    channel_output_power = field_group(
+        _channel_battery("_battery_slot_power_{n}"),
+        NUM_OF_CHANNELS,
+        name_template="channel{n}_output_power",
     )
 
     # Per-channel enable state, driving the switch control below. ch_sta is the

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -112,6 +112,14 @@ def _channel_signal_connected(info: dev_apl_comm_pb2.BackupChInfo) -> bool | Non
     return info.signal_line_sta == 1
 
 
+def _charging_power(pwr: int | None) -> int | None:
+    return None if pwr is None else max(pwr, 0)
+
+
+def _discharging_power(pwr: int | None) -> int | None:
+    return None if pwr is None else max(-pwr, 0)
+
+
 class Device(DeviceBase, ProtobufProps):
     """Smart Home Panel 3"""
 
@@ -120,6 +128,7 @@ class Device(DeviceBase, ProtobufProps):
 
     NUM_OF_CIRCUITS = 32
     NUM_OF_CHANNELS = 3
+    NUM_OF_BATTERIES = 10
     _KEEPALIVE_INTERVAL = 20
 
     battery_level = pb_field(pb.cms_batt_soc, pround(2))
@@ -207,6 +216,44 @@ class Device(DeviceBase, ProtobufProps):
     load_from_grid = pb_field(pb.pow_get_sys_grid, pround(2))
     battery_power = pb_field(pb.pow_get_bp_cms, pround(2))
     pv_power_sum = pb_field(pb.pow_get_pv_sum, pround(2))
+
+    # Batteries attached to the backup channels (`DevieBatteryInfo` slots, pointed at
+    # by `panel_backup_ch{n}_Info.ch_dev_id`), exposed via the extra-battery harness.
+    # `ac_pwr` is signed: negative while the battery discharges into the panel.
+    battery_enabled = pb_field_group(
+        pb.panel_generate_energy_battery_info_1.sn,
+        match="panel_generate_energy_battery_info_{n}",
+        count=NUM_OF_BATTERIES,
+        transform=bool,
+        name_template="battery_{n}_enabled",
+    )
+    battery_sn = pb_field_group(
+        pb.panel_generate_energy_battery_info_1.sn,
+        match="panel_generate_energy_battery_info_{n}",
+        count=NUM_OF_BATTERIES,
+        name_template="battery_{n}_sn",
+    )
+    battery_battery_level = pb_field_group(
+        pb.panel_generate_energy_battery_info_1.soc_cms,
+        match="panel_generate_energy_battery_info_{n}",
+        count=NUM_OF_BATTERIES,
+        transform=pround(2),
+        name_template="battery_{n}_battery_level",
+    )
+    battery_input_power = pb_field_group(
+        pb.panel_generate_energy_battery_info_1.ac_pwr,
+        match="panel_generate_energy_battery_info_{n}",
+        count=NUM_OF_BATTERIES,
+        transform=_charging_power,
+        name_template="battery_{n}_input_power",
+    )
+    battery_output_power = pb_field_group(
+        pb.panel_generate_energy_battery_info_1.ac_pwr,
+        match="panel_generate_energy_battery_info_{n}",
+        count=NUM_OF_BATTERIES,
+        transform=_discharging_power,
+        name_template="battery_{n}_output_power",
+    )
 
     # Per-channel enable state, driving the switch control below. ch_sta is the
     # enable/connected status (None for an empty channel); the switch writes ctrl_en.

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -233,11 +233,6 @@ class Device(DeviceBase, ProtobufProps):
     battery_power = pb_field(pb.pow_get_bp_cms, pround(2))
     pv_power_sum = pb_field(pb.pow_get_pv_sum, pround(2))
 
-    # Batteries attached to the backup channels: `panel_backup_ch{n}_Info.ch_dev_id`
-    # points into the `panel_generate_energy_battery_info_{n}` slots, and the
-    # channel{n}_* fields (named after SHP2's per-channel energy info) resolve
-    # through that indirection. `ac_pwr` is signed: negative while discharging
-    # into the panel, hence `out_power` for the output power reading.
     _battery_slot_sn = pb_field_group(
         pb.panel_generate_energy_battery_info_1.sn,
         match="panel_generate_energy_battery_info_{n}",

--- a/custom_components/ef_ble/eflib/entity/base.py
+++ b/custom_components/ef_ble/eflib/entity/base.py
@@ -18,6 +18,7 @@ class EntityType:
     translation_placeholders: dict[str, str] | None = dataclasses.field(
         default=None, kw_only=True
     )
+    name_field: str | None = dataclasses.field(default=None, kw_only=True)
 
     @property
     def _field(self) -> "updatable_props.Field":

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -227,12 +227,16 @@ def for_each(
     availability: "Iterable[updatable_props.Field | None] | None" = None,
     translation_key: str | None = None,
     translation_placeholders: Callable[[int], dict[str, str]] | None = None,
+    name_field: Callable[[int], str] | None = None,
 ) -> Callable[[Callable], Callable]:
     """
     Decorate a function to register a toggle control for each field in the list
 
     The decorated function must accept (self, index: int, enabled: bool) where
     index is 1-based (i.e. 1 for the first field, 2 for the second, etc.).
+
+    `name_field(idx)` returns the device field whose value names the entity (e.g. a
+    circuit name); the HA platform composes the display name from it.
     """
 
     def decorator(func: Callable) -> Callable:
@@ -250,6 +254,7 @@ def for_each(
                 availability=avail,
                 translation_key=translation_key,
                 translation_placeholders=placeholders,
+                name_field=name_field(idx) if name_field is not None else None,
             )
 
             async def _enable(

--- a/custom_components/ef_ble/entity.py
+++ b/custom_components/ef_ble/entity.py
@@ -6,6 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from .const import DOMAIN, MANUFACTURER
 from .eflib import DeviceBase
@@ -158,6 +159,88 @@ class EcoflowBatteryAddonEntity(EcoflowEntity):
         registry.async_update_device(
             device_entry.id, serial_number=battery_sn, model=battery_model
         )
+
+
+@dataclasses.dataclass
+class _RestoredDeviceName(ExtraStoredData):
+    """Cached last-known device-provided name, persisted across HA restarts"""
+
+    name: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name}
+
+
+class DeviceNamedEntity(RestoreEntity):
+    """
+    Mixin for entities whose display name comes from a device field (e.g. a circuit)
+
+    The device sends these names only in its heartbeat, so they arrive late and can
+    change. We format the localized `... {name} ...` translation template ourselves -
+    HA's own formatter does not know the `{name}` placeholder and would raise - and
+    cache the last value via `RestoreEntity`, so after an HA restart the name survives
+    the reconnect gap instead of briefly dropping the circuit name from every entity.
+
+    Mix in before the concrete entity base, e.g.
+    `class Foo(DeviceNamedEntity, EcoflowSensor)`.
+    """
+
+    entity_description: EntityDescription
+    _device: DeviceBase
+    _restored_name: str | None = None
+
+    @property
+    def _name_field(self) -> str | None:
+        return getattr(self.entity_description, "name_field", None)
+
+    def _localized_name_template(self) -> str | None:
+        """Localized name template for this entity's `translation_key`, if loaded"""
+        if getattr(self, "platform_data", None) is None:
+            return None
+        if (key := self._name_translation_key) is None:
+            return None
+        return self.platform_data.platform_translations.get(key)
+
+    @property
+    def name(self):
+        if (name_field := self._name_field) is None:
+            return super().name
+
+        template = self._localized_name_template()
+        if template is None or "{name}" not in template:
+            return super().name
+
+        device_name = getattr(self._device, name_field, None) or self._restored_name
+        placeholders = {
+            **(self.translation_placeholders or {}),
+            "name": device_name or "",
+        }
+        try:
+            return " ".join(template.format(**placeholders).split())
+        except (KeyError, IndexError, ValueError):
+            return super().name
+
+    @property
+    def extra_restore_state_data(self) -> _RestoredDeviceName | None:
+        if (name_field := self._name_field) is None:
+            return None
+        # Persist the live name, or the restored one when the device has not sent it
+        # yet, so the cache survives a session that never reconnected.
+        name = getattr(self._device, name_field, None) or self._restored_name
+        return _RestoredDeviceName(name)
+
+    async def async_added_to_hass(self) -> None:
+        if (last := await self.async_get_last_extra_data()) is not None:
+            if restored := last.as_dict().get("name"):
+                self._restored_name = restored
+        await super().async_added_to_hass()
+        if (name_field := self._name_field) is not None:
+            self._device.register_callback(self.async_write_ha_state, name_field)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if (name_field := self._name_field) is not None:
+            self._device.remove_callback(self.async_write_ha_state, name_field)
+        await super().async_will_remove_from_hass()
 
 
 @runtime_checkable

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -46,6 +46,7 @@ from .eflib.devices import (
 from .eflib.entity import units
 from .eflib.props.enums import IntFieldValue
 from .entity import (
+    DeviceNamedEntity,
     EcoflowBatteryAddonEntity,
     EcoflowEntity,
     resolve_entity_description_keys,
@@ -931,6 +932,15 @@ _BATTERY_ADDON_SENSORS: Final = {
 }
 
 
+def _sensor_class(sensor: str) -> "type[EcoflowSensor]":
+    description = SENSOR_TYPES[sensor]
+    has_device_name = (
+        isinstance(description, EcoflowSensorEntityDescription)
+        and description.name_field is not None
+    )
+    return EcoflowNamedSensor if has_device_name else EcoflowSensor
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: DeviceConfigEntry,
@@ -940,7 +950,7 @@ async def async_setup_entry(
     device = config_entry.runtime_data
 
     new_sensors = [
-        EcoflowSensor(device, sensor)
+        _sensor_class(sensor)(device, sensor)
         for sensor in SENSOR_TYPES
         if hasattr(device, sensor)
     ]
@@ -1033,24 +1043,6 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
         self._register_update_callback(None, sensor)
         for attribute_field in self._attribute_fields:
             self._register_update_callback(None, attribute_field)
-        # Refresh the entity name when the name source (e.g. circuit name) updates.
-        self._register_update_callback(None, self._name_field)
-
-    @property
-    def _name_field(self) -> str | None:
-        desc = self.entity_description
-        if isinstance(desc, EcoflowSensorEntityDescription):
-            return desc.name_field
-        return None
-
-    @property
-    def name(self):
-        """Use a device-provided name (e.g. circuit name) when available"""
-        if (name_field := self._name_field) is not None:
-            value = getattr(self._device, name_field, None)
-            if value:
-                return value
-        return super().name
 
     @property
     def native_value(self):
@@ -1082,6 +1074,10 @@ class EcoflowSensor(EcoflowEntity, SensorEntity):
             for field_name in self._attribute_fields
             if hasattr(self._device, field_name)
         }
+
+
+class EcoflowNamedSensor(DeviceNamedEntity, EcoflowSensor):
+    """Sensor whose display name comes from a device field (see DeviceNamedEntity)"""
 
 
 class EcoflowBatteryAddonSensor(EcoflowBatteryAddonEntity, SensorEntity):

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -31,6 +31,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import DeviceConfigEntry
 from .const import CONF_EXTRA_BATTERY, DOMAIN
 from .eflib import DeviceBase
+from .eflib.device_mappings import extra_battery_indices
 from .eflib.devices import (
     _delta3_base,
     delta_pro_3,
@@ -967,9 +968,7 @@ async def async_setup_entry(
 def _get_extra_battery_entities(
     hass: HomeAssistant, device: DeviceBase, conf: list[str] | None
 ):
-    available_indices = [
-        i for i in range(1, 6) if hasattr(device, f"battery_{i}_battery_level")
-    ]
+    available_indices = extra_battery_indices(device)
 
     if not available_indices:
         return []

--- a/custom_components/ef_ble/switch.py
+++ b/custom_components/ef_ble/switch.py
@@ -17,13 +17,14 @@ from .deprecated.switches import DEPRECATED_SWITCH_TYPES
 from .description_builder import EntityDescriptionBuilder
 from .eflib import DeviceBase, get_controls
 from .eflib.entity import controls
-from .entity import EcoflowEntity
+from .entity import DeviceNamedEntity, EcoflowEntity
 
 
 @dataclass(frozen=True, kw_only=True)
 class EcoflowSwitchEntityDescription[T: DeviceBase](SwitchEntityDescription):
     set_state: Callable[[T, bool], Awaitable] | None = None
     availability_prop: str | None = None
+    name_field: str | None = None
 
 
 @dataclass(init=False)
@@ -52,6 +53,7 @@ class SwitchBuilder(EntityDescriptionBuilder):
             translation_key=self._entity_translation_key,
             translation_placeholders=self._translation_placeholders,
             availability_prop=self._availability_prop,
+            name_field=self._name_field,
             icon=self._icon,
         )
 
@@ -104,7 +106,14 @@ async def async_setup_entry(
             )
         ]
 
-    entities = [EcoflowSwitchEntity(device, desc) for desc in descriptions]
+    entities = [
+        (
+            EcoflowNamedSwitchEntity
+            if getattr(desc, "name_field", None) is not None
+            else EcoflowSwitchEntity
+        )(device, desc)
+        for desc in descriptions
+    ]
     if entities:
         async_add_entities(entities)
 
@@ -173,3 +182,7 @@ class EcoflowSwitchEntity(EcoflowEntity, SwitchEntity):
     @property
     def is_on(self):
         return self._on_off_state if self._on_off_state is not None else False
+
+
+class EcoflowNamedSwitchEntity(DeviceNamedEntity, EcoflowSwitchEntity):
+    """Switch whose display name comes from a device field (see DeviceNamedEntity)"""

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -486,7 +486,7 @@
         "name": "Grid Energy"
       },
       "circuit_power": {
-        "name": "Circuit Power {index}"
+        "name": "C{index} {name} Power"
       },
       "circuit_current": {
         "name": "Circuit Current {index}"
@@ -495,7 +495,7 @@
         "name": "Circuit Voltage {index}"
       },
       "circuit_status": {
-        "name": "Circuit {index} Status",
+        "name": "C{index} {name} Status",
         "state": {
           "unknown": "Unknown",
           "off": "Off",
@@ -1107,7 +1107,7 @@
     },
     "switch": {
       "circuit_is_enabled": {
-        "name": "Circuit {circuit}"
+        "name": "C{circuit} {name}"
       },
       "channel_is_enabled": {
         "name": "Channel {channel}"

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -483,7 +483,7 @@
         "name": "Енергія мережі"
       },
       "circuit_power": {
-        "name": "Потужність контуру {index}"
+        "name": "C{index} {name} Потужність"
       },
       "circuit_current": {
         "name": "Струм контуру {index}"
@@ -940,7 +940,7 @@
         "name": "Тип входу AC C20"
       },
       "circuit_status": {
-        "name": "Стан контуру {index}",
+        "name": "C{index} {name} Стан",
         "state": {
           "unknown": "Невідомо",
           "off": "Вимкнено",
@@ -1104,7 +1104,7 @@
     },
     "switch": {
       "circuit_is_enabled": {
-        "name": "Контур {circuit}"
+        "name": "C{circuit} {name}"
       },
       "channel_is_enabled": {
         "name": "Канал {channel}"

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -483,7 +483,7 @@
         "name": "电网能量"
       },
       "circuit_power": {
-        "name": "电路功率 {index}"
+        "name": "C{index} {name} 功率"
       },
       "circuit_current": {
         "name": "电路电流 {index}"
@@ -940,7 +940,7 @@
         "name": "AC C20 输入类型"
       },
       "circuit_status": {
-        "name": "电路 {index} 状态",
+        "name": "C{index} {name} 状态",
         "state": {
           "unknown": "未知",
           "off": "关闭",
@@ -1104,7 +1104,7 @@
     },
     "switch": {
       "circuit_is_enabled": {
-        "name": "电路 {circuit}"
+        "name": "C{circuit} {name}"
       },
       "channel_is_enabled": {
         "name": "通道 {channel}"

--- a/tests/eflib/test_shp2.py
+++ b/tests/eflib/test_shp2.py
@@ -256,6 +256,7 @@ def test_shp2_field_group_are_expanded_and_renamed():
         *(f"circuit_current_{i}" for i in range(1, 13)),
         *(f"channel_power_{i}" for i in range(1, 4)),
         *(f"circuit_{i}" for i in range(1, 13)),
+        *(f"circuit_name_{i}" for i in range(1, 13)),
         *(f"circuit_split_link_{i}" for i in range(1, 13)),
         *(f"circuit_split_info_loaded_{i}" for i in range(1, 13)),
         *(

--- a/tests/eflib/test_shp3.py
+++ b/tests/eflib/test_shp3.py
@@ -282,7 +282,6 @@ async def test_shp3_channel_is_enabled_state_from_backup_channels(device):
 
 
 async def test_shp3_channel_battery_info_resolves_through_dev_id(device):
-    """Layout mirrors a captured diagnostics dump: channel 1 -> slot 5, channel 2 -> slot 6"""
     msg = dev_apl_comm_pb2.DisplayPropertyUpload()
     msg.panel_backup_ch1_Info.ch_dev_id = 5
     msg.panel_backup_ch2_Info.ch_dev_id = 6
@@ -328,13 +327,6 @@ async def test_shp3_set_channel_enable_writes_backup_ctrl(device):
 
 
 async def test_shp3_config_write_mirrors_post_frame(device, packet_sequence):
-    """
-    After a post, PR #389 mirrors the panel's own v4 frame for the write.
-
-    The transport (addressing, inner header, obfuscation keys) is the post's verbatim
-    via `dataclasses.replace`; only cmd_flags / is_ack / is_rw_cmd and the application
-    payload change. The payload is `serial9 + serial16 + envelope + ConfigWrite`.
-    """
     post = await device.packet_parse(bytes.fromhex(packet_sequence[1]))
     await device.data_parse(post)
 

--- a/tests/eflib/test_shp3.py
+++ b/tests/eflib/test_shp3.py
@@ -144,6 +144,11 @@ def test_shp3_field_groups_are_expanded_and_renamed():
             f"circuit_split_info_loaded_{i}"
             for i in range(1, Device.NUM_OF_CIRCUITS + 1)
         ),
+        *(f"battery_{i}_enabled" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"battery_{i}_sn" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"battery_{i}_battery_level" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"battery_{i}_input_power" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"battery_{i}_output_power" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
         *(f"ch{i}_is_enabled" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
         *(f"ch{i}_type" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
         *(f"ch{i}_force_charge" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
@@ -269,6 +274,34 @@ async def test_shp3_channel_is_enabled_state_from_backup_channels(device):
     assert device.channel_is_enabled[1] is True
     assert device.channel_is_enabled[2] is False
     assert device.channel_is_enabled[3] is None
+
+
+async def test_shp3_parses_attached_battery_soc_power_and_serial(device):
+    """Slot layout mirrors a captured diagnostics dump (batteries in slots 5/6)"""
+    msg = dev_apl_comm_pb2.DisplayPropertyUpload()
+    # Slot 5 charging, slot 6 discharging into the panel, other slots empty.
+    msg.panel_generate_energy_battery_info_5.sn = "Y711XXXXXXXXX001"
+    msg.panel_generate_energy_battery_info_5.soc_cms = 93.456
+    msg.panel_generate_energy_battery_info_5.ac_pwr = 1520
+    msg.panel_generate_energy_battery_info_6.sn = "P101XXXXXXXXX002"
+    msg.panel_generate_energy_battery_info_6.soc_cms = 92.0
+    msg.panel_generate_energy_battery_info_6.ac_pwr = -352
+
+    device.update_from_message(msg)
+
+    assert device.battery_sn[5] == "Y711XXXXXXXXX001"
+    assert device.battery_battery_level[5] == 93.46
+    assert device.battery_input_power[5] == 1520
+    assert device.battery_output_power[5] == 0
+    assert device.battery_enabled[5] is True
+    assert device.battery_sn[6] == "P101XXXXXXXXX002"
+    assert device.battery_battery_level[6] == 92.0
+    assert device.battery_input_power[6] == 0
+    assert device.battery_output_power[6] == 352
+    assert device.battery_enabled[6] is True
+    assert device.battery_sn[1] is None
+    assert device.battery_battery_level[1] is None
+    assert device.battery_enabled[1] is None
 
 
 async def test_shp3_set_channel_enable_writes_backup_ctrl(device):

--- a/tests/eflib/test_shp3.py
+++ b/tests/eflib/test_shp3.py
@@ -144,11 +144,16 @@ def test_shp3_field_groups_are_expanded_and_renamed():
             f"circuit_split_info_loaded_{i}"
             for i in range(1, Device.NUM_OF_CIRCUITS + 1)
         ),
-        *(f"battery_{i}_enabled" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
-        *(f"battery_{i}_sn" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
-        *(f"battery_{i}_battery_level" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
-        *(f"battery_{i}_input_power" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
-        *(f"battery_{i}_output_power" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"_battery_slot_sn_{i}" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"_battery_slot_soc_{i}" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"_battery_slot_power_{i}" for i in range(1, Device.NUM_OF_BATTERIES + 1)),
+        *(f"_ch{i}_dev_id" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
+        *(f"channel{i}_sn" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
+        *(
+            f"channel{i}_battery_percentage"
+            for i in range(1, Device.NUM_OF_CHANNELS + 1)
+        ),
+        *(f"channel{i}_output_power" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
         *(f"ch{i}_is_enabled" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
         *(f"ch{i}_type" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
         *(f"ch{i}_force_charge" for i in range(1, Device.NUM_OF_CHANNELS + 1)),
@@ -276,10 +281,14 @@ async def test_shp3_channel_is_enabled_state_from_backup_channels(device):
     assert device.channel_is_enabled[3] is None
 
 
-async def test_shp3_parses_attached_battery_soc_power_and_serial(device):
-    """Slot layout mirrors a captured diagnostics dump (batteries in slots 5/6)"""
+async def test_shp3_channel_battery_info_resolves_through_dev_id(device):
+    """Layout mirrors a captured diagnostics dump: channel 1 -> slot 5, channel 2 -> slot 6"""
     msg = dev_apl_comm_pb2.DisplayPropertyUpload()
-    # Slot 5 charging, slot 6 discharging into the panel, other slots empty.
+    msg.panel_backup_ch1_Info.ch_dev_id = 5
+    msg.panel_backup_ch2_Info.ch_dev_id = 6
+    msg.panel_backup_ch3_Info.ch_dev_id = 7
+    # Channel 1's battery charging, channel 2's discharging into the panel;
+    # channel 3 has a dev id but no battery info slot (empty channel).
     msg.panel_generate_energy_battery_info_5.sn = "Y711XXXXXXXXX001"
     msg.panel_generate_energy_battery_info_5.soc_cms = 93.456
     msg.panel_generate_energy_battery_info_5.ac_pwr = 1520
@@ -289,19 +298,15 @@ async def test_shp3_parses_attached_battery_soc_power_and_serial(device):
 
     device.update_from_message(msg)
 
-    assert device.battery_sn[5] == "Y711XXXXXXXXX001"
-    assert device.battery_battery_level[5] == 93.46
-    assert device.battery_input_power[5] == 1520
-    assert device.battery_output_power[5] == 0
-    assert device.battery_enabled[5] is True
-    assert device.battery_sn[6] == "P101XXXXXXXXX002"
-    assert device.battery_battery_level[6] == 92.0
-    assert device.battery_input_power[6] == 0
-    assert device.battery_output_power[6] == 352
-    assert device.battery_enabled[6] is True
-    assert device.battery_sn[1] is None
-    assert device.battery_battery_level[1] is None
-    assert device.battery_enabled[1] is None
+    assert device.channel_sn[1] == "Y711XXXXXXXXX001"
+    assert device.channel_battery_percentage[1] == 93.46
+    assert device.channel_output_power[1] == -1520
+    assert device.channel_sn[2] == "P101XXXXXXXXX002"
+    assert device.channel_battery_percentage[2] == 92.0
+    assert device.channel_output_power[2] == 352
+    assert device.channel_sn[3] is None
+    assert device.channel_battery_percentage[3] is None
+    assert device.channel_output_power[3] is None
 
 
 async def test_shp3_set_channel_enable_writes_backup_ctrl(device):


### PR DESCRIPTION
This PR surfaces per-channel sensors that mirror the SHP2's (`channel{n}_battery_level`, `channel{n}_output_power`, `channel{n}_serial_number`), so a mixed SHP2/SHP3 setup reads consistently and setups that can only reach the panel still get per-battery data over the single panel link. The values come from the panel's own per-battery slots, tied to the backup channels through the panel's channel-to-battery pointer, so no proto changes were needed.

This is stacked on the circuit-naming PR (#423) and targets that branch; the two are independent in behavior but share the branch history.

Full list of changes:

- **The per-channel sensors are resolved through the panel's own indirection.** Each backup channel carries a device id that points at one of the panel's battery-info slots; computed field groups follow that pointer to expose `channel{n}_sn`, `channel{n}_battery_percentage` and `channel{n}_output_power`. Because those attribute names match the SHP2's existing sensor descriptions and translations, no new sensor entries or translation keys were needed - the SHP2's per-channel sensor definitions light up for the SHP3 as-is.
- **Panel-reported battery power is signed** (negative while the battery discharges into the panel); it is negated into `output_power` so discharge reads positive, matching the SHP2 convention.
- **The extra-battery slot scan was generalized.** The hardcoded 1-5 range in the sensor platform and config flow is replaced by an `extra_battery_indices()` helper that discovers the slots a device actually declares (up to 10), so the extra-battery harness no longer assumes a fixed count.
- **Attached batteries that are really full devices get their real model name.** A panel can report a standalone unit (e.g. a Delta Pro Ultra) as an attached battery; battery naming now falls back to the supported-device registry so it shows the actual model instead of a generic "Extra Battery". The registry lookup imports the devices package at module level rather than inside the function, to avoid a blocking import on the event loop.

Resolves #412
