### PR TITLE
Validate GATT characteristics at connect time and clear stale service cache

### DIFF
--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -46,7 +46,7 @@ from .eflib.connection import (
     ConnectionTimeout,
     MaxConnectionAttemptsReached,
 )
-from .eflib.exceptions import AuthErrors
+from .eflib.exceptions import AuthErrors, UnsupportedBluetoothProtocol
 from .eflib.logging_util import ConnectionLog
 
 PLATFORMS: list[Platform] = [
@@ -140,7 +140,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeviceConfigEntry) -> bo
         )
         async with asyncio.timeout(timeout):
             state = await device.wait_until_authenticated_or_error(raise_on_error=True)
-    except (ConnectionTimeout, BleakError, TimeoutError) as e:
+    except (
+        ConnectionTimeout,
+        BleakError,
+        TimeoutError,
+        UnsupportedBluetoothProtocol,
+    ) as e:
         await device.disconnect()
         raise ConfigEntryNotReady(
             translation_key="could_not_connect",

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -386,6 +386,15 @@ class Connection:
                 max_attempts=ble_attempts,
                 timeout=self._options.timeout,
             )
+            self._validate_characteristics()
+        except UnsupportedBluetoothProtocol as e:
+            error = e
+            if not e.available_characteristics:
+                # An empty service table is a host-side GATT cache glitch, not the
+                # device genuinely lacking the protocol - wipe the cache so the
+                # reconnect re-discovers services instead of failing the same way.
+                await self._clear_gatt_cache()
+            self._set_state(ConnectionState.ERROR_BLEAK, e)
         except TimeoutError as e:
             error = e
             self._set_state(
@@ -701,15 +710,35 @@ class Connection:
             f"{c.uuid} {c.description} {c.properties}"
             for c in self._client.services.characteristics.values()
         ]
-        raise UnsupportedBluetoothProtocol("write", characteristic_list)
+        raise UnsupportedBluetoothProtocol(char_type, characteristic_list)
 
-    @cached_property
+    @property
     def _notify_characteristic(self):
         return self._get_characteristics("notify")
 
-    @cached_property
+    @property
     def _write_characteristic(self):
         return self._get_characteristics("write")
+
+    def _validate_characteristics(self) -> None:
+        """Resolve both GATT characteristics against the freshly connected client"""
+        self._get_characteristics("notify")
+        self._get_characteristics("write")
+
+    async def _clear_gatt_cache(self) -> None:
+        # BlueZ can report `ServicesResolved` against an empty or stale cache (typically
+        # right after a bluetoothd restart or host update); without wiping it every
+        # reconnect keeps resolving the same broken service table. `clear_cache` is the
+        # `bleak_retry_connector.BleakClientWithServiceCache` interface, duck-typed via
+        # `getattr` because not every client implements it (plain `BleakClient` doesn't)
+        clear_cache = getattr(self._client, "clear_cache", None)
+        if clear_cache is None:
+            return
+        self._logger.warning("Clearing GATT cache to force service re-discovery")
+        try:
+            await clear_cache()
+        except BleakError as e:
+            self._logger.warning("Failed to clear GATT cache: %s", e)
 
     async def genSessionKey(self, seed: bytes, srand: bytes):
         """Implements the necessary part of the logic, rest is skipped"""

--- a/custom_components/ef_ble/eflib/exceptions.py
+++ b/custom_components/ef_ble/eflib/exceptions.py
@@ -96,6 +96,8 @@ class AuthErrors:
 
 class UnsupportedBluetoothProtocol(Exception):
     def __init__(self, characteristic_type: str, available_characteristics: list[str]):
+        self.characteristic_type = characteristic_type
+        self.available_characteristics = available_characteristics
         characteristics = "\n    ".join(available_characteristics)
         super().__init__(
             f"Device is using unsupported protocol for {characteristic_type}.\n"


### PR DESCRIPTION
This PR makes the integration recover automatically when BlueZ hands it a connected client with a broken GATT service table, instead of failing with a captured `UnsupportedBluetoothProtocol` exception at the first send. The reported failure had an *empty* characteristics list right after an HA restart on a freshly updated host: BlueZ can report `ServicesResolved` against an empty or stale cache (typically after a bluetoothd restart or host update), and the integration only noticed at the first write, retried against the same dead service table, and never recovered without manual intervention.

Full list of changes:

- **Characteristics are validated at connect time.** Both the notify and write characteristics are resolved right after `establish_connection`, so a broken service table fails the connect itself, where HA's normal retry machinery (`ConfigEntryNotReady` with backoff, entry reload on disconnect) takes over, instead of surfacing deep inside the auth routine.
- **An empty service table triggers a GATT cache clear.** When validation fails and the device exposes *no* characteristics at all, the client's `clear_cache()` is called so the next attempt re-discovers services instead of resolving the same broken table again. The call is guarded with `getattr` since HA's client wrapper and `BleakClientWithServiceCache` provide it but plain `BleakClient` does not.
- `_notify_characteristic`/`_write_characteristic` are plain properties now; the previous `cached_property` was never invalidated, so a characteristic object resolved from an old client could leak into the next connection after a reconnect.
- `UnsupportedBluetoothProtocol` now names the characteristic type that actually failed to resolve (the reported traceback was a notify lookup misreported as "write") and exposes `characteristic_type`/`available_characteristics` for callers.
- Setup treats `UnsupportedBluetoothProtocol` like the other connect failures, so the entry shows "could not connect" with the real message instead of logging "Unknown error".

Resolves #425
