### PR TITLE
Remove charge limit override in River 3 set_ac_charging_speed

### DIFF
--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -254,8 +254,6 @@ class Device(DeviceBase, ProtobufProps):
         max=dynamic(max_ac_charging_power),
     )
     async def set_ac_charging_speed(self, value: float):
-        await self.set_battery_charge_limit_max(12)
-
         if (
             self.max_ac_charging_power is None
             or value > self.max_ac_charging_power


### PR DESCRIPTION
Fixes #430

`set_ac_charging_speed` in `river3.py` starts with `await self.set_battery_charge_limit_max(12)`, which forces the max charge limit to 12% every time the AC charging speed is changed - discarding whatever limit the user had configured. The call was introduced in the #249 refactor (the pre-refactor implementation didn't have it), no other device module does this, and it's unrelated to the `cfg_plug_in_info_ac_in_chg_pow_max` write below it.

This PR removes the call.

Verified on a River 3 Plus (HA 2026.7.2, USB Bluetooth dongle).

- `uv run pytest tests/eflib` — 154 passed
- `uvx prek run --all-files` — all hooks pass