### PR TITLE
Add DCJ serial prefix for the Japan-spec Delta Pro

### DIFF
--- a/custom_components/ef_ble/eflib/device_mappings.py
+++ b/custom_components/ef_ble/eflib/device_mappings.py
@@ -104,6 +104,7 @@ ECOFLOW_DEVICE_LIST = {
 
     "DCA": {"name": "EcoFlow DELTA Pro", "packets": "v1"},
     "DCF": {"name": "EcoFlow DELTA Pro", "packets": "v1"},
+    "DCJ": {"name": "EcoFlow DELTA Pro", "packets": "v1"},
     "R511":{"name": "EcoFlow DELTA Pro", "packets": "v1"},
     "Z0":  {"name": "EcoFlow DELTA Pro DZ500", "packets": "v1"},
 

--- a/custom_components/ef_ble/eflib/devices/delta_pro.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro.py
@@ -77,7 +77,9 @@ class Device(DeviceBase, RawDataProps):
     dc_input_current = raw_field(rd_mppt.in_amp, pdiv(100, 2))
 
     ac_charging_speed = raw_field(rd_inv.cfg_slow_chg_watts)
-    max_ac_charging_power = Field[int]()
+    max_ac_charging_power = raw_field(
+        rd_inv.ac_chg_rated_power, lambda x: x if x and x > 200 else 1800
+    )
 
     input_power = raw_field(rd_pd.watts_in_sum)
     output_power = raw_field(rd_pd.watts_out_sum)
@@ -107,7 +109,6 @@ class Device(DeviceBase, RawDataProps):
         self._dormant = True
         self._wake_up_sent = False
         self._initialized = False
-        self.max_ac_charging_power = 2900
 
         self.add_timer_task(self.request_heartbeat, 0.35)
 

--- a/custom_components/ef_ble/eflib/devices/delta_pro.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro.py
@@ -40,6 +40,7 @@ class Device(DeviceBase, RawDataProps):
         b"DCG",
         b"DCS",
         b"DCF",
+        b"DCJ",
         b"Z1",
         b"R511",
     )

--- a/tests/eflib/test_delta_pro.py
+++ b/tests/eflib/test_delta_pro.py
@@ -190,6 +190,7 @@ async def test_delta_pro_exact_values_from_known_packets(device, packet_sequence
         Device.ac_input_current: 0.0,
         Device.ac_ports: True,
         Device.ac_charging_speed: 500,
+        Device.max_ac_charging_power: 2900,
         Device.input_power: 0,
         Device.output_power: 200,
         Device.dc_output_power: 0,


### PR DESCRIPTION
This PR adds the `DCJ` serial prefix to the Delta Pro device class, so units with that prefix are detected as a Delta Pro instead of falling through to the unsupported-device fallback. `DCJ` is the Japan-spec variant of the same product: the app's product catalog lists it under the same `product_ps_delta_delta_pro_3600` key, `pid` and product type as the already-supported `DCA`/`DCF`/`DCU` prefixes, so it speaks the same protocol.

It also stops hardcoding the AC charging ceiling. The app doesn't derive that limit from the serial or region at all - it reads `acChgRatedPower` from the INV heartbeat and only falls back to a fixed 1800 W when the device reports 0 (or a value at or below the lowest selectable speed). We already parse that field, so the device now supplies its own ceiling, which is what makes the 100 V regional variants correct without any prefix-specific code.

Full list of changes:

- **`DCJ` added to `Device.SN_PREFIX` in `delta_pro.py`.** The existing three-character prefix matching in `check()` covers it; no new matching logic.
- **`DCJ` added to `ECOFLOW_DEVICE_LIST`** alongside the other Delta Pro prefixes, so the name is right if the device is ever seen through the unsupported-device path.
- **`max_ac_charging_power` now reads `acChgRatedPower` from the INV heartbeat**, replacing the hardcoded 2900 W that was assigned in `__init__`. Same fallback as the app: 1800 W when the reported value is missing or at or below 200 W. On a 230 V unit this reports the same 2900 W as before, so nothing changes there.
- The number entity's lower bound is left alone. The app's picker starts at 200 W, but that is a separate question from the ceiling and the current behavior has not been reported as a problem.

Resolves #432

