### PR TITLE
Rebuild the frame assembler per auth routine so a reconnect stops decoding garbage

### DIFF
--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -39,6 +39,7 @@ from .exceptions import (
 )
 from .frame_assembler import (
     EncPacketAssembler,
+    FrameAssembler,
     PassthroughAssembler,
     RawHeaderAssembler,
     SimplePacketAssembler,
@@ -239,6 +240,7 @@ class Connection:
         self._encryption: EncryptionStrategy | None = None
         self._initial_session_key: bytes = b""
         self._simple_assembler = SimplePacketAssembler()
+        self._frame_assembler: FrameAssembler | None = None
         self._options = Connection.Options()
 
         self._errors = 0
@@ -801,7 +803,7 @@ class Connection:
         )
 
         frame_assembler = (
-            self._frame_assembler
+            self._get_frame_assembler()
             if self._connection_state.received_session_key
             else self._create_frame_assembler()
         )
@@ -905,7 +907,7 @@ class Connection:
         )
 
         frame_assembler = (
-            self._frame_assembler
+            self._get_frame_assembler()
             if self._connection_state.received_session_key
             else self._create_frame_assembler()
         )
@@ -940,6 +942,8 @@ class Connection:
         self._add_task(self.sendPacket(reply_packet))
 
     async def initBleSessionKey(self):
+        self._reset_assemblers()
+
         match self._encrypt_type:
             case 0:
                 await self._type_0_session()
@@ -947,6 +951,13 @@ class Connection:
                 await self._type_1_session()
             case _:
                 await self._ecdh_key_exchange()
+
+    def _reset_assemblers(self) -> None:
+        """Drop buffered frame data and rebuild assemblers for a fresh auth routine"""
+        self._simple_assembler = SimplePacketAssembler()
+        # Clear it so the next use rebuilds it against this attempt's encryption rather
+        # than reusing a previous attempt's session key.
+        self._frame_assembler = None
 
     async def _type_0_session(self):
         self._encryption = None
@@ -1217,9 +1228,10 @@ class Connection:
             case _:
                 raise ValueError(f"Unsupported encryption type: {self._encrypt_type}")
 
-    @cached_property
-    def _frame_assembler(self):
-        return self._create_frame_assembler()
+    def _get_frame_assembler(self) -> FrameAssembler:
+        if self._frame_assembler is None:
+            self._frame_assembler = self._create_frame_assembler()
+        return self._frame_assembler
 
     def _cancel_tasks(self):
         for task in self._tasks:

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -46,7 +46,7 @@ from .frame_assembler import (
 )
 from .listeners import ListenerGroup, ListenerRegistry
 from .logging_util import ConnectionLogger, LogOptions, caller_chain
-from .packet import Packet
+from .packet import InvalidPacket, Packet
 from .props.utils import classproperty
 
 MAX_RECONNECT_ATTEMPTS = 2
@@ -217,6 +217,11 @@ class Connection:
 
     _listeners = _ConnectionListeners.create()
 
+    # Consecutive undecodable frames tolerated before the session is treated as lost.
+    # A handful can follow a reconnect while stale notifications drain; a stream of them
+    # means the key no longer matches.
+    _UNDECRYPTABLE_FRAME_LIMIT = 10
+
     def __init__(
         self,
         ble_dev: BLEDevice,
@@ -244,6 +249,7 @@ class Connection:
         self._options = Connection.Options()
 
         self._errors = 0
+        self._undecryptable_frames = 0
         self._last_errors = deque(maxlen=10)
         self._disconnect_log: deque[dict[str, Any]] = deque(maxlen=10)
         self._client = None
@@ -371,13 +377,10 @@ class Connection:
 
             self._set_state(ConnectionState.ESTABLISHING_CONNECTION)
             self._logger.info("Connecting to device")
-            # Clear any ghost connection BlueZ is still holding for this
-            # device (e.g. left over from a bad disconnect); otherwise new
-            # connection attempts can be refused until the adapter is reset.
+            # Clear any ghost connection BlueZ is still holding for this device (e.g.
+            # left over from a bad disconnect); otherwise new connection attempts can be
+            # refused until the adapter is reset.
             await close_stale_connections_by_address(self.ble_dev().address)
-            # max_attempts=0 means unlimited at Connection level, but
-            # establish_connection needs a real retry count for BLE-level
-            # attempts (e.g. when adapter slots are contested).
             ble_attempts = max_attempts if max_attempts != 0 else MAX_CONNECT_ATTEMPTS
             self._client = await establish_connection(
                 BleakClient,
@@ -660,6 +663,25 @@ class Connection:
                 self._logger.warning("Client disconnected after encountering 5 errors")
                 await self._disconnect_client()
 
+    async def _handle_undecryptable_frame(self, packet: InvalidPacket):
+        # A frame that passes the outer CRC but not the parser decrypted to noise, so
+        # our key no longer matches the device's. Nothing re-derives it mid-session,
+        # which is why the link has to be dropped for the handshake to run again.
+        self._undecryptable_frames += 1
+        if self._undecryptable_frames < self._UNDECRYPTABLE_FRAME_LIMIT:
+            return
+
+        self._undecryptable_frames = 0
+        self._logger.warning(
+            "Session lost - %d consecutive frames could not be decoded (%s), "
+            "reconnecting to renegotiate the session key",
+            self._UNDECRYPTABLE_FRAME_LIMIT,
+            packet.error_message,
+        )
+        self._set_state(ConnectionState.ERROR_TOO_MANY_ERRORS)
+        if self._client is not None and self._client.is_connected:
+            await self._disconnect_client()
+
     def _reset_error_counter(self):
         self._errors = 0
 
@@ -828,7 +850,10 @@ class Connection:
                     "Parsed packet: %s",
                     packet,
                 )
-                if not Packet.is_invalid(packet):
+                if Packet.is_invalid(packet):
+                    await self._handle_undecryptable_frame(packet)
+                else:
+                    self._undecryptable_frames = 0
                     packets.append(packet)
             except Exception as e:  # noqa: BLE001
                 await self.add_error(e)
@@ -958,6 +983,7 @@ class Connection:
         # Clear it so the next use rebuilds it against this attempt's encryption rather
         # than reusing a previous attempt's session key.
         self._frame_assembler = None
+        self._undecryptable_frames = 0
 
     async def _type_0_session(self):
         self._encryption = None


### PR DESCRIPTION
This PR fixes devices that keep looking connected while every frame arrives as noise, filling the log with `prefix is incorrect` and `incorrect CRC16` until Home Assistant is restarted. The frame assembler was a `cached_property` that bound whichever encryption object existed at first access, but a reconnect reuses the same `Connection` and runs the auth routine again with a freshly negotiated session key - so the cached assembler went on decrypting with the previous key, and kept whatever partial frame it had buffered from the old session. Nothing re-derives the key mid-session, so once that happened the device never recovered on its own.

Full list of changes:

- **The assembler is rebuilt for each auth routine.** `_reset_assemblers()` runs at the start of the session-key init and drops both the buffered bytes and the assembler itself, so the next use binds the encryption that this attempt negotiated. The `cached_property` becomes an explicit `_get_frame_assembler()` so the lifetime is visible rather than implied.
- **A session that stops decoding drops its link instead of streaming forever.** After ten consecutive payloads that decrypt to something unparseable, one warning names the reason and the client is disconnected, which lets the existing reload re-run the handshake. The counter resets on any payload that does parse and at the start of each auth routine, so it only fires when nothing is getting through.
- Parse failures keep their existing error level. With the recovery in place the flood is bounded to roughly one burst per incident, so silencing them would only hide a genuinely malformed packet from a device we do not parse correctly yet.

Note that a corrupted frame from a poor radio link cannot trigger any of this: the assembler drops frames that fail CRC16 before they are ever decrypted, so what reaches the recovery path is a frame that arrived intact and still decrypted to noise, which is a key mismatch rather than interference.

Resolves #443
