### PR TITLE
Add P322 serial prefix for the Delta 3 Classic

### DIFF
--- a/custom_components/ef_ble/eflib/device_mappings.py
+++ b/custom_components/ef_ble/eflib/device_mappings.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 ADDON_BATTERY_MAP: dict[str, str] = {
     "Y712": "Delta Pro Ultra Battery",
-    "D3E1": "DELTA 3 Max Extra Battery",
+    "D3E1": "DELTA 3 Max Plus Extra Battery",
     "MR52": "DELTA Pro 3 Smart Extra Battery",
     "R361": "DELTA 2 Max Smart Extra Battery",
     "R341": "DELTA 2 Extra Battery",
@@ -62,14 +62,18 @@ def battery_name_from_sn(sn: str | None) -> str:
     if not sn:
         return "Extra Battery"
 
-    for serial_num in [sn[:4], sn[:3], sn[:2]]:
-        if name := ADDON_BATTERY_MAP.get(serial_num):
-            return name
+    if name := ADDON_BATTERY_MAP.get(sn[:4]):
+        return name
 
     # A connected "battery" may actually be a full supported device (e.g. a Delta Pro
-    # Ultra feeding a panel), so fall back to its real model name before the generic one.
+    # Ultra feeding a panel), so fall back to its real model name before the generic one,
+    # and before the 2-3 char battery prefixes: "P3" also matches the P32x Delta 3 Classic.
     if name := _supported_device_name(sn):
         return name
+
+    for serial_num in [sn[:3], sn[:2]]:
+        if name := ADDON_BATTERY_MAP.get(serial_num):
+            return name
 
     for serial_num in [sn[:4], sn[:3], sn[:2]]:
         if device := ECOFLOW_DEVICE_LIST.get(serial_num):
@@ -123,12 +127,13 @@ ECOFLOW_DEVICE_LIST = {
     "P231":{"name": "EcoFlow DELTA 3", "packets": "v3"},
     "D361":{"name": "EcoFlow DELTA 3 (1500)", "packets": "v2"},
     "D365":{"name": "EcoFlow DELTA 3 (1500)", "packets": "v2"},
+    "P32": {"name": "EcoFlow DELTA 3 Classic", "packets": "v3"},
     "P351":{"name": "EcoFlow DELTA 3 Plus", "packets": "v3"},
-    "D3N1":{"name": "EcoFlow DELTA 3 Classic", "packets": "v3"},
-    "D3M1":{"name": "EcoFlow DELTA 3 Max", "packets": "v3"},
-    "D3E1":{"name": "EcoFlow DELTA 3 Max Plus", "packets": "v3"},
-    "D3U1":{"name": "EcoFlow DELTA 3 Ultra", "packets": "v3"},
-    "D3UP":{"name": "EcoFlow DELTA 3 Ultra Plus", "packets": "v3"},
+    "D3N1":{"name": "EcoFlow DELTA 3 Max", "packets": "v3"},
+    "D3M1":{"name": "EcoFlow DELTA 3 Max Plus", "packets": "v3"},
+    "D3E1":{"name": "EcoFlow DELTA 3 Max Plus Extra Battery", "packets": "v3"},
+    "D751":{"name": "EcoFlow DELTA 3 Ultra", "packets": "v3"},
+    "D511":{"name": "EcoFlow DELTA 3 Ultra Plus", "packets": "v3"},
     "PR11":{"name": "EcoFlow DELTA 3 1000 Air", "packets": "v3"},
     "PR12":{"name": "EcoFlow DELTA 3 1000 Air (10ms UPS)", "packets": "v3"},
     "PR21":{"name": "EcoFlow DELTA 3 2000 Air", "packets": "v3"},

--- a/custom_components/ef_ble/eflib/devices/delta3_classic.py
+++ b/custom_components/ef_ble/eflib/devices/delta3_classic.py
@@ -9,7 +9,7 @@ from ._delta3_base import Delta3Base, pb
 class Device(Delta3Base):
     """Delta 3 Classic"""
 
-    SN_PREFIX = (b"P321",)
+    SN_PREFIX = (b"P321", b"P322")
     NAME_PREFIX = "EF-P3"
 
     energy_backup_battery_level = pb_field(pb.backup_reverse_soc)


### PR DESCRIPTION
This PR adds the `P322` serial prefix to the Delta 3 Classic device class, so units with that prefix are detected as a Delta 3 Classic instead of falling through to the unsupported-device fallback. The app's product catalog lists `P321` and `P322` under the same `product_ps_delta_delta_3_c` key and the same product name, so it is the same product speaking the same protocol - the reporter also patched the prefix locally and confirmed the device works on hardware, and replaying their capture through `delta3_classic` parses 99 of 100 packets with 39 populated fields.

While adding the matching `ECOFLOW_DEVICE_LIST` entry, several existing Delta 3 rows turned out not to match the app catalog, so they are corrected here too. That list is only consulted for devices that have no class of their own, where it supplies the displayed name and the packet version, and for naming attached extra batteries - so these are label and lookup corrections, not protocol changes. No proto changes were needed anywhere in this PR.

Full list of changes:

- **`P322` added to `Device.SN_PREFIX` in `delta3_classic.py`.** The existing four-character prefix matching covers it, and the Delta 3 base takes its display name from the class docstring, so no name-matching logic changes.
- **`P32` added to `ECOFLOW_DEVICE_LIST`.** The catalog uses the three-character key for this model and `P321`/`P322` are the only members, so one row covers the family; the list lookup already tries progressively shorter prefixes.
- **`D3N1` and `D3M1` names were shifted by one.** The catalog and our own device classes agree that `D3N1` is the DELTA 3 Max and `D3M1` the DELTA 3 Max Plus, while the list called them Classic and Max respectively.
- **`D3E1` is an extra battery, not a device.** It was listed as "DELTA 3 Max Plus"; both the catalog and `ADDON_BATTERY_MAP` describe it as the Max Plus extra battery, and the battery map's slightly different wording is aligned with the catalog.
- **`D3U1` and `D3UP` do not exist.** The Ultra and Ultra Plus prefixes are `D751` and `D511`, which is what `delta3_ultra.py` and `delta3_ultra_plus.py` already match on, so those two rows never matched a real serial.
- **A supported device now wins over the short extra-battery prefixes when naming an attached battery.** `ADDON_BATTERY_MAP` contains two- and three-character keys broad enough to swallow whole model families - `P3` is the RIVER Pro extra battery, but it also matches every `P32x` Delta 3 Classic. Four-character battery prefixes are still checked first, so no existing battery name changes.


Resolves #455
