### PR TITLE
Route every device packet through a connection-aware send helper

### DIFF
--- a/custom_components/ef_ble/eflib/commands.py
+++ b/custom_components/ef_ble/eflib/commands.py
@@ -30,7 +30,7 @@ class TimeCommands:
         payload = utcs.SerializeToString()
         packet = Packet(0x21, 0x0B, 0x01, 0x55, payload, 0x01, 0x01, 0x13)
 
-        await self.device._conn.sendPacket(packet)
+        await self.device.send_packet(packet)
 
     async def sendRTCRespond(self):
         """Send RTC timestamp seconds and TZ as respond to device's request"""
@@ -64,7 +64,7 @@ class TimeCommands:
             0x03,
         )
 
-        await self.device._conn.sendPacket(packet)
+        await self.device.send_packet(packet)
 
     async def sendRTCCheck(self):
         """Send command to check RTC of the device"""
@@ -98,7 +98,7 @@ class TimeCommands:
             0x03,
         )
 
-        await self.device._conn.sendPacket(packet)
+        await self.device.send_packet(packet)
 
     def async_send_all(self):
         now = time.monotonic()

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -33,6 +33,7 @@ from .exceptions import (
     FailedToAuthenticate,
     MaxConnectionAttemptsReached,
     MaxReconnectAttemptsReached,
+    NotConnectedError,
     PacketParseError,
     PacketReceiveError,
     UnsupportedBluetoothProtocol,
@@ -860,7 +861,9 @@ class Connection:
 
         return packets
 
-    async def sendRequest(self, send_data: bytes, response_handler=None):
+    async def sendRequest(
+        self, send_data: bytes, response_handler=None, *, raise_on_failure: bool = False
+    ):
         self._logger.log_filtered(LogOptions.CONNECTION_DEBUG, "Sending: %r", send_data)
         self._listeners.on_data_send(send_data)
 
@@ -868,8 +871,10 @@ class Connection:
         err = None
         for retry in range(4):
             try:
-                await self._sendRequest(send_data, response_handler)
-            except Exception as e:  # noqa: BLE001
+                await self._sendRequest(
+                    send_data, response_handler, raise_on_failure=raise_on_failure
+                )
+            except Exception as e:
                 if self._client is None or not self._client.is_connected:
                     # The BLE link dropped mid-request - e.g. BlueZ raising "Remote peer
                     # disconnected" synchronously from start_notify. bleak does not
@@ -880,6 +885,10 @@ class Connection:
                         "BLE link lost while sending request (%s); reconnecting", e
                     )
                     self.disconnected()
+                    if raise_on_failure:
+                        raise NotConnectedError(
+                            "BLE link lost while sending command"
+                        ) from e
                     return
                 self._logger.log_filtered(
                     LogOptions.CONNECTION_DEBUG,
@@ -900,6 +909,10 @@ class Connection:
                 return
 
         await self.add_error(err)
+        if raise_on_failure and err is not None:
+            # Retries exhausted while still nominally connected - the command never
+            # reached the device, so surface it instead of reporting success
+            raise err
 
     async def _start_notify(self, callback: Callable):
         kwargs = {}
@@ -907,9 +920,13 @@ class Connection:
             kwargs["bluez"] = {"use_start_notify": True}
         await self._client.start_notify(self._notify_characteristic, callback, **kwargs)
 
-    async def _sendRequest(self, send_data: bytes, response_handler=None):
+    async def _sendRequest(
+        self, send_data: bytes, response_handler=None, *, raise_on_failure: bool = False
+    ):
         # Make sure the connection is here, otherwise just skipping
         if self._client is None or not self._client.is_connected:
+            if raise_on_failure:
+                raise NotConnectedError("Cannot send command: device is not connected")
             self._logger.log_filtered(
                 LogOptions.CONNECTION_DEBUG,
                 "Skip sending: disconnected: %r",
@@ -925,7 +942,12 @@ class Connection:
         )
 
     async def sendPacket(
-        self, packet: Packet, response_handler=None, wait_for_response: bool = True
+        self,
+        packet: Packet,
+        response_handler=None,
+        wait_for_response: bool = True,
+        *,
+        raise_on_failure: bool = False,
     ):
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "Sending packet: %r", packet
@@ -940,11 +962,15 @@ class Connection:
         to_send = await frame_assembler.encode(packet)
 
         if frame_assembler.write_with_response and wait_for_response:
-            await self.sendRequest(to_send, response_handler)
+            await self.sendRequest(
+                to_send, response_handler, raise_on_failure=raise_on_failure
+            )
         elif self._client is not None and self._client.is_connected:
             await self._client.write_gatt_char(
                 self._write_characteristic, bytearray(to_send), response=False
             )
+        elif raise_on_failure:
+            raise NotConnectedError("Cannot send command: device is not connected")
 
     async def replyPacket(self, packet: Packet):
         """Copy and change the packet to be reply packet and sends it back to device"""

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -20,6 +20,7 @@ from .connection import (
     PacketParsedListener,
     PacketReceivedListener,
 )
+from .exceptions import NotConnectedError
 from .listeners import ListenerGroup, ListenerRegistry
 from .logging_util import (
     ConnectionLog,
@@ -81,7 +82,7 @@ class DeviceBase(abc.ABC):
             sn,
         )
 
-        self._conn: Connection = None
+        self._conn: Connection | None = None
         self._connection_event = asyncio.Event()
         self._callbacks = set()
         self._callbacks_map = {}
@@ -177,6 +178,47 @@ class DeviceBase(abc.ABC):
 
         self.on_connection_state_change(_register_timer_task)
 
+    async def send_packet(
+        self,
+        packet: Packet,
+        *,
+        wait_for_response: bool = True,
+        raise_on_failure: bool = False,
+    ) -> None:
+        """
+        Send `packet` to the device, tolerating a link that is down
+
+        `_conn` is `None` for the whole disconnect/reconnect window, so every send has
+        to cope with it. Background traffic (time sync, heartbeat polls, auto-replies)
+        is best-effort and silently dropped, which is the default here. A user-initiated
+        command must not be lost without notice, so those pass `raise_on_failure=True`:
+        `NotConnectedError` when there is no live link or it drops mid-send, and the
+        underlying `BleakError` when the write fails after retries, so a swallowed write
+        is never reported as success. A command whose write and response both completed
+        counts as delivered even if the link drops immediately afterwards.
+
+        Parameters
+        ----------
+        packet
+            Packet to deliver.
+        wait_for_response
+            Forwarded to `Connection.sendPacket`.
+        raise_on_failure
+            Raise instead of dropping the packet when it cannot be delivered.
+        """
+        conn = self._conn
+        if conn is None:
+            if raise_on_failure:
+                raise NotConnectedError(
+                    f"{self.name}: cannot send packet, device is not connected"
+                )
+            return
+        await conn.sendPacket(
+            packet,
+            wait_for_response=wait_for_response,
+            raise_on_failure=raise_on_failure,
+        )
+
     def call_later(
         self,
         delay: float,
@@ -200,6 +242,10 @@ class DeviceBase(abc.ABC):
             Optional deduplication key. When set, a new call with the same key cancels
             the previous one.
         """
+        # `_conn` is None during a disconnect/reconnect window; any pending callback
+        # would be cancelled on disconnect anyway, so there is nothing to schedule
+        if self._conn is None:
+            return
         self._conn.call_later(delay, callback, key)
 
     def with_update_period(self, period: int):

--- a/custom_components/ef_ble/eflib/devices/_delta2_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta2_base.py
@@ -176,7 +176,7 @@ class Delta2Base(DeviceBase, RawDataProps):
     @controls.switch(usb_ports)
     async def enable_usb_ports(self, enabled: bool):
         packet = Packet(0x21, 0x02, 0x20, 0x22, enabled.to_bytes(), version=0x02)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.switch(dc_12v_port)
     async def enable_dc_12v_port(self, enabled: bool):
@@ -188,13 +188,13 @@ class Delta2Base(DeviceBase, RawDataProps):
             enabled.to_bytes(),
             version=0x02,
         )
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.outlet(ac_ports)
     async def enable_ac_ports(self, enabled: bool):
         payload = bytes([1 if enabled else 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
         packet = Packet(0x21, self.ac_commands_dst, 0x20, 0x42, payload, version=0x02)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.battery(battery_charge_limit_max, min=dynamic(battery_charge_limit_min))
     async def set_battery_charge_limit_max(self, limit: float):
@@ -204,7 +204,7 @@ class Delta2Base(DeviceBase, RawDataProps):
         ):
             return False
         packet = Packet(0x21, 0x03, 0x20, 0x31, int(limit).to_bytes(), version=0x02)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     @controls.battery(battery_charge_limit_min, max=dynamic(battery_charge_limit_max))
@@ -215,7 +215,7 @@ class Delta2Base(DeviceBase, RawDataProps):
         ):
             return False
         packet = Packet(0x21, 0x03, 0x20, 0x33, int(limit).to_bytes(), version=0x02)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     def _update_extra_batteries(self, kit_data: AllKitDetailData):

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -164,7 +164,7 @@ class Delta3Base(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message: Message):
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.button(enabled=False)
     async def power_off(self) -> None:

--- a/custom_components/ef_ble/eflib/devices/alternator_charger.py
+++ b/custom_components/ef_ble/eflib/devices/alternator_charger.py
@@ -127,7 +127,7 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message: dc009_apl_comm_pb2.ConfigWrite):
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x14, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def enable_charger_open(self, enable: bool):
         await self._send_config_packet(

--- a/custom_components/ef_ble/eflib/devices/delta2.py
+++ b/custom_components/ef_ble/eflib/devices/delta2.py
@@ -77,13 +77,13 @@ class Device(Delta2Base):
         )
         payload = bytes([0x01 if enabled else 0, value, 0x00, 0x00])
         packet = Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.power(ac_charging_speed, min=1, max=dynamic(max_ac_charging_power))
     async def set_ac_charging_speed(self, value: float):
         payload = int(value).to_bytes(2, "little") + bytes([0xFF])
         packet = Packet(0x21, self.ac_commands_dst, 0x20, 0x45, payload, version=0x02)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     @controls.switch(disable_grid_bypass, enabled=False)
@@ -91,4 +91,4 @@ class Device(Delta2Base):
         packet = Packet(
             0x21, 0x02, 0x20, 0x60, bytes([1 if disabled else 0]), version=0x02
         )
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)

--- a/custom_components/ef_ble/eflib/devices/delta2_max.py
+++ b/custom_components/ef_ble/eflib/devices/delta2_max.py
@@ -67,14 +67,16 @@ class Device(Delta2Base):
             min(value, self.battery_charge_limit_max),
         )
         payload = bytes([0x01 if enabled else 0, value, 0x00, 0x00])
-        await self._conn.sendPacket(
-            Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02)
+        await self.send_packet(
+            Packet(0x21, 0x02, 0x20, 0x5E, payload, version=0x02),
+            raise_on_failure=True,
         )
 
     @controls.power(ac_charging_speed, min=1, max=dynamic(max_ac_charging_power))
     async def set_ac_charging_speed(self, value: float):
         payload = bytes([0xFF, 0xFF]) + int(value).to_bytes(2, "little") + bytes([0xFF])
-        await self._conn.sendPacket(
-            Packet(0x20, 0x04, 0x20, 0x45, payload, version=0x02)
+        await self.send_packet(
+            Packet(0x20, 0x04, 0x20, 0x45, payload, version=0x02),
+            raise_on_failure=True,
         )
         return True

--- a/custom_components/ef_ble/eflib/devices/delta_pro.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro.py
@@ -140,7 +140,7 @@ class Device(DeviceBase, RawDataProps):
 
                 if dormant:
                     # dormancy status
-                    await self._conn.sendPacket(
+                    await self.send_packet(
                         Packet(
                             src=0x21,
                             dst=0x32,
@@ -185,7 +185,7 @@ class Device(DeviceBase, RawDataProps):
         async with self._lock:
             self._wake_up_sent = True
 
-        await self._conn.sendPacket(
+        await self.send_packet(
             Packet(
                 src=0x21,
                 dst=0x03,
@@ -214,7 +214,7 @@ class Device(DeviceBase, RawDataProps):
         async with self._lock:
             self.index = (self.index + 1) % len(cmd_map)
 
-        await self._conn.sendPacket(
+        await self.send_packet(
             Packet(
                 src=src,
                 dst=dst,
@@ -252,8 +252,9 @@ class Device(DeviceBase, RawDataProps):
         return 0x07 if self._sn.startswith("R511") else 0x05
 
     async def _send_config_packet(self, dst: int, cmd_id: int, payload: bytes):
-        await self._conn.sendPacket(
-            Packet(0x21, dst, 0x20, cmd_id, payload, version=0x02)
+        await self.send_packet(
+            Packet(0x21, dst, 0x20, cmd_id, payload, version=0x02),
+            raise_on_failure=True,
         )
 
     async def enable_ac_ports(self, enabled: bool):
@@ -278,8 +279,9 @@ class Device(DeviceBase, RawDataProps):
             return False
         value = max(1, min(value, self.max_ac_charging_power))
         payload = bytes([0xFF, 0xFF]) + value.to_bytes(2, "little") + bytes([0xFF])
-        await self._conn.sendPacket(
-            Packet(0x20, 0x04, 0x20, 0x45, payload, version=0x02)
+        await self.send_packet(
+            Packet(0x20, 0x04, 0x20, 0x45, payload, version=0x02),
+            raise_on_failure=True,
         )
         return True
 

--- a/custom_components/ef_ble/eflib/devices/delta_pro_3.py
+++ b/custom_components/ef_ble/eflib/devices/delta_pro_3.py
@@ -163,7 +163,7 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message: Message):
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.battery(
         energy_backup_battery_level,

--- a/custom_components/ef_ble/eflib/devices/dpu.py
+++ b/custom_components/ef_ble/eflib/devices/dpu.py
@@ -378,11 +378,19 @@ class Device(DeviceBase, ProtobufProps):
 
         return processed
 
-    async def _send_command_packet(self, dst: int, cmd_func: int, cmd_id: int, message):
+    async def _send_module_command(
+        self,
+        dst: int,
+        cmd_func: int,
+        cmd_id: int,
+        message,
+        *,
+        raise_on_failure: bool = True,
+    ):
         payload = message.SerializeToString()
         p = Packet(0x21, dst, cmd_func, cmd_id, payload, 0x01, 0x01, 0x13)
 
-        await self._conn.sendPacket(p)
+        await self.send_packet(p, raise_on_failure=raise_on_failure)
 
     async def enable_wireless_4g(self, enable: bool):
         """Send command to enable/disable wireless 4G"""
@@ -391,7 +399,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_heartbeat.wireless_4g_on
         message = yj751_sys_pb2.Switch4GEnable(en_4G_open=int(enable))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x35, cmd_func=0x35, cmd_id=0x75, message=message
         )
         return True
@@ -404,7 +412,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_heartbeat.show_flag bit 1
         message = yj751_sys_pb2.DCSwitchSet(enable=int(enable))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x44, message=message
         )
 
@@ -420,7 +428,7 @@ class Device(DeviceBase, ProtobufProps):
 
         message = yj751_sys_pb2.ACDsgSet(enable=int(enable))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x48, message=message
         )
 
@@ -431,7 +439,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.ac_xboost
         message = yj751_sys_pb2.ACDsgSet(xboost=int(enable))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x48, message=message
         )
         return True
@@ -443,7 +451,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.bms_mode_set
         message = yj751_sys_pb2.BpHeatSet(en_bp_heat=int(enable))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x59, message=message
         )
         return True
@@ -463,7 +471,7 @@ class Device(DeviceBase, ProtobufProps):
             ac_often_open_min_soc=0,
         )
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x5D, message=message
         )
         return True
@@ -476,7 +484,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_display_property_upload.plug_in_info_pv_weak_source_flag
         message = yj751_sys_pb2.ConfigWrite(unlock_pv_weak=True)
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0xFE, cmd_id=0x11, message=message
         )
         return True
@@ -493,7 +501,7 @@ class Device(DeviceBase, ProtobufProps):
         cfg.operate_scheduled_open = mode == OperatingMode.SCHEDULED
         cfg.operate_tou_mode_open = mode == OperatingMode.TIME_OF_USE
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0xFE, cmd_id=0x11, message=message
         )
 
@@ -511,7 +519,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.chg_c20_set_watts
         message = yj751_sys_pb2.ACChgSet(chg_c20_watts=int(watts))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x49, message=message
         )
         return True
@@ -524,7 +532,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.chg_5p8_set_watts
         message = yj751_sys_pb2.ACChgSet(chg_5p8_watts=int(watts))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x49, message=message
         )
         return True
@@ -537,7 +545,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.dsg_min_soc
         message = yj751_sys_pb2.DsgSocMinSet(min_dsg_soc=int(soc))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x58, message=message
         )
         return True
@@ -550,7 +558,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.chg_max_soc
         message = yj751_sys_pb2.ChgSocMaxSet(max_chg_soc=int(soc))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x57, message=message
         )
         return True
@@ -563,7 +571,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.sys_backup_soc
         message = yj751_sys_pb2.ConfigWrite(cfg_backup_reverse_soc=int(soc))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0xFE, cmd_id=0x11, message=message
         )
         return True
@@ -577,7 +585,7 @@ class Device(DeviceBase, ProtobufProps):
             power_standby_min=_bracket(0, minutes, 1440)
         )
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x51, message=message
         )
         return True
@@ -591,7 +599,7 @@ class Device(DeviceBase, ProtobufProps):
             screen_standby_sec=_bracket(0, seconds, 1800)
         )
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x52, message=message
         )
         return True
@@ -603,7 +611,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.dc_standby_mins
         message = yj751_sys_pb2.DCStandbySet(dc_standby_min=_bracket(0, minutes, 1440))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x54, message=message
         )
         return True
@@ -615,7 +623,7 @@ class Device(DeviceBase, ProtobufProps):
         # Current value from pb_app_para_heartbeat.ac_standby_mins
         message = yj751_sys_pb2.ACStandbySet(ac_standby_min=_bracket(0, minutes, 1440))
 
-        await self._send_command_packet(
+        await self._send_module_command(
             dst=0x02, cmd_func=0x02, cmd_id=0x53, message=message
         )
         return True
@@ -627,7 +635,11 @@ class Device(DeviceBase, ProtobufProps):
 
         message = yj751_sys_pb2.SystemParamGet(get_param_type=param_type)
 
-        await self._send_command_packet(
-            dst=0x02, cmd_func=0x02, cmd_id=0x67, message=message
+        await self._send_module_command(
+            dst=0x02,
+            cmd_func=0x02,
+            cmd_id=0x67,
+            message=message,
+            raise_on_failure=False,
         )
         return True

--- a/custom_components/ef_ble/eflib/devices/dpu_x.py
+++ b/custom_components/ef_ble/eflib/devices/dpu_x.py
@@ -194,4 +194,4 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message: pd100_pb2.ConfigWrite):
         payload = message.SerializeToString()
         packet = Packet(0x21, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)

--- a/custom_components/ef_ble/eflib/devices/powerstream.py
+++ b/custom_components/ef_ble/eflib/devices/powerstream.py
@@ -101,6 +101,7 @@ class Device(DeviceBase, ProtobufProps):
                     await self._send_ble_packet(
                         wn511_sys_pb2.inv_power_pack_ack(sys_seq=msg.sys_seq),
                         cmd_id=0x88,
+                        raise_on_failure=False,
                     )
             case _:
                 return False
@@ -115,11 +116,16 @@ class Device(DeviceBase, ProtobufProps):
         return True
 
     async def _send_ble_packet(
-        self, message: Message, cmd_id: int, dst: int = _DST_INVERTER
+        self,
+        message: Message,
+        cmd_id: int,
+        dst: int = _DST_INVERTER,
+        *,
+        raise_on_failure: bool = True,
     ) -> None:
         payload = message.SerializeToString()
         packet = Packet(0x21, dst, 0x14, cmd_id, payload, version=0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=raise_on_failure)
 
     @controls.power(load_power, max=dynamic(load_power_max), step=0.1)
     async def set_load_power(self, watts: float) -> bool:

--- a/custom_components/ef_ble/eflib/devices/river2.py
+++ b/custom_components/ef_ble/eflib/devices/river2.py
@@ -146,23 +146,23 @@ class Device(DeviceBase, RawDataProps):
     async def enable_ac_ports(self, enabled: bool):
         payload = bytes([1 if enabled else 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
         packet = Packet(0x21, 0x05, 0x20, 0x42, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.switch(dc_12v_port)
     async def enable_dc_12v_port(self, enabled: bool):
         payload = bytes([0x01 if enabled else 0x00])
         packet = Packet(0x21, 0x05, 0x20, 0x51, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def enable_ac_xboost(self, enabled: bool):
         payload = bytes([0xFF, 0x01 if enabled else 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
         packet = Packet(0x21, 0x05, 0x20, 0x42, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def enable_ac_always_on(self, enabled: bool):
         payload = bytes([0x01 if enabled else 0x00, 0x05])
         packet = Packet(0x21, 0x02, 0x20, 0x5F, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.switch(energy_backup)
     async def enable_energy_backup(self, enabled: bool):
@@ -175,7 +175,7 @@ class Device(DeviceBase, RawDataProps):
 
         payload = bytes([0x01 if enabled else 0x00, reserve, 0x00, 0x00])
         packet = Packet(0x21, 0x02, 0x20, 0x5E, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.battery(
         energy_backup_battery_level,
@@ -187,7 +187,7 @@ class Device(DeviceBase, RawDataProps):
         percent = max(0, min(int(value), 100))
         payload = bytes([0x01, percent, 0x00, 0x00])
         packet = Packet(0x21, 0x02, 0x20, 0x5E, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     @controls.battery(battery_charge_limit_min, max=dynamic(battery_charge_limit_max))
@@ -200,7 +200,7 @@ class Device(DeviceBase, RawDataProps):
             return False
 
         packet = Packet(0x21, 0x03, 0x20, 0x33, limit.to_bytes(), version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     @controls.battery(battery_charge_limit_max, min=dynamic(battery_charge_limit_min))
@@ -213,20 +213,20 @@ class Device(DeviceBase, RawDataProps):
             return False
 
         packet = Packet(0x21, 0x03, 0x20, 0x31, limit.to_bytes(), version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     @controls.current(dc_charging_max_amps, max=dynamic(dc_charging_current_max))
     async def set_dc_charging_amps_max(self, value: float) -> bool:
         payload = (int(value) * 1000).to_bytes(4, "little")
         packet = Packet(0x21, 0x05, 0x20, 0x47, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True
 
     @controls.select(dc_mode, options=DCMode)
     async def set_dc_mode(self, value: DCMode):
         packet = Packet(0x21, 0x05, 0x20, 0x52, value.to_bytes(), version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.power(
         ac_charging_speed,
@@ -236,5 +236,5 @@ class Device(DeviceBase, RawDataProps):
     async def set_ac_charging_speed(self, value: float) -> bool:
         payload = int(value).to_bytes(2, "little") + b"\xff"
         packet = Packet(0x21, 0x05, 0x20, 0x45, payload, version=2)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
         return True

--- a/custom_components/ef_ble/eflib/devices/river3.py
+++ b/custom_components/ef_ble/eflib/devices/river3.py
@@ -180,7 +180,7 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message):
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.button(enabled=False)
     async def power_off(self) -> None:

--- a/custom_components/ef_ble/eflib/devices/shp2.py
+++ b/custom_components/ef_ble/eflib/devices/shp2.py
@@ -275,7 +275,7 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message):
         payload = message.SerializeToString()
         packet = Packet(0x21, 0x0B, 0x0C, 0x21, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def set_config_flag(self, enable):
         """Send command to enable/disable sending config data from device to the host"""

--- a/custom_components/ef_ble/eflib/devices/shp3.py
+++ b/custom_components/ef_ble/eflib/devices/shp3.py
@@ -371,7 +371,7 @@ class Device(DeviceBase, ProtobufProps):
             ddst=0x01,
             version=0x03,
         )
-        await self._conn.sendPacket(packet, wait_for_response=False)
+        await self.send_packet(packet, wait_for_response=False)
 
     async def packet_parse(self, data: bytes):
         return Packet.from_bytes(data, xor_payload=True)
@@ -543,7 +543,7 @@ class Device(DeviceBase, ProtobufProps):
 
     async def _send_config_packet(self, message: Message):
         packet = self._routing.write_packet(message.SerializeToString())
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def _write_energy_strategy(
         self, mode: OperatingMode | None, eps_enable: bool

--- a/custom_components/ef_ble/eflib/devices/smart_generator.py
+++ b/custom_components/ef_ble/eflib/devices/smart_generator.py
@@ -150,7 +150,7 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message: ge305_sys_pb2.ConfigWrite):
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x08, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def enable_ac_port(self, enabled: bool):
         await self._send_config_packet(

--- a/custom_components/ef_ble/eflib/devices/smart_meter.py
+++ b/custom_components/ef_ble/eflib/devices/smart_meter.py
@@ -82,4 +82,4 @@ class Device(DeviceBase, ProtobufProps):
         payload = message.SerializeToString()
         message.cfg_utc_time = round(time.time())
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)

--- a/custom_components/ef_ble/eflib/devices/smart_meter.py
+++ b/custom_components/ef_ble/eflib/devices/smart_meter.py
@@ -79,7 +79,7 @@ class Device(DeviceBase, ProtobufProps):
         return processed
 
     async def _send_config_packet(self, message: bk622_common_pb2.ConfigWrite):
-        payload = message.SerializeToString()
         message.cfg_utc_time = round(time.time())
+        payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self.send_packet(packet, raise_on_failure=True)

--- a/custom_components/ef_ble/eflib/devices/stream_ac.py
+++ b/custom_components/ef_ble/eflib/devices/stream_ac.py
@@ -271,7 +271,7 @@ class Device(DeviceBase, ProtobufProps):
         message.cfg_utc_time = round(time.time())
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @controls.battery(
         battery_charge_limit_max,
@@ -400,7 +400,8 @@ class Device(DeviceBase, ProtobufProps):
             if target is None or self._all_timer_tasks is None:
                 return False
 
-            chain.pending_mods.append((target.task_index, modify))
+            pending_mod = (target.task_index, modify)
+            chain.pending_mods.append(pending_mod)
 
             config = bk_series_pb2.ConfigWrite()
 
@@ -412,7 +413,15 @@ class Device(DeviceBase, ProtobufProps):
                     if task.task_index == mod_idx:
                         mod_fn(new_task)
 
-            await self._send_config_packet(config)
+            sent = False
+            try:
+                await self._send_config_packet(config)
+                sent = True
+            finally:
+                # If the send failed the mod never reached the device, so drop it;
+                # otherwise it would be silently re-applied on the next successful edit
+                if not sent:
+                    chain.pending_mods.remove(pending_mod)
 
             # Clear pending mods after the device has had time to process and send back
             # updated state

--- a/custom_components/ef_ble/eflib/devices/stream_microinverter.py
+++ b/custom_components/ef_ble/eflib/devices/stream_microinverter.py
@@ -65,8 +65,8 @@ class Device(DeviceBase, ProtobufProps):
         return processed
 
     async def _send_config_packet(self, message: bk_series_pb2.ConfigWrite):
-        payload = message.SerializeToString()
         message.cfg_utc_time = round(time.time())
+        payload = message.SerializeToString()
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
         await self.send_packet(packet, raise_on_failure=True)
 

--- a/custom_components/ef_ble/eflib/devices/stream_microinverter.py
+++ b/custom_components/ef_ble/eflib/devices/stream_microinverter.py
@@ -68,7 +68,7 @@ class Device(DeviceBase, ProtobufProps):
         payload = message.SerializeToString()
         message.cfg_utc_time = round(time.time())
         packet = Packet(0x20, 0x02, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def set_inverter_target_power(self, power: int):
         if power < 0:

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -158,7 +158,7 @@ class Device(DeviceBase, RawDataProps):
             version=self.packet_version,
         )
 
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     @computed_field
     def _climate_main_mode(self) -> MainMode | None:

--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -171,7 +171,7 @@ class Device(DeviceBase, ProtobufProps):
     async def _send_config_packet(self, message: ac517_apl_comm_pb2.ConfigWrite):
         payload = message.SerializeToString()
         packet = Packet(0x20, 0x42, 0xFE, 0x11, payload, 0x01, 0x01, 0x13)
-        await self._conn.sendPacket(packet)
+        await self.send_packet(packet, raise_on_failure=True)
 
     async def set_battery_charge_limit_min(self, limit: int):
         if (

--- a/custom_components/ef_ble/eflib/exceptions.py
+++ b/custom_components/ef_ble/eflib/exceptions.py
@@ -10,6 +10,10 @@ class PacketReceiveError(Exception):
     """Error during receiving packet"""
 
 
+class NotConnectedError(Exception):
+    """Raised when a command cannot be delivered because the BLE link is unavailable"""
+
+
 class FailedToAuthenticate(Exception):
     """Failed to connect"""
 


### PR DESCRIPTION
This PR stops writes issued during a BLE reconnect from raising `AttributeError: 'NoneType' object has no attribute ...` and takes the whole automation run down with them. `DeviceBase.disconnect()` sets `self._conn = None` as a sentinel for `observe_connection()`, so for the length of the disconnect window every send and every scheduled callback dereferences `None`. The connection layer already skipped sends on a dead link gracefully, so the crash was purely the nulled reference, not a deeper problem in the send path. No proto changes were needed.

The fix is a single `DeviceBase.send_packet()` that every packet now goes through, plus a `raise_on_failure` flag that decides what a caller wants when delivery is impossible. Background traffic keeps its existing best-effort behavior and is dropped silently; a user-initiated command raises `NotConnectedError` instead of being swallowed and reported as success, so an automation sees a clear failure rather than a write that quietly never happened.

Full list of changes:

- **`send_packet()` is now the only way a device sends anything.** It returns early when the link is gone, or raises when the caller passed `raise_on_failure=True`. There are no remaining direct `_conn.sendPacket` call sites in the library, which is what removes the crash rather than patching the paths it was reported from.
- **`raise_on_failure` is threaded through `Connection.sendPacket` / `sendRequest` / `_sendRequest`**, defaulting to `False` so every existing send behaves exactly as before. It raises in three places: no live client at send time, the link dropping mid-request, and retries being exhausted while still nominally connected. A command whose write and response both completed counts as delivered even if the link drops immediately afterwards.
- **`call_later()` is a no-op while disconnected.** This is the crash site users actually hit, since a config write commonly schedules a timer immediately after it completes. Pending callbacks are cancelled on disconnect anyway, so there is nothing to schedule.
- **All 47 send sites were ported:** 38 user-initiated commands across 18 device modules ask to fail loudly, while time sync, heartbeat polls, dormancy and wake-up traffic, protocol acks and SHP3 user-id registration stay best-effort.
- **Helpers that serve both roles take the flag.** `powerstream._send_ble_packet` and the DPU module-command helper default to raising, and their background callers (the power-pack ack and the heartbeat-info poll) opt out explicitly.
- **STREAM timer-task edits no longer keep a mod that was never delivered.** The pending modification is now removed again when the send fails, instead of being silently re-applied on the next successful edit.
- **DPU's private `_send_command_packet` was renamed to `_send_module_command`**, since sitting one underscore away from the new base method invited misreading at every call site.
- A separate commit fixes `smart_meter` and `stream_microinverter` stamping `cfg_utc_time` *after* serializing the message, so the timestamp never reached the wire.

Addresses #448, #405
