### PR TITLE
Derive the repeated protobuf field registry from each device's own fields

### DIFF
--- a/custom_components/ef_ble/eflib/props/protobuf_props.py
+++ b/custom_components/ef_ble/eflib/props/protobuf_props.py
@@ -45,18 +45,20 @@ class ProtobufProps(UpdatableProps):
 
     """
 
-    _repeated_field_map: dict[type[Message], dict[str, list[ProtobufRepeatedField]]] = (
-        defaultdict(lambda: defaultdict(list))
-    )
     _proto_listeners = _Listeners.create()
 
-    @classmethod
-    def add_repeated_field(cls, repeated_field: ProtobufRepeatedField):
-        updated_field_map = cls._repeated_field_map.copy()
-        updated_field_map[repeated_field.pb_field.message_type][
-            repeated_field.pb_field.name
-        ].append(repeated_field)
-        cls._repeated_field_map = updated_field_map
+    @cached_property
+    def _repeated_field_map(
+        self,
+    ) -> dict[type[Message], dict[str, list[ProtobufRepeatedField]]]:
+        field_map: dict[type[Message], dict[str, list[ProtobufRepeatedField]]]
+        field_map = defaultdict(lambda: defaultdict(list))
+        for field in self._fields:
+            if isinstance(field, ProtobufRepeatedField):
+                field_map[field.pb_field.message_type][field.pb_field.name].append(
+                    field
+                )
+        return field_map
 
     @cached_property
     def message_to_field(self) -> dict[type[Message], list[ProtobufField]]:

--- a/custom_components/ef_ble/eflib/props/repeated_protobuf_field.py
+++ b/custom_components/ef_ble/eflib/props/repeated_protobuf_field.py
@@ -62,10 +62,6 @@ class ProtobufRepeatedField[T_ITEM, T_OUT](ProtobufField[T_OUT]):
     def get_item(self, value: Sequence[T_ITEM]) -> T_OUT | None:
         """Process item from sequence returned from `get_list`"""
 
-    def __set_name__(self, owner: type["ProtobufProps"], name: str):
-        super().__set_name__(owner, name)
-        owner.add_repeated_field(self)
-
     def __set__(self, instance: "ProtobufProps", value: Sequence[Any]):
         if (item := self.get_item(value)) is None:
             return


### PR DESCRIPTION
This PR stops repeated protobuf fields declared on one device from being parsed by unrelated devices in the same family, which surfaces as phantom sensors whose state is an empty list and which HA rejects with `non-numeric value: '[]'`. The registry of repeated fields was a class attribute maintained by copy-on-write from `__set_name__`, and `dict.copy()` duplicates only the outer dict - the inner `defaultdict(list)` objects stayed shared with the base class and every sibling, so appending a field mutated a list the whole family reads from. Rebinding the outer dict afterwards hid it, because the top-level dict really is per class. No proto changes were needed.

Rather than deep-copying more carefully, the registry is no longer stored at all. It is derived from `_fields`, which `Field.__set_name__` already rebuilds per class, so there is no shared mutable state left to corrupt and no separate registration step that can disagree with what a device declares.

Full list of changes:

- **`_repeated_field_map` is now a `cached_property` derived from the device's own fields**, mirroring the `message_to_field` property directly below it, which had always done this correctly for non-repeated fields - the repeated case was the odd one out.
- **`add_repeated_field` and the `ProtobufRepeatedField.__set_name__` override are removed.** With the map derived on demand there is nothing to register, and the removal is what makes the leak unrepresentable rather than merely fixed.
- **Field overrides keep working without special handling.** `_fields` already replaces an inherited entry with the same `public_name`, so a subclass that redeclares a repeated field no longer needs the registry to filter its parent's copy.
- **The attribute is now instance-scoped.** It was documented private and is read only inside `update_from_message`; reading it off the class returns the descriptor rather than a dict, so any out-of-tree caller of the old class attribute or of `add_repeated_field` fails immediately instead of silently.
- **In practice only the Delta 3 family was affected**, eight classes of it. The leak needs sibling classes to declare *different* repeated fields against the *same* protobuf message, which is only true there; other families either declare the same fields throughout the chain or key a different message type, so their registries were correct by luck rather than by design.
- **No behavior change for correctly declared devices.** Every protobuf device now registers exactly the repeated fields it declares, verified across all of them, and the owning devices still parse their own fields as before.

The affected sensors only appear when a message carrying the leaked field is processed before the sensor platform enumerates the device, which is why it showed up on some cold starts and not on reloads. Entities already created by the old behavior stay in the registry and need deleting in Settings -> Entities; this only stops new ones appearing.

Resolves #457
