### PR TITLE
Record every session key in diagnostics so older captures stay readable

### DIFF
--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -195,6 +195,7 @@ type PacketReceivedListener = Callable[[bytes], None]
 type PacketParsedListener = Callable[[Packet], None]
 type DataReceivedListener = Callable[[bytes, ConnectionState], None]
 type DataSendListener = Callable[[bytes], None]
+type SessionKeyDerivedListener = Callable[[bytes, bytes], None]
 
 
 class _ConnectionListeners(ListenerRegistry):
@@ -204,6 +205,7 @@ class _ConnectionListeners(ListenerRegistry):
     on_packet_parsed: ListenerGroup[PacketParsedListener]
     on_data_received: ListenerGroup[DataReceivedListener]
     on_data_send: ListenerGroup[DataSendListener]
+    on_session_key_derived: ListenerGroup[SessionKeyDerivedListener]
 
 
 class Connection:
@@ -319,6 +321,9 @@ class Connection:
 
     def on_data_send(self, listener: DataSendListener):
         return self._listeners.on_data_send.add(listener)
+
+    def on_session_key_derived(self, listener: SessionKeyDerivedListener):
+        return self._listeners.on_session_key_derived.add(listener)
 
     def _notify_disconnect(self, exception: Exception | type[Exception] | None = None):
         if exception is None:
@@ -1012,7 +1017,7 @@ class Connection:
         self._undecryptable_frames = 0
 
     async def _type_0_session(self):
-        self._encryption = None
+        self._use_encryption(None)
 
         await self._start_notify(self.listenForDataHandler)
 
@@ -1022,7 +1027,7 @@ class Connection:
     async def _type_1_session(self):
         session_key = hashlib.md5(self._dev_sn.encode()).digest()
         iv = hashlib.md5(self._dev_sn[::-1].encode()).digest()
-        self._encryption = Type1Encryption(session_key, iv)
+        self._use_encryption(Type1Encryption(session_key, iv))
 
         await self._start_notify(self.listenForDataHandler)
 
@@ -1077,7 +1082,7 @@ class Connection:
         # Set Initialization Vector from digest of the original shared key
         iv = hashlib.md5(shared_key).digest()
 
-        self._encryption = Type7Encryption(shared_key[:16], iv)
+        self._use_encryption(Type7Encryption(shared_key[:16], iv))
 
         await self.getKeyInfoReq()
 
@@ -1117,7 +1122,7 @@ class Connection:
         # Parse the data that contains sRand (first 16 bytes) & seed (last 2 bytes)
         session_key = await self.genSessionKey(data[16:18], data[:16])
         self._initial_session_key = self._encryption.session_key
-        self._encryption = Type7Encryption(session_key, self._encryption.iv)
+        self._use_encryption(Type7Encryption(session_key, self._encryption.iv))
 
         await self.getAuthStatus()
 
@@ -1268,6 +1273,13 @@ class Connection:
                 self._logger.log_filtered(
                     LogOptions.CONNECTION_DEBUG, "listenForDataHandler: %r", packet
                 )
+
+    def _use_encryption(self, encryption: EncryptionStrategy | None) -> None:
+        self._encryption = encryption
+        if encryption is not None:
+            self._listeners.on_session_key_derived(
+                encryption.session_key, encryption.iv
+            )
 
     def _create_frame_assembler(self):
         match self._encrypt_type:

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -19,6 +19,7 @@ from .connection import (
     DisconnectListener,
     PacketParsedListener,
     PacketReceivedListener,
+    SessionKeyDerivedListener,
 )
 from .exceptions import NotConnectedError
 from .listeners import ListenerGroup, ListenerRegistry
@@ -46,6 +47,7 @@ class _Listeners(ListenerRegistry):
     on_packet_parsed: ListenerGroup[PacketParsedListener]
     on_data_received: ListenerGroup[DataReceivedListener]
     on_data_send: ListenerGroup[DataSendListener]
+    on_session_key_derived: ListenerGroup[SessionKeyDerivedListener]
 
 
 class DeviceBase(abc.ABC):
@@ -341,6 +343,7 @@ class DeviceBase(abc.ABC):
             self._conn.on_state_change(self._append_state_to_log)
             self._conn.on_data_received(self._listeners.on_data_received)
             self._conn.on_data_send(self._listeners.on_data_send)
+            self._conn.on_session_key_derived(self._listeners.on_session_key_derived)
 
         elif self._conn._user_id != user_id:
             self._conn._user_id = user_id
@@ -432,6 +435,9 @@ class DeviceBase(abc.ABC):
 
     def on_data_send(self, listener: DataSendListener):
         return self._listeners.on_data_send.add(listener)
+
+    def on_session_key_derived(self, listener: SessionKeyDerivedListener):
+        return self._listeners.on_session_key_derived.add(listener)
 
     def on_connection_state_change(
         self, connection_state_listener: ConnectionStateListener

--- a/custom_components/ef_ble/eflib/logging_util.py
+++ b/custom_components/ef_ble/eflib/logging_util.py
@@ -275,6 +275,7 @@ class DeviceDiagnostics:
     iv: bytes
     session_key: bytes
     initial_session_key: bytes
+    session_keys: list[tuple[float, bytes, bytes]]
 
     def _encode_bytes(self, value: bytes, session: Session | None) -> str:
         if session is not None:
@@ -300,6 +301,10 @@ class DeviceDiagnostics:
             iv=self._encode_bytes(self.iv, session),
             session_key=self._encode_bytes(self.session_key, session),
             initial_session_key=self._encode_bytes(self.initial_session_key, session),
+            session_keys=[
+                (t, self._encode_bytes(key, session), self._encode_bytes(iv, session))
+                for (t, key, iv) in self.session_keys
+            ],
         )
 
     def as_dict(self):
@@ -322,6 +327,8 @@ class DeviceDiagnosticsCollector:
         self._raw_data_connection: list[tuple[float, bytes]] = []
         self._raw_data_messages: deque[tuple[float, bytes]] = deque(maxlen=1000)
         self._raw_data_send: deque[tuple[float, bytes]] = deque(maxlen=1000)
+
+        self._session_keys: deque[tuple[float, bytes, bytes]] = deque(maxlen=10)
 
         self._disconnect_times: deque[float] = deque(maxlen=buffer_size)
         self._skip_first_messages: int = 8
@@ -372,6 +379,9 @@ class DeviceDiagnosticsCollector:
             raw_data_connection=self._raw_data_connection,
             raw_data_messages=list(self._raw_data_messages),
             raw_data_send=list(self._raw_data_send),
+            session_keys=[
+                (t - self._start_time, key, iv) for (t, key, iv) in self._session_keys
+            ],
             iv=encryption.iv if encryption is not None else b"",
             session_key=encryption.session_key if encryption is not None else b"",
             initial_session_key=conn._initial_session_key,
@@ -410,8 +420,10 @@ class DeviceDiagnosticsCollector:
                     self._device.on_packet_parsed(self._on_packet_parsed),
                     self._device.on_data_received(self._on_data_received),
                     self._device.on_data_send(self._on_data_send),
+                    self._device.on_session_key_derived(self._on_session_key_derived),
                 ]
             )
+            self._record_current_session_key()
             return self
 
         return self
@@ -575,7 +587,17 @@ class DeviceDiagnosticsCollector:
 
         task.add_done_callback(_log_result)
 
+    def _on_session_key_derived(self, session_key: bytes, iv: bytes) -> None:
+        self._session_keys.append((time.time(), session_key, iv))
+
+    def _record_current_session_key(self) -> None:
+        conn = self._device._conn
+        encryption = None if conn is None else conn._encryption
+        if encryption is not None:
+            self._on_session_key_derived(encryption.session_key, encryption.iv)
+
     def _clear_buffers(self):
+        self._session_keys.clear()
         self._last_packets.clear()
         self._last_errors.clear()
         self._connect_times.clear()


### PR DESCRIPTION
This PR records the session keys of recent connections in diagnostics, so that the packets already in the buffer stay decodable after a reconnect. A dump carries the last few hundred raw frames but only the key in use when it was taken, and a device that reconnects negotiates a fresh key: everything captured before that point decrypts to noise, which is exactly the part of a capture worth reading when the reported problem is a reconnect. The keys are recorded by the diagnostics collector, which lives on the device and therefore outlives any single connection, and they are encrypted with the same per-dump session as the existing key fields, so nothing new is exposed.

Full list of changes:

- **Every encryption change goes through one `_use_encryption()` helper**, which sets `_encryption` and emits `on_session_key_derived`. All four assignment sites use it - the type-1 derived key, the ECDH shared key, the negotiated type-7 session key, and the type-0 case, which emits nothing because there is no key.
- **The history is kept by `DeviceDiagnosticsCollector`, not by `Connection`.** A device-level reconnect builds a new `Connection` while the collector and its packet buffers stay, so keys held on the connection would be discarded exactly when the frames they decode are not. Keys and buffers now share one owner, one lifetime and one clearing point.
- **The history is capped at the ten most recent keys**, which comfortably outlives the packet buffers it exists to decode, and is cleared with them when collection is toggled.
- **The ECDH shared key is recorded too, not just the negotiated session key.** The handshake frames of a session are encrypted with the shared key, so without it the beginning of every reconnected session stays unreadable even though the rest decodes.
- **Diagnostics gain a `session_keys` list**, each entry encrypted exactly like the existing `session_key` and `iv` fields, with timestamps relative to the start of collection so they line up with the packet timestamps already in the dump.
- **Switching collection on records the key already in use**, rather than waiting for the next handshake. Collection is normally enabled after a problem appears, and the session being captured authenticated long before that, so without this the newest frames in the buffer - the ones the user just reproduced - would have no key at all.
- The history only appears in a dump when packet collection is enabled, since that is what puts frames in the buffer in the first place.

Both a BLE-level retry and a device-level reconnect now add their keys to the same history, so a dump taken after several reconnects can still be read from the first frame in the buffer. Reloading the config entry rebuilds the device, which clears the buffers and the keys together, so a dump never contains frames whose key is missing.
