### PR TITLE
Add ac_in_flow sensor for Delta 3 devices as a working AC-input signal

### DIFF
--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -124,6 +124,7 @@ def shp2_channel(
 _BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "error_happened": problem("error", entity_category=EntityCategory.DIAGNOSTIC),
     "plugged_in_ac": plug(),
+    "ac_in_flow": plug(),
     "fan_running": _make_desc(
         BinarySensorDeviceClass.RUNNING,
         enabled=False,

--- a/custom_components/ef_ble/eflib/devices/_delta3_base.py
+++ b/custom_components/ef_ble/eflib/devices/_delta3_base.py
@@ -81,6 +81,7 @@ class Delta3Base(DeviceBase, ProtobufProps):
     usba2_output_power = pb_field(pb.pow_get_qcusb2, out_power)
 
     plugged_in_ac = pb_field(pb.plug_in_info_ac_charger_flag)
+    ac_in_flow = pb_field(pb.flow_info_ac_in, flow_is_on)
     battery_input_power = pb_field(pb.pow_get_bms, lambda value: max(0, value))
     battery_output_power = pb_field(pb.pow_get_bms, lambda value: -min(0, value))
 

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -340,6 +340,9 @@
       "plugged_in_ac": {
         "name": "AC Plugged In"
       },
+      "ac_in_flow": {
+        "name": "AC Input Flowing"
+      },
       "fan_running": {
         "name": "Fan Running"
       },


### PR DESCRIPTION
## Summary

`plugged_in_ac` (mapped to `plug_in_info_ac_charger_flag`) never reflects whether mains power is actually present on the built-in AC inlet. That field sits alongside `plug_in_info_pv_charger_flag`, `plug_in_info_dcp_charger_flag` and `plug_in_info_dcp2_charger_flag` — it's a per-accessory "is this specific pluggable charging module connected" flag, not a general AC-input indicator. On a unit using the standard AC inlet (no swappable AC charger accessory), it simply never gets set, and the entity sits on "unknown" indefinitely even while AC power is flowing normally and other fields (`ac_input_power`, `battery_level`) keep updating fine from the same `DisplayPropertyUpload` packet.

`flow_info_ac_in` is the input-side counterpart to `flow_info_ac_out`, which is already used for the `ac_ports` (AC output on/off) sensor via the `flow_is_on` transform. This adds a new `ac_in_flow` sensor using the identical pattern for AC input, giving a reliable boolean for "is AC actually flowing in" — useful for anyone using one of these as backup/UPS power and wanting to detect a mains outage.

Verified on a Delta 3 Max by physically pulling and restoring mains power: the sensor flipped `off` within ~6s of disconnection and back `on` within ~3s of reconnection, both confirmed against `ac_input_power` dropping to/recovering from 0W in the same window.

Cross-checked field numbers and semantics against the official EcoFlow app (decompiled `com.ecoflow.energyStorageModule.proto.Pd335Sys`, same `pd335_sys` protobuf module this integration uses): `flow_info_ac_in` = field 47, `flow_info_ac_out` = field 367, `plug_in_info_ac_charger_flag` = field 202. The app's own detail-screen logic for "is AC input connected" reads `flowInfoAcIn` (OR'd with raw input power > 0 as a belt-and-braces check) — not `plugInInfoAcChargerFlag`, which the app only ever surfaces as a separate pass-through field, never as a general connectivity signal. This matches the fix here.

Scoped to `Delta3Base` only, since that's what I could test. `delta_pro_3.py`, `river3.py` and `dpu_x.py` share the identical `plugged_in_ac` mapping and would likely benefit from the same addition, but I don't have that hardware to verify against.

## Note on scope

This adds a new sensor rather than fixing `plugged_in_ac` in place. `plugged_in_ac`/`plug_in_info_ac_charger_flag` appears to be a per-accessory "is a specific swappable AC-charger module connected" flag rather than a general AC-input indicator — on hardware using the standard built-in AC inlet (no charger accessory), it never gets set and the entity sits on "unknown" indefinitely, even while AC power is flowing normally. I didn't want to repoint `plugged_in_ac` at `flow_info_ac_in` directly in case there's a device configuration where the accessory-flag field does report something meaningful and other users depend on its current behavior — that's a call for @rabits to make, not something to guess at. Happy to fold `ac_in_flow` into `plugged_in_ac` instead, or deprecate the old field, if that's preferred.

## Test plan

- [x] `python3 -m py_compile` on both changed `.py` files
- [x] `python3 -m json.tool` on the changed `en.json`
- [x] Live-verified on Delta 3 Max hardware by pulling/restoring mains power
- [x] Field semantics cross-checked against the official EcoFlow Android app's decompiled protobuf/UI logic
