### PR TITLE
Add connected and disconnected device triggers with a connection event and state sensor

### DIFF
--- a/custom_components/ef_ble/__init__.py
+++ b/custom_components/ef_ble/__init__.py
@@ -57,6 +57,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SELECT,
     Platform.CLIMATE,
+    Platform.EVENT,
 ]
 
 type DeviceConfigEntry = ConfigEntry[eflib.DeviceBase]

--- a/custom_components/ef_ble/device_trigger.py
+++ b/custom_components/ef_ble/device_trigger.py
@@ -1,0 +1,127 @@
+"""Device triggers for the EcoFlow BLE connection event."""
+
+import voluptuous as vol
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.components.event import ATTR_EVENT_TYPE
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+from .event import CONNECTION_EVENT_TYPES, is_connection_event
+
+TRIGGER_TYPES = CONNECTION_EVENT_TYPES
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List `connected`/`disconnected` triggers for the device's connection event"""
+    registry = er.async_get(hass)
+    triggers: list[dict[str, str]] = []
+    for entry in er.async_entries_for_device(registry, device_id):
+        # A disabled entity has no state to watch, so a trigger built on it would sit
+        # there doing nothing; leave it out of the list instead of offering a dud.
+        if entry.disabled_by is not None or not is_connection_event(entry):
+            continue
+        triggers.extend(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.id,
+                CONF_TYPE: trigger_type,
+            }
+            for trigger_type in TRIGGER_TYPES
+        )
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """
+    Fire when the connection event of the configured type is emitted
+
+    Watches the event entity's state - a timestamp that advances on every emission -
+    rather than its `event_type` attribute, so two emissions of the same type in a row
+    each fire. Matching on the attribute alone would miss the second one, since the
+    attribute would not have changed.
+    """
+    registry = er.async_get(hass)
+    entity_id = er.async_resolve_entity_id(registry, config[CONF_ENTITY_ID])
+    entry = registry.async_get(entity_id) if entity_id is not None else None
+    if entity_id is None or entry is None:
+        raise InvalidDeviceAutomationConfig(
+            f"Connection event entity {config[CONF_ENTITY_ID]} no longer exists"
+        )
+    if entry.disabled_by is not None:
+        # Attaching would succeed and then never fire, leaving the automation looking
+        # healthy; failing here puts the reason in front of whoever disabled it.
+        raise InvalidDeviceAutomationConfig(
+            f"Connection event entity {entity_id} is disabled, so it cannot trigger"
+        )
+
+    event_type = config[CONF_TYPE]
+    job = HassJob(action, f"ef_ble device trigger {entity_id} {event_type}")
+
+    @callback
+    def _handle_state_change(event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        old_state = event.data["old_state"]
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return
+        if new_state.attributes.get(ATTR_EVENT_TYPE) != event_type:
+            return
+        if old_state is not None and old_state.state == new_state.state:
+            return
+
+        hass.async_run_hass_job(
+            job,
+            {
+                "trigger": {
+                    **trigger_info["trigger_data"],
+                    CONF_PLATFORM: "device",
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_DEVICE_ID: config[CONF_DEVICE_ID],
+                    CONF_ENTITY_ID: entity_id,
+                    CONF_TYPE: event_type,
+                    "description": f"{event_type} event on {entity_id}",
+                }
+            },
+            new_state.context,
+        )
+
+    return async_track_state_change_event(hass, [entity_id], _handle_state_change)

--- a/custom_components/ef_ble/event.py
+++ b/custom_components/ef_ble/event.py
@@ -1,0 +1,103 @@
+"""EcoFlow BLE connection event"""
+
+from homeassistant.components.event import ATTR_EVENT_TYPES, EventEntity
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import DeviceConfigEntry
+from .eflib import DeviceBase
+from .eflib.connection import ConnectionState
+from .entity import EcoflowEntity
+
+EVENT_CONNECTED = "connected"
+EVENT_DISCONNECTED = "disconnected"
+CONNECTION_EVENT_TYPES = (EVENT_CONNECTED, EVENT_DISCONNECTED)
+
+
+def is_connection_event(entry: er.RegistryEntry) -> bool:
+    """
+    Whether a registry entry is a connection event entity of ours
+
+    Matched on the event types the entity registered rather than on its id: an event
+    entity that can fire all of `CONNECTION_EVENT_TYPES` is the one a connection trigger
+    needs, whatever it ends up being called.
+    """
+    if entry.domain != EVENT_DOMAIN:
+        return False
+    event_types = (entry.capabilities or {}).get(ATTR_EVENT_TYPES) or ()
+    return set(CONNECTION_EVENT_TYPES).issubset(event_types)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: DeviceConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add the connection event entity for the config entry"""
+    async_add_entities([EcoflowConnectionEvent(config_entry.runtime_data)])
+
+
+class EcoflowConnectionEvent(EcoflowEntity, EventEntity):
+    """
+    Fires when the device connection is (re-)established or lost
+
+    Fires on the edges of `authenticated` only, so a reconnect that never reaches a
+    terminal state - `AUTHENTICATED` -> `RECONNECTING` -> `AUTHENTICATED`, which is what
+    an automatic reconnect looks like - still produces `disconnected` followed by
+    `connected`. Being added does not fire anything: an entry reload or a Home Assistant
+    restart is not a reconnect, and an automation waiting for one should not run then.
+    """
+
+    _attr_translation_key = "connection"
+    _attr_event_types = list(CONNECTION_EVENT_TYPES)
+
+    def __init__(self, device: DeviceBase) -> None:
+        super().__init__(device)
+        self._attr_unique_id = f"ef_{self._device.serial_number}_connection"
+        self._remove_listener = None
+        self._was_connected: bool | None = None
+
+    @property
+    def available(self) -> bool:
+        """Keep the event available so its last-fired value survives a reconnect."""
+        return True
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        # A reconnect recreates this entity, so the edge that matters can straddle two
+        # instances: seed from the last event this entity fired, not from the live state.
+        # Restored `disconnected` means the link dropped while we were gone, so becoming
+        # authenticated now is a real reconnect and fires; restored `connected` means a
+        # restart or reload of a healthy link and stays quiet.
+        restored = await self.async_get_last_event_data()
+        self._was_connected = (
+            restored is not None and restored.last_event_type == EVENT_CONNECTED
+        )
+        self._remove_listener = self._device.on_connection_state_change(
+            self._on_connection_state_change
+        )
+        state = self._device.connection_state
+        if state is not None:
+            self._on_connection_state_change(state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._remove_listener is not None:
+            self._remove_listener()
+            self._remove_listener = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _on_connection_state_change(self, state: ConnectionState) -> None:
+        # Every state that is not `authenticated` counts as disconnected, including the
+        # intermediate ones a reconnect passes through; only the transition fires.
+        is_connected = state.authenticated
+        if is_connected == self._was_connected:
+            return
+        self._was_connected = is_connected
+        self._fire(EVENT_CONNECTED if is_connected else EVENT_DISCONNECTED)
+
+    def _fire(self, event_type: str) -> None:
+        self._trigger_event(event_type)
+        self.async_write_ha_state()

--- a/custom_components/ef_ble/icons.json
+++ b/custom_components/ef_ble/icons.json
@@ -43,7 +43,15 @@
         }
       }
     },
+    "event": {
+      "connection": {
+        "default": "mdi:bluetooth-connect"
+      }
+    },
     "sensor": {
+      "connection_state": {
+        "default": "mdi:bluetooth"
+      },
       "input_power": {
         "default": "mdi:home-lightning-bolt-outline"
       },

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -24,13 +24,14 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import DeviceConfigEntry
 from .const import CONF_EXTRA_BATTERY, DOMAIN
 from .eflib import DeviceBase
+from .eflib.connection import ConnectionState
 from .eflib.device_mappings import extra_battery_indices
 from .eflib.devices import (
     _delta3_base,
@@ -963,6 +964,8 @@ async def async_setup_entry(
     if new_sensors:
         async_add_entities(new_sensors)
 
+    async_add_entities([EcoflowConnectionStateSensor(device)])
+
     if battery_entities := _get_extra_battery_entities(
         hass=hass, device=device, conf=config_entry.data.get(CONF_EXTRA_BATTERY)
     ):
@@ -1121,3 +1124,56 @@ class EcoflowBatteryAddonSensor(EcoflowBatteryAddonEntity, SensorEntity):
             for field_name in self._attribute_fields
             if hasattr(self._device, field_name)
         }
+
+
+def _connection_status(state: ConnectionState | None) -> str:
+    """Collapse the fine-grained connection state into a small diagnostic status."""
+    match state:
+        case None:
+            return "disconnected"
+        case state if state.authenticated:
+            return "connected"
+        case state if state.is_error:
+            return "error"
+        case state if state.is_connecting:
+            return "connecting"
+        case _:
+            return "disconnected"
+
+
+class EcoflowConnectionStateSensor(EcoflowEntity, SensorEntity):
+    """Diagnostic sensor reflecting the device's BLE connection state."""
+
+    _attr_translation_key = "connection_state"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_options = ["connected", "connecting", "disconnected", "error"]
+
+    def __init__(self, device: DeviceBase) -> None:
+        super().__init__(device)
+        self._attr_unique_id = f"ef_{device.serial_number}_connection_state"
+        self._remove_listener = None
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def native_value(self) -> str:
+        return _connection_status(self._device.connection_state)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._remove_listener = self._device.on_connection_state_change(
+            self._on_connection_state_change
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._remove_listener is not None:
+            self._remove_listener()
+            self._remove_listener = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _on_connection_state_change(self, state: ConnectionState) -> None:
+        self.async_write_ha_state()

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -297,6 +297,12 @@
       "description": "Failed to connect to {device_name} after {attempts} unsuccessful attempts. Check the logs for more info.\n\nAutomatic retry was disabled to not spam logs, integration has to be reloaded manually. This error clears after successful connection."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "connected": "{entity_name} connected",
+      "disconnected": "{entity_name} disconnected"
+    }
+  },
   "entity": {
     "button": {
       "power_off": {
@@ -386,7 +392,28 @@
         "name": "LV Solar Voltage Low"
       }
     },
+    "event": {
+      "connection": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "connected": "Connected",
+              "disconnected": "Disconnected"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
+      "connection_state": {
+        "name": "Connection state",
+        "state": {
+          "connected": "Connected",
+          "connecting": "Connecting",
+          "disconnected": "Disconnected",
+          "error": "Error"
+        }
+      },
       "collecting_data": {
         "name": "Collecting diagnostics data"
       },

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -297,6 +297,12 @@
       "description": "Не вдалося підключитися до {device_name} після {attempts} невдалих спроб. Перевірте журнали для отримання додаткової інформації.\n\nАвтоматичне повторення було вимкнено, щоб не засмічувати журнали, інтеграцію потрібно перезавантажити вручну. Ця помилка зникає після успішного підключення."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "connected": "{entity_name} підключено",
+      "disconnected": "{entity_name} відключено"
+    }
+  },
   "entity": {
     "button": {
       "unpause_solar": {
@@ -381,6 +387,18 @@
       },
       "lv_solar_low_voltage": {
         "name": "Низька напруга сонячної енергії (LV)"
+      }
+    },
+    "event": {
+      "connection": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "connected": "Підключено",
+              "disconnected": "Відключено"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -966,6 +984,15 @@
           "battery": "Акумулятор",
           "oil": "Розумний генератор",
           "station_charger": "Зарядна станція"
+        }
+      },
+      "connection_state": {
+        "name": "Стан підключення",
+        "state": {
+          "connected": "Підключено",
+          "connecting": "Підключення",
+          "disconnected": "Відключено",
+          "error": "Помилка"
         }
       }
     },

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -297,6 +297,12 @@
       "description": "{attempts} 次尝试后仍无法连接到 {device_name}。请查看日志了解更多信息。\n\n为避免日志 spam，自动重试已被禁用，需要手动重新加载集成。成功连接后此错误会清除。"
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "connected": "{entity_name} 已连接",
+      "disconnected": "{entity_name} 已断开"
+    }
+  },
   "entity": {
     "button": {
       "unpause_solar": {
@@ -381,6 +387,18 @@
       },
       "lv_solar_low_voltage": {
         "name": "低压太阳能电压低"
+      }
+    },
+    "event": {
+      "connection": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "connected": "已连接",
+              "disconnected": "已断开"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -966,6 +984,15 @@
           "battery": "电池",
           "oil": "智能发电机",
           "station_charger": "充电桩"
+        }
+      },
+      "connection_state": {
+        "name": "连接状态",
+        "state": {
+          "connected": "已连接",
+          "connecting": "连接中",
+          "disconnected": "已断开",
+          "error": "错误"
         }
       }
     },


### PR DESCRIPTION
This PR gives automations something to hang off when a device's BLE link comes and goes: an event entity that fires `connected` / `disconnected`, a diagnostic sensor showing the current connection status, and device triggers so both show up in the automation editor as "connected" / "disconnected" on the device rather than as a state trigger someone has to hand-write. Until now the only signal was entity availability, which tells an automation that a device went away but not that it came back, and nothing at all while the entry is retrying. Everything comes from the connection state the integration already tracks.

Full list of changes:

- **The event entity fires on the edges of `authenticated`, not on every state change.** Every state that is not `authenticated` counts as disconnected, including the intermediate ones, so an automatic reconnect (`AUTHENTICATED` -> `RECONNECTING` -> `AUTHENTICATED`) produces `disconnected` followed by `connected` instead of nothing.
- **Being added does not fire anything, but a reconnect across two instances still does.** A dropped link reloads the config entry, which destroys and recreates the entity, so the edge that matters can straddle two instances. The entity seeds itself from the last event it fired (`async_get_last_event_data`) rather than from the live state: a restored `disconnected` plus a currently authenticated device is a real reconnect and fires, while a restored `connected` - an entry reload or a Home Assistant restart of a healthy link - stays quiet.
- **Device triggers resolve the event entity by the event types it registered**, not by its id: the trigger looks for an event entity whose `event_types` capability covers both types, so renaming the entity or changing the unique-id scheme cannot break the lookup.
- **The trigger watches the entity's state, not its `event_type` attribute.** An event entity's state is a timestamp that advances on every emission, so two emissions of the same type in a row each fire; matching `to: <type>` on the attribute would have missed the second one because the attribute would not have changed.
- **A disabled entity fails loudly instead of silently.** Disabled entities are left out of the trigger list, and attaching to one (or to an entity that no longer exists) raises `InvalidDeviceAutomationConfig` rather than returning a no-op unsubscribe that leaves the automation looking healthy while never firing.
