### PR TITLE
Make the Wave 2 climate entity's temperature unit follow the device's display unit

### DIFF
--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -178,6 +178,7 @@ class Device(DeviceBase, RawDataProps):
             "high": FanGear.HIGH,
         },
         current_temperature_field=ambient_temperature,
+        temperature_unit=dynamic(temp_unit),
     )
 
     @_climate.power(power)

--- a/tests/eflib/test_wave2.py
+++ b/tests/eflib/test_wave2.py
@@ -11,6 +11,7 @@ from custom_components.ef_ble.eflib.devices.wave2 import (
     SubMode,
     WaterLevel,
 )
+from custom_components.ef_ble.eflib.entity.base import DynamicValue
 
 PACKETS = {
     "fan_celsius_target_30": "aa026c00bc2de6b30200012d42214250e4e5f8e45a3990a7e6ece6e7e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e4e7e7e7e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e66d8b9fa7e6e6e4e6e6e6e7e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e671a6",
@@ -126,6 +127,32 @@ async def test_temperature_unit_and_limits_follow_device_temp_sys(
     assert device.target_temperature_min == expected_min
     assert device.target_temperature_max == expected_max
     assert device.target_temperature == expected_temp
+
+
+@pytest.mark.parametrize(
+    ("packet_name", "expected_unit"),
+    [
+        ("heat_celsius_target_30", units.Temperature.C),
+        ("fan_fahrenheit_target_60", units.Temperature.F),
+    ],
+)
+async def test_climate_temperature_unit_follows_device_temp_sys(
+    device, packet_name, expected_unit
+):
+    """
+    The climate entity's own declared unit must track `temp_unit`, not stay fixed at
+    the framework default - otherwise HA labels values that are already in the
+    device's active unit (see the ambient_temperature check above) as if they were
+    always Celsius, which is "way off" whenever the device is actually in Fahrenheit.
+    """
+    dynamic_unit = Device._climate.temperature_unit
+    assert isinstance(dynamic_unit, DynamicValue), (
+        "climate.temperature_unit must be dynamic(temp_unit), not a fixed default"
+    )
+
+    await _process(device, PACKETS[packet_name])
+
+    assert dynamic_unit.resolve(device) is expected_unit
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The Wave 2's climate entity temperature reads correctly only when the physical unit's LCD is set to Celsius - switching the device to Fahrenheit makes the reported temperature "way off."

`wave2.py` already detects the device's active display unit (`temp_unit`, derived from `temp_sys`) and already uses it for the target-temperature step/min/max via `unit=dynamic(temp_unit)` on both `@_climate.target_temp(...)` and `@controls.temperature(...)`. But the `controls.climate(...)` call itself never passed `temperature_unit=`, so the climate entity's own declared unit stayed hardcoded at the framework default of Celsius regardless of what the device is actually reporting.

A captured Fahrenheit heartbeat in the existing test suite confirms the device already reports `ambient_temperature`/`target_temperature` pre-converted into whichever unit its LCD is showing (`63.62` decodes as a plausible room temperature in °F, not °C) - so no additional F↔C conversion math is needed, only telling the entity which unit that already-correct value is in.

`ClimateBuilder.temperature_unit()` already supports a dynamic field/`DynamicValue` and already converts it via `unit_to_hassunit()` - this capability just wasn't wired up for any device yet.

## Fix

Add `temperature_unit=dynamic(temp_unit)` to the existing `controls.climate(...)` call in `wave2.py`, reusing the same `dynamic(...)` helper already used elsewhere in the file.

## Test plan
- [x] `ruff format --check` / `ruff check` clean
- [x] `pytest tests -q` - 156 passed
- [x] New test asserting the climate control's `temperature_unit` is a `DynamicValue` wrapping `temp_unit` (not the fixed default) and resolves to the correct unit against both a Celsius and a Fahrenheit captured heartbeat
- [ ] Confirmed against real Wave 2 hardware with the LCD set to Fahrenheit

🤖 Generated with [Claude Code](https://claude.com/claude-code)