### PR TITLE
Gate Wave 2 controls on power state and withhold select options the device rejects

### DIFF
--- a/custom_components/ef_ble/binary_sensor.py
+++ b/custom_components/ef_ble/binary_sensor.py
@@ -124,6 +124,8 @@ def shp2_channel(
 _BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "error_happened": problem("error", entity_category=EntityCategory.DIAGNOSTIC),
     "plugged_in_ac": plug(),
+    "battery_connected": connectivity(),
+    "solar_connected": connectivity(),
     "fan_running": _make_desc(
         BinarySensorDeviceClass.RUNNING,
         enabled=False,

--- a/custom_components/ef_ble/eflib/devices/wave2.py
+++ b/custom_components/ef_ble/eflib/devices/wave2.py
@@ -8,7 +8,7 @@ from ..props import computed_field
 from ..props.enums import IntFieldValue
 from ..props.raw_data_field import dataclass_attr_mapper, raw_field
 from ..props.raw_data_props import RawDataProps
-from ..props.transforms import pround
+from ..props.transforms import prop_has_bit_on, pround
 
 pb = dataclass_attr_mapper(KT210SAC)
 
@@ -123,12 +123,16 @@ class Device(DeviceBase, RawDataProps):
             return DrainMode.EXTERNAL
         return DrainMode.from_wte(self.wte_fth_en)
 
-    # power_src looks like a bitmask, observations:
-    # bit 0 - battery
-    # bits 1-2 - optional internal power sources?
-    # Bits 3, 5–7 - unused
-    # bit 4 - AC mains
-    # power_src = raw_field(pb.power_src)
+    # power_src is a bitmask, read off a unit reporting 1 on mains alone, 16 on battery
+    # alone, 17 on mains and battery, and 18 on battery and solar:
+    # bit 0 - AC mains
+    # bit 1 - solar
+    # bit 2 - grouped with mains and solar in the app, set in none of those readings
+    # bit 4 - battery
+    # bits 3, 5-7 - unused
+    plugged_in_ac = raw_field(pb.power_src, prop_has_bit_on(0))
+    solar_connected = raw_field(pb.power_src, prop_has_bit_on(1))
+    battery_connected = raw_field(pb.power_src, prop_has_bit_on(4))
 
     @classmethod
     def check(cls, sn):
@@ -184,11 +188,11 @@ class Device(DeviceBase, RawDataProps):
     async def enable_power(self, enabled: bool):
         await self.set_power_mode(PowerMode.ON if enabled else PowerMode.STANDBY)
 
-    @controls.switch(ambient_light)
+    @controls.switch(ambient_light, availability=power)
     async def enable_ambient_light(self, enabled: bool):
         await self._send_config_packet(0x5C, (0x01 if enabled else 0x02).to_bytes())
 
-    @controls.switch(automatic_drain)
+    @controls.switch(automatic_drain, availability=power)
     async def enable_automatic_drain(self, enabled: bool):
         preference = (self.wte_fth_en or 0) & 1
         if not enabled:
@@ -201,7 +205,18 @@ class Device(DeviceBase, RawDataProps):
             payload = preference
         await self._send_config_packet(0x59, payload.to_bytes())
 
-    @controls.select(drain_mode, options=DrainMode)
+    @controls.select(
+        drain_mode,
+        # The unit can only drain itself while cooling, so outside Cool the app offers
+        # the external hose alone
+        options=(
+            controls.option_set(DrainMode).exclude_if(
+                dynamic(main_mode, lambda mode: mode in (MainMode.WARM, MainMode.FAN)),
+                DrainMode.DRAIN_FREE,
+            )
+        ),
+        availability=power,
+    )
     async def set_drain_mode(self, mode: DrainMode):
         main_mode = self.main_mode
         if main_mode is MainMode.WARM or main_mode is MainMode.FAN:
@@ -218,16 +233,26 @@ class Device(DeviceBase, RawDataProps):
         fan_speed,
         modes={HvacMode.COOL, HvacMode.HEAT, HvacMode.FAN_ONLY},
     )
-    @controls.select(fan_speed, options=FanGear)
+    @controls.select(fan_speed, options=FanGear, availability=power)
     async def set_fan_speed(self, fan_gear: FanGear):
         await self._send_config_packet(0x5E, fan_gear.to_bytes())
 
     @_climate.mode()
-    @controls.select(main_mode, options=MainMode)
+    @controls.select(main_mode, options=MainMode, availability=power)
     async def set_main_mode(self, mode: MainMode):
         await self._send_config_packet(0x51, mode.to_bytes())
 
-    @controls.select(power_mode, options=PowerMode, exclude=[PowerMode.INIT])
+    @controls.select(
+        power_mode,
+        # On mains the firmware turns a power-off into standby, so offering Off there
+        # only ever looks broken. The app draws the same line, asking to confirm a
+        # power-off on battery alone and sending it without asking otherwise
+        options=(
+            controls.option_set(PowerMode)
+            .exclude(PowerMode.INIT)
+            .exclude_if(plugged_in_ac, PowerMode.OFF)
+        ),
+    )
     async def set_power_mode(self, mode: PowerMode):
         await self._send_config_packet(0x5B, mode.to_bytes())
 
@@ -244,11 +269,12 @@ class Device(DeviceBase, RawDataProps):
         min=dynamic(target_temperature_min),
         max=dynamic(target_temperature_max),
         unit=dynamic(temp_unit),
+        availability=power,
     )
     async def set_temperature(self, temperature: float):
         await self._send_config_packet(0x58, int(temperature).to_bytes())
         return True
 
-    @controls.select(sub_mode, options=SubMode)
+    @controls.select(sub_mode, options=SubMode, availability=power)
     async def set_sub_mode(self, sub_mode: SubMode):
         await self._send_config_packet(0x52, sub_mode.to_bytes())

--- a/custom_components/ef_ble/eflib/entity/base.py
+++ b/custom_components/ef_ble/eflib/entity/base.py
@@ -47,8 +47,12 @@ class DynamicValue[F, T]:
     field: "updatable_props.Field[F]"
     transform: Callable[[F], T] | None = None
 
+    @property
+    def prop_name(self) -> str:
+        return self.field.public_name  # pyright: ignore[reportAttributeAccessIssue]
+
     def resolve(self, instance) -> T | None:
-        raw = getattr(instance, self.field.public_name, None)
+        raw = getattr(instance, self.prop_name, None)
         if raw is None:
             return None
         return self.transform(raw) if self.transform is not None else raw  # type: ignore[return-value]

--- a/custom_components/ef_ble/eflib/entity/controls.py
+++ b/custom_components/ef_ble/eflib/entity/controls.py
@@ -27,7 +27,7 @@ class HvacMode(enum.StrEnum):
 
 def _resolve(value: float | DynamicValue | None, device: "DeviceBase") -> float | None:
     if isinstance(value, DynamicValue):
-        raw = getattr(device, value.field.public_name, None)  # pyright: ignore[reportAttributeAccessIssue]
+        raw = getattr(device, value.prop_name, None)
         if raw is None:
             return None
         return value.transform(raw) if value.transform is not None else float(raw)
@@ -172,32 +172,84 @@ class weight(NumberType):
     pass
 
 
+@dataclasses.dataclass
+class option_set[E: IntFieldValue]:
+    """
+    The options a select offers, and the ones it withholds
+
+    `exclude` drops a member for good, for an internal state that is never a choice.
+    `exclude_if` drops one only while a device field says so, which keeps the rest of
+    the select usable where hiding the whole entity would not
+    """
+
+    options: type[E]
+    excluded: list[E] = dataclasses.field(default_factory=list, init=False)
+    conditional: list[tuple[DynamicValue, list[E]]] = dataclasses.field(
+        default_factory=list, init=False
+    )
+
+    def exclude(self, *options: E) -> "option_set[E]":
+        self.excluded.extend(options)
+        return self
+
+    def exclude_if(
+        self, condition: "Field[Any] | bool", *options: E
+    ) -> "option_set[E]":
+        """
+        Withhold `options` while `condition` holds
+
+        `condition` is a boolean field, or a `dynamic(field, transform)` reading one -
+        which is annotated as the value it resolves to, the same way a number's `min`
+        takes one
+        """
+        if isinstance(condition, Field):
+            condition = cast("Any", DynamicValue(condition))
+        if not isinstance(condition, DynamicValue):
+            raise TypeError(
+                f"{condition!r} is not a field to read the condition from - pass the "
+                "field itself, or dynamic(field, transform)"
+            )
+        self.conditional.append((condition, list(options)))
+        return self
+
+
 class select[E: IntFieldValue](ControlType):
     type SetFunc = Callable[[DeviceBase, E], Awaitable[None]]
 
-    options: type[E] | list[str]
-    exclude: list[E] = dataclasses.field(default_factory=list, kw_only=True)
+    options: "type[E] | option_set[E] | list[str]"
     set_value_func: SetFunc = dataclasses.field(
         repr=False,
         init=False,
     )
 
     def __post_init__(self) -> None:
-        if isinstance(self.options, list):
+        options = self.options
+        excluded: list[E] = []
+        self._conditional: list[tuple[DynamicValue, list[E]]] = []
+        if isinstance(options, option_set):
+            self._conditional = options.conditional
+            excluded = options.excluded
+            options = options.options
+
+        if isinstance(options, list):
             self._value_type: type[E] | None = None
+            self._options_str = options
         else:
-            self._value_type = self.options
-            self.options = self.options.options(
-                include_unknown=False, exclude=self.exclude
-            )
+            self._value_type = options
+            self._options_str = options.options(include_unknown=False, exclude=excluded)
+        self.options = self._options_str
 
     @property
     def options_str(self) -> list[str]:
-        return (
-            self.options
-            if isinstance(self.options, list)
-            else self.options.options(include_unknown=False)
-        )
+        return self._options_str
+
+    @property
+    def conditional_options(self) -> list[tuple[DynamicValue, list[str]]]:
+        """Each condition, with the options to withhold while it holds"""
+        return [
+            (condition, [option.name.lower() for option in options])
+            for condition, options in self._conditional
+        ]
 
     def __call__[D: "DeviceBase"](
         self,

--- a/custom_components/ef_ble/select.py
+++ b/custom_components/ef_ble/select.py
@@ -1,6 +1,6 @@
 import dataclasses
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, Self
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant, callback
@@ -10,6 +10,7 @@ from . import DeviceConfigEntry
 from .deprecated.selects import SELECT_TYPES
 from .description_builder import EntityDescriptionBuilder
 from .eflib import DeviceBase, controls, get_controls
+from .eflib.entity import DynamicValue
 from .entity import EcoflowEntity
 
 
@@ -17,6 +18,7 @@ from .entity import EcoflowEntity
 class EcoflowSelectEntityDescription[T: DeviceBase](SelectEntityDescription):
     set_state: Callable[[T, str], Awaitable] | None = None
     availability_prop: str | None = None
+    conditional_options: tuple[tuple[DynamicValue, list[str]], ...] = ()
 
 
 class SelectSensorBuilder(EntityDescriptionBuilder):
@@ -24,9 +26,16 @@ class SelectSensorBuilder(EntityDescriptionBuilder):
         self._options = None
         self._async_set_native_value = None
         self._availability_prop = None
+        self._conditional_options = ()
 
     def options(self, options: list[str]):
         self._options = options
+        return self
+
+    def conditional_options(
+        self, conditional: list[tuple[DynamicValue, list[str]]]
+    ) -> Self:
+        self._conditional_options = tuple(conditional)
         return self
 
     def async_set_native_value(
@@ -50,6 +59,7 @@ class SelectSensorBuilder(EntityDescriptionBuilder):
             translation_key=self._entity_translation_key,
             entity_registry_enabled_default=self._entity_registry_enabled_default,
             availability_prop=self._availability_prop,
+            conditional_options=self._conditional_options,
             icon=self._icon,
         )
 
@@ -79,6 +89,7 @@ async def async_setup_entry(
             .builder(select, SelectSensorBuilder.from_entity(select))
             .set_state(select.set_value_func)
             .availability_prop(select.availability_prop)
+            .conditional_options(select.conditional_options)
             .options(select.options_str)
             .build()
         )
@@ -108,6 +119,13 @@ class EcoflowSelect(EcoflowEntity, SelectEntity):
         self._set_state = description.set_state
         self._attr_current_option = getattr(device, self._prop_name, None)
         self._availability_prop = description.availability_prop
+        self._offered_options = list(description.options or [])
+        # The deprecated descriptions this platform falls back to are a separate class
+        # that carries no conditions
+        self._conditional_options: tuple[tuple[DynamicValue, list[str]], ...] = getattr(
+            description, "conditional_options", ()
+        )
+        self._attr_options = self._options_now()
 
         if self.entity_description.translation_key is None:
             self._attr_translation_key = self.entity_description.key
@@ -126,6 +144,22 @@ class EcoflowSelect(EcoflowEntity, SelectEntity):
             prop_name=self._availability_prop,
             get_state=lambda state: state if state is not None else self.SkipWrite,
         )
+        for condition, _ in self._conditional_options:
+            self._register_update_callback(
+                entity_attr="_attr_options",
+                prop_name=condition.prop_name,
+                get_state=lambda _: self._options_now(),
+            )
+
+    def _options_now(self) -> list[str]:
+        withheld = {
+            option
+            for condition, options in self._conditional_options
+            if condition.resolve(self._device)
+            for option in options
+        }
+        withheld.discard(self._attr_current_option)
+        return [option for option in self._offered_options if option not in withheld]
 
     @property
     def available(self):

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -364,6 +364,12 @@
       "plugged_in_ac": {
         "name": "AC Plugged In"
       },
+      "battery_connected": {
+        "name": "Battery Connected"
+      },
+      "solar_connected": {
+        "name": "Solar Connected"
+      },
       "fan_running": {
         "name": "Fan Running"
       },

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -361,6 +361,12 @@
       "plugged_in_ac": {
         "name": "Змінний струм (AC) підключено"
       },
+      "battery_connected": {
+        "name": "Батарея підключена"
+      },
+      "solar_connected": {
+        "name": "Сонячні панелі підключено"
+      },
       "fan_running": {
         "name": "Вентилятор працює"
       },

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -361,6 +361,12 @@
       "plugged_in_ac": {
         "name": "交流已插入"
       },
+      "battery_connected": {
+        "name": "电池已连接"
+      },
+      "solar_connected": {
+        "name": "太阳能已连接"
+      },
       "fan_running": {
         "name": "风扇运行中"
       },


### PR DESCRIPTION
This PR stops the Wave 2 offering controls the device is not currently able to act on. Several writable controls could be changed while the unit was off or in standby, where the device ignores the write and the entity silently reverts a moment later; Drain Mode's "Drain Free" is only accepted while cooling; and Power Mode's "Off" is turned back into "Standby" by the firmware whenever the unit runs on mains. All of it is decidable from `power_src`, a field the device class already parsed but never used.

Selects needed one new capability for this: an option that is valid in one device state and rejected in another can neither be excluded permanently, which loses a working feature, nor handled with `availability`, which hides the options that still work.

Full list of changes:

- **`option_set` replaces the `exclude` keyword on `controls.select`,** carrying both permanent exclusions and ones conditional on a device field: `options=controls.option_set(PowerMode).exclude(PowerMode.INIT).exclude_if(plugged_in_ac, PowerMode.OFF)`. `exclude=` had a single call site, so nothing else moved.
- **`exclude_if` accepts a boolean field or a `dynamic(field, transform)`,** so Drain Mode can express a test over `main_mode` inline rather than through a computed field. `EcoflowSelect` recomputes its options from one update callback per condition, the mechanism `availability` already uses; a select with no conditions keeps a fixed list and behaves as before.
- **`power_src` is decoded into AC Plugged In, Solar Connected and Battery Connected** through the existing `prop_has_bit_on` transform. The old comment had mains and battery the wrong way round, which never showed because the field was commented out.
- **Ambient Light, Automatic Drain, Drain Mode, Fan Speed, Main Mode, Sub Mode and Target Temperature now follow `power`** and report unavailable outside the running state instead of accepting a write and reverting.

Both new behaviours rest on readings from a single unit. The `power_src` bits come from a unit reporting 1 on mains alone, 16 on battery alone, 17 on mains and battery and 18 on battery and solar, which fixes bits 0, 1 and 4 but leaves bit 2 unexercised; the Power Mode gating withholds Off only while mains is present, the case confirmed to be demoted, so units on solar alone still offer it.

Supersedes #490, whose reporting and hardware readings this is built on.