### PR TITLE
Recognise River 2 Max units with the R613 serial prefix

### DIFF
--- a/custom_components/ef_ble/eflib/devices/river2_max.py
+++ b/custom_components/ef_ble/eflib/devices/river2_max.py
@@ -8,4 +8,4 @@ pb_mppt = river2.pb_mppt
 class Device(river2.Device):
     """River 2 Max"""
 
-    SN_PREFIX = (b"R611", "R613")
+    SN_PREFIX = (b"R611", b"R613")


### PR DESCRIPTION
This PR makes River 2 Max units whose serial number starts with `R613` come up as a River 2 Max instead of falling back to the unsupported device.

Resolves #482