### PR TITLE
Replace ecdsa with OpenSSL for BLE key exchange

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -7,7 +7,10 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    name: Run python tests
+    name: Python ${{ matrix.python-version }}
+    strategy:
+      matrix:
+        python-version: ['3.13', '3.14']
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
@@ -16,9 +19,9 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
-      - name: Setup Python 3.x
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: ${{ matrix.python-version }}
       - name: Tests
-        run: uv run pytest tests/eflib
+        run: uv run --python ${{ matrix.python-version }} pytest tests/eflib

--- a/README.md
+++ b/README.md
@@ -735,10 +735,20 @@ Click on any device below to see available sensors, switches, and controls:
 ### Prerequisites
 
 - Home Assistant with Bluetooth support
+- OpenSSL 3 (`libcrypto.so.3`) with SECP160r1 support for ECDH devices (encryption type 7)
 - Your device must be **bound to your account** through the EcoFlow app before setup
 - Your **User ID** from the EcoFlow app (can be retrieved via the config flow login form
   during setup)
 - [HACS](https://hacs.xyz/) installed (recommended method)
+
+The ECDH backend currently supports Linux. Home Assistant needs the OpenSSL library
+inside its runtime, even if OpenSSL is installed on the host. Installing `cryptography`
+does not replace this system library. Native Windows and macOS need separate library
+loading support.
+
+FIPS-only configurations cannot perform the device's SECP160r1 handshake. The integration
+does not override OpenSSL security policies or fall back to another curve. Encryption
+types 0 and 1 do not need this ECDH backend.
 
 ### Method 1: HACS Installation (Recommended)
 

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -13,7 +13,6 @@ from enum import StrEnum, auto
 from functools import cached_property
 from typing import Any, Concatenate, Literal, Self
 
-import ecdsa
 from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
@@ -26,6 +25,7 @@ from bleak_retry_connector import (
 )
 
 from . import keydata
+from .ecdh import key_exchange
 from .encryption import EncryptionStrategy, Type1Encryption, Type7Encryption
 from .exceptions import (
     AuthErrors,
@@ -749,35 +749,27 @@ class Connection:
         self._logger.log_filtered(
             LogOptions.CONNECTION_DEBUG, "initBleSessionKey: Pub key exchange"
         )
-        self._private_key = ecdsa.SigningKey.generate(curve=ecdsa.SECP160r1)
-        self._public_key: ecdsa.VerifyingKey = self._private_key.get_verifying_key()  # pyright: ignore[reportAttributeAccessIssue]
+        async with key_exchange() as key:
+            async with self._expecting_response():
+                # Payload contains some weird prefix and generated public key
+                await self.send_request(
+                    SimplePacketAssembler.encode(b"\x01\x00" + key.public_key)
+                )
+                data = await self._read_simple_reply(0x01, min_length=43)
+            self._set_state(ConnectionState.PUBLIC_KEY_RECEIVED)
 
-        async with self._expecting_response():
-            # Payload contains some weird prefix and generated public key
-            await self.send_request(
-                SimplePacketAssembler.encode(b"\x01\x00" + self._public_key.to_string())
-            )
-            data = await self._read_simple_reply(0x01, min_length=43)
-        self._set_state(ConnectionState.PUBLIC_KEY_RECEIVED)
+            # status = data[1]
+            ecdh_type_size = _get_ecdh_type_size(data[2])
+            if len(data) < ecdh_type_size + 3:
+                raise PacketParseError(
+                    f"Pub key data is {len(data)} bytes, need {ecdh_type_size + 3}: "
+                    + data.hex()
+                )
 
-        # status = data[1]
-        ecdh_type_size = _get_ecdh_type_size(data[2])
-        if len(data) < ecdh_type_size + 3:
-            raise PacketParseError(
-                f"Pub key data is {len(data)} bytes, need {ecdh_type_size + 3}: "
-                + data.hex()
-            )
-        self._dev_pub_key = ecdsa.VerifyingKey.from_string(
-            data[3 : ecdh_type_size + 3], curve=ecdsa.SECP160r1
-        )
+            # The device derives the same raw secret from its private key and
+            # our public key. Keep all 20 bytes, including any leading zeros.
+            shared_key = await key.exchange(data[3 : ecdh_type_size + 3])
 
-        # Generating shared key from our private key and received device public key
-        # NOTE: The device will do the same with it's private key and our public key to
-        # generate the # same shared key value and use it to encrypt/decrypt using
-        # symmetric encryption algorithm
-        shared_key = ecdsa.ECDH(
-            ecdsa.SECP160r1, self._private_key, self._dev_pub_key
-        ).generate_sharedsecret_bytes()
         # Set Initialization Vector from digest of the original shared key
         iv = hashlib.md5(shared_key).digest()
 

--- a/custom_components/ef_ble/eflib/ecdh.py
+++ b/custom_components/ef_ble/eflib/ecdh.py
@@ -1,0 +1,274 @@
+"""SECP160r1 key agreement through OpenSSL 3's public EVP API"""
+
+import asyncio
+import ctypes
+import functools
+import threading
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+
+# Distributions such as NixOS can replace this with an absolute library path.
+_LIBCRYPTO = "libcrypto.so.3"
+_PROPERTIES = b"provider=default"
+_BYTE_PTR = ctypes.POINTER(ctypes.c_ubyte)
+_SIZE_PTR = ctypes.POINTER(ctypes.c_size_t)
+_KEY_PTR = ctypes.POINTER(ctypes.c_void_p)
+
+# RFC 5480 SubjectPublicKeyInfo: id-ecPublicKey, secp160r1, then an uncompressed
+# SEC1 point. The device sends only X[20] || Y[20], without the 04 prefix.
+_SPKI_PREFIX = bytes.fromhex("303e301006072a8648ce3d020106052b81040008032a0004")
+
+# Declare pointer argument and return types explicitly. ctypes defaults to a
+# C int return value, which truncates pointers on 64-bit hosts. Do not bind
+# variadic functions or macros.
+_SIGNATURES = {
+    "OpenSSL_version_num": (ctypes.c_ulong, []),
+    "EVP_PKEY_CTX_new_from_name": (
+        ctypes.c_void_p,
+        [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p],
+    ),
+    "EVP_PKEY_keygen_init": (ctypes.c_int, [ctypes.c_void_p]),
+    "EVP_PKEY_CTX_set_group_name": (
+        ctypes.c_int,
+        [ctypes.c_void_p, ctypes.c_char_p],
+    ),
+    "EVP_PKEY_generate": (ctypes.c_int, [ctypes.c_void_p, _KEY_PTR]),
+    "EVP_PKEY_free": (None, [ctypes.c_void_p]),
+    "EVP_PKEY_CTX_free": (None, [ctypes.c_void_p]),
+    "EVP_PKEY_get_octet_string_param": (
+        ctypes.c_int,
+        [ctypes.c_void_p, ctypes.c_char_p, _BYTE_PTR, ctypes.c_size_t, _SIZE_PTR],
+    ),
+    "d2i_PUBKEY_ex": (
+        ctypes.c_void_p,
+        [
+            _KEY_PTR,
+            ctypes.POINTER(_BYTE_PTR),
+            ctypes.c_long,
+            ctypes.c_void_p,
+            ctypes.c_char_p,
+        ],
+    ),
+    "EVP_PKEY_get0_provider": (ctypes.c_void_p, [ctypes.c_void_p]),
+    "EVP_PKEY_CTX_new_from_pkey": (
+        ctypes.c_void_p,
+        [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p],
+    ),
+    "EVP_PKEY_public_check": (ctypes.c_int, [ctypes.c_void_p]),
+    "EVP_PKEY_derive_init": (ctypes.c_int, [ctypes.c_void_p]),
+    "EVP_PKEY_CTX_set_ecdh_kdf_type": (
+        ctypes.c_int,
+        [ctypes.c_void_p, ctypes.c_int],
+    ),
+    "EVP_PKEY_derive_set_peer": (
+        ctypes.c_int,
+        [ctypes.c_void_p, ctypes.c_void_p],
+    ),
+    "EVP_PKEY_derive": (ctypes.c_int, [ctypes.c_void_p, _BYTE_PTR, _SIZE_PTR]),
+    "ERR_clear_error": (None, []),
+    "ERR_get_error": (ctypes.c_ulong, []),
+    "ERR_error_string_n": (None, [ctypes.c_ulong, ctypes.c_char_p, ctypes.c_size_t]),
+    "OPENSSL_cleanse": (None, [ctypes.c_void_p, ctypes.c_size_t]),
+}
+
+
+class ECDHError(RuntimeError):
+    """The native backend could not perform the device's key agreement"""
+
+
+@functools.cache
+def _load_libcrypto() -> ctypes.CDLL:
+    # Loading the library, configuration, or providers can read files. This runs
+    # in a worker to keep that I/O off the event loop.
+    try:
+        lib = ctypes.CDLL(_LIBCRYPTO)
+        for name, (restype, argtypes) in _SIGNATURES.items():
+            function = getattr(lib, name)
+            function.restype = restype
+            function.argtypes = argtypes
+    except (OSError, AttributeError) as error:
+        raise ECDHError(
+            "EcoFlow key agreement requires the OpenSSL 3 libcrypto shared library "
+            "with SECP160r1 support"
+        ) from error
+    if lib.OpenSSL_version_num() >> 28 != 3:
+        raise ECDHError("EcoFlow key agreement requires OpenSSL 3")
+    return lib
+
+
+def _error(lib: ctypes.CDLL, operation: str) -> ECDHError:
+    # The error queue is thread-local: drain it here, before cleanup or returning
+    # to asyncio. Error descriptions contain no key buffers or device data.
+    errors = []
+    while code := lib.ERR_get_error():
+        buffer = ctypes.create_string_buffer(256)
+        lib.ERR_error_string_n(code, buffer, len(buffer))
+        errors.append(buffer.value.decode("ascii", errors="replace"))
+    detail = "; ".join(errors) or "no OpenSSL error details"
+    return ECDHError(f"OpenSSL could not {operation}: {detail}")
+
+
+def _check(lib: ctypes.CDLL, result: int, operation: str) -> None:
+    if result != 1:
+        raise _error(lib, operation)
+
+
+@contextmanager
+def _context(
+    lib: ctypes.CDLL, key: ctypes.c_void_p | int | None = None
+) -> Iterator[int]:
+    context = (
+        lib.EVP_PKEY_CTX_new_from_name(None, b"EC", _PROPERTIES)
+        if key is None
+        else lib.EVP_PKEY_CTX_new_from_pkey(None, key, _PROPERTIES)
+    )
+    if not context:
+        raise _error(lib, "create an EC context")
+    try:
+        yield context
+    finally:
+        lib.EVP_PKEY_CTX_free(context)
+
+
+class _KeyExchange:
+    def __init__(self) -> None:
+        self.public_key = b""
+        self._lib: ctypes.CDLL | None = None
+        self._key = ctypes.c_void_p()
+        self._lock = threading.Lock()
+        self._closed = threading.Event()
+
+    @contextmanager
+    def _operation(self) -> Iterator[None]:
+        try:
+            with self._lock:
+                if self._closed.is_set():
+                    raise ECDHError("ECDH exchange is closed")
+                yield
+        finally:
+            # Canceling to_thread leaves the worker running. Check _closed after
+            # releasing the lock: close() can fail to acquire it just before release.
+            if self._closed.is_set():
+                self.close()
+
+    def _free(self) -> None:
+        if self._key:
+            assert self._lib is not None
+            self._lib.EVP_PKEY_free(self._key)
+            self._key = ctypes.c_void_p()
+
+    def close(self) -> None:
+        self._closed.set()
+        if self._lock.acquire(blocking=False):
+            try:
+                self._free()
+            finally:
+                self._lock.release()
+
+    def generate(self) -> None:
+        with self._operation():
+            self._lib = lib = _load_libcrypto()
+            lib.ERR_clear_error()
+            with _context(lib) as context:
+                _check(lib, lib.EVP_PKEY_keygen_init(context), "initialize EC keygen")
+                _check(
+                    lib,
+                    lib.EVP_PKEY_CTX_set_group_name(context, b"secp160r1"),
+                    "select SECP160r1",
+                )
+                _check(
+                    lib,
+                    lib.EVP_PKEY_generate(context, ctypes.byref(self._key)),
+                    "generate an ephemeral EC key",
+                )
+            if not self._key:
+                raise ECDHError("OpenSSL returned no EC key")
+            point = (ctypes.c_ubyte * 41)()
+            size = ctypes.c_size_t()
+            _check(
+                lib,
+                lib.EVP_PKEY_get_octet_string_param(
+                    self._key, b"encoded-pub-key", point, len(point), ctypes.byref(size)
+                ),
+                "export the EC public key",
+            )
+            if size.value != len(point) or point[0] != 4:
+                raise ECDHError("OpenSSL returned an unexpected EC public key encoding")
+            self.public_key = bytes(point)[1:]
+
+    async def exchange(self, peer_public_key: bytes) -> bytes:
+        return await asyncio.to_thread(self._derive, peer_public_key)
+
+    def _derive(self, peer_public_key: bytes) -> bytes:
+        with self._operation():
+            if len(peer_public_key) != 40:
+                raise ValueError("SECP160r1 peer public keys must contain 40 bytes")
+            lib = self._lib
+            assert lib is not None
+            lib.ERR_clear_error()
+            encoded = _SPKI_PREFIX + peer_public_key
+            buffer = (ctypes.c_ubyte * len(encoded)).from_buffer_copy(encoded)
+            cursor = ctypes.cast(buffer, _BYTE_PTR)
+            peer = lib.d2i_PUBKEY_ex(
+                None, ctypes.byref(cursor), len(buffer), None, _PROPERTIES
+            )
+            if not peer:
+                raise _error(lib, "decode the SECP160r1 peer public key")
+            try:
+                consumed = ctypes.cast(cursor, ctypes.c_void_p).value
+                end = ctypes.addressof(buffer) + len(buffer)
+                if consumed != end or not lib.EVP_PKEY_get0_provider(peer):
+                    raise ECDHError("OpenSSL did not import a provider-backed EC key")
+                with _context(lib, peer) as context:
+                    _check(
+                        lib, lib.EVP_PKEY_public_check(context), "validate the EC peer"
+                    )
+                with _context(lib, self._key) as context:
+                    _check(lib, lib.EVP_PKEY_derive_init(context), "initialize ECDH")
+                    # EVP_PKEY_ECDH_KDF_NONE is 1. The caller hashes and truncates
+                    # the raw 20-byte X coordinate after key agreement.
+                    _check(
+                        lib,
+                        lib.EVP_PKEY_CTX_set_ecdh_kdf_type(context, 1),
+                        "select raw ECDH",
+                    )
+                    _check(
+                        lib, lib.EVP_PKEY_derive_set_peer(context, peer), "set EC peer"
+                    )
+                    size = ctypes.c_size_t()
+                    _check(
+                        lib,
+                        lib.EVP_PKEY_derive(context, None, ctypes.byref(size)),
+                        "size the ECDH secret",
+                    )
+                    if size.value != 20:
+                        raise ECDHError(
+                            "OpenSSL returned an unexpected ECDH secret size"
+                        )
+                    secret = (ctypes.c_ubyte * 20)()
+                    try:
+                        _check(
+                            lib,
+                            lib.EVP_PKEY_derive(context, secret, ctypes.byref(size)),
+                            "derive the ECDH secret",
+                        )
+                        if size.value != len(secret):
+                            raise ECDHError("OpenSSL returned a truncated ECDH secret")
+                        return bytes(secret)
+                    finally:
+                        # This clears only the native scratch buffer, not the
+                        # returned Python bytes or the caller's symmetric key.
+                        lib.OPENSSL_cleanse(secret, len(secret))
+            finally:
+                lib.EVP_PKEY_free(peer)
+
+
+@asynccontextmanager
+async def key_exchange() -> AsyncIterator[_KeyExchange]:
+    """Own one ephemeral key, including during cancellation of native work"""
+    key = _KeyExchange()
+    try:
+        await asyncio.to_thread(key.generate)
+        yield key
+    finally:
+        key.close()

--- a/custom_components/ef_ble/manifest.json
+++ b/custom_components/ef_ble/manifest.json
@@ -227,7 +227,6 @@
     "loggers": ["custom_components.ef_ble"],
 
     "requirements": [
-        "ecdsa~=0.19",
         "PyCryptodome~=3.23",
         "protobuf~=6.30"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
   "bleak",
   "bleak-retry-connector",
   "bluetooth-adapters",
-  "ecdsa~=0.19",
   "protobuf~=6.30",
   "pycryptodome~=3.23",
 ]

--- a/tests/eflib/conftest.py
+++ b/tests/eflib/conftest.py
@@ -1,8 +1,16 @@
 """Pytest configuration for testing eflib without Home Assistant dependencies."""
 
+import ctypes
+import importlib
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
+
+import pytest
+from pytest_mock import MockerFixture
+
+from .ecdh_vectors import PUBLIC_KEYS
 
 # Create minimal stub modules for custom_components and ef_ble - This prevents their
 # __init__.py files from being executed
@@ -15,3 +23,51 @@ ef_ble.__path__ = [str(Path(__file__).parents[2] / "custom_components" / "ef_ble
 sys.modules["custom_components.ef_ble"] = ef_ble
 
 setattr(custom_components, "ef_ble", ef_ble)
+
+
+@pytest.fixture
+def libcrypto() -> ctypes.CDLL:
+    # Import after the package stubs, and only for tests that use native ECDH.
+    ecdh = importlib.import_module("custom_components.ef_ble.eflib.ecdh")
+    return ecdh._load_libcrypto()
+
+
+@pytest.fixture
+def fixed_ecdh_key(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL
+) -> Callable[[int], None]:
+    # These tests import fixed private keys in SEC1 format. Production code never
+    # imports or exports private scalars. The test scalars are public and are not
+    # real credentials.
+    byte_pointer = ctypes.POINTER(ctypes.c_ubyte)
+    decoder = libcrypto.d2i_AutoPrivateKey_ex
+    decoder.restype = ctypes.c_void_p
+    decoder.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(byte_pointer),
+        ctypes.c_long,
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+    ]
+
+    def set_scalar(scalar: int) -> None:
+        encoded = (
+            bytes.fromhex("30510201010415")
+            + scalar.to_bytes(21, "big")
+            + bytes.fromhex("a00706052b81040008a12c032a0004")
+            + PUBLIC_KEYS[scalar]
+        )
+
+        def generate(_context: int, key_out: object) -> int:
+            buffer = (ctypes.c_ubyte * len(encoded)).from_buffer_copy(encoded)
+            cursor = ctypes.cast(buffer, byte_pointer)
+            key = decoder(
+                None, ctypes.byref(cursor), len(buffer), None, b"provider=default"
+            )
+            assert key, "OpenSSL rejected the synthetic private-key fixture"
+            ctypes.cast(key_out, ctypes.POINTER(ctypes.c_void_p))[0] = key
+            return 1
+
+        mocker.patch.object(libcrypto, "EVP_PKEY_generate", side_effect=generate)
+
+    return set_scalar

--- a/tests/eflib/ecdh_vectors.py
+++ b/tests/eflib/ecdh_vectors.py
@@ -1,0 +1,36 @@
+"""Synthetic SECP160r1 fixtures, not captured device or account credentials"""
+
+# Cross-checked with python-ecdsa 0.19 and OpenSSL 3.6 EVP raw ECDH. For a
+# private scalar of 1, the shared secret is the peer point's 20-byte X coordinate.
+# Scalar 130 has leading zeros in both coordinates; n - 1 needs 161 bits.
+PUBLIC_KEYS = {
+    1: bytes.fromhex(
+        "4a96b5688ef573284664698968c38bb913cbfc82"
+        "23a628553168947d59dcc912042351377ac5fb32"
+    ),
+    2: bytes.fromhex(
+        "02f997f33c5ed04c55d3edf8675d3e92e8f46686"
+        "f083a323482993e9440e817e21cfb7737df8797b"
+    ),
+    130: bytes.fromhex(
+        "007746d0467cae6e1d9e71ec04f993a7961c95d8"
+        "0044580fc3f7ebf6f379ac3f568d48073505c1d5"
+    ),
+    0x100000000000000000001F4C8F927AED3CA752256: bytes.fromhex(
+        "4a96b5688ef573284664698968c38bb913cbfc82"
+        "dc59d7aace976b82a62336edfbdcaec8053a04cd"
+    ),
+}
+
+# Fixed results from the original handshake with local scalar 130, peer scalar 1,
+# sRand = bytes(range(16)), seed = 02 01, and the existing key table / AES framing.
+PUBLIC_REQUEST = bytes.fromhex(
+    "5a5a00012c000100007746d0467cae6e1d9e71ec04f993a7961c95d8"
+    "0044580fc3f7ebf6f379ac3f568d48073505c1d54871"
+)
+INITIAL_KEY = bytes.fromhex("007746d0467cae6e1d9e71ec04f993a7")
+IV = bytes.fromhex("57e383f27f30eac2c33935e213a73b76")
+KEY_INFO_REPLY = bytes.fromhex(
+    "5a5a000123000237ad4ef76d1d6fd8f31b283cba91715c242547452ed97b5d1dd72f6df559889909ab"
+)
+SESSION_KEY = bytes.fromhex("0fd4fa7e5a68909e37d5f2e1494256c0")

--- a/tests/eflib/test_connection.py
+++ b/tests/eflib/test_connection.py
@@ -1,0 +1,212 @@
+"""Hardware-free regression tests for the Bluetooth authentication handshake"""
+
+import asyncio
+import ctypes
+import hashlib
+from collections.abc import Callable
+
+import pytest
+from bleak.backends.device import BLEDevice
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
+from pytest_mock import MockerFixture
+
+from custom_components.ef_ble.eflib import ecdh
+from custom_components.ef_ble.eflib.connection import Connection, ConnectionState
+from custom_components.ef_ble.eflib.encryption import Type7Encryption
+from custom_components.ef_ble.eflib.frame_assembler import (
+    EncPacketAssembler,
+    SimplePacketAssembler,
+)
+from custom_components.ef_ble.eflib.packet import Packet
+
+from .ecdh_vectors import (
+    INITIAL_KEY,
+    IV,
+    KEY_INFO_REPLY,
+    PUBLIC_KEYS,
+    PUBLIC_REQUEST,
+    SESSION_KEY,
+)
+
+
+@pytest.fixture
+def connection(mocker: MockerFixture) -> Connection:
+    connection = Connection(
+        BLEDevice("AA:BB:CC:DD:EE:FF", "Synthetic EcoFlow", {}),
+        "Y711TEST000000001",
+        "123456789",
+        mocker.AsyncMock(return_value=True),
+        mocker.AsyncMock(side_effect=Packet.from_bytes),
+    ).with_disabled_reconnect()
+    connection._client = mocker.Mock(is_connected=True)
+    connection._client.write_gatt_char = mocker.AsyncMock()
+    connection._client.disconnect = mocker.AsyncMock()
+    connection._inbox = asyncio.Queue()
+    return connection
+
+
+@pytest.fixture
+def fixed_key(fixed_ecdh_key: Callable[[int], None]) -> None:
+    fixed_ecdh_key(130)
+
+
+@pytest.mark.parametrize("fragmented", [False, True])
+@pytest.mark.usefixtures("fixed_key")
+async def test_type7_key_exchange(connection: Connection, fragmented: bool) -> None:
+    reply = SimplePacketAssembler.encode(b"\x01\x00\x00" + PUBLIC_KEYS[1])
+    notifications = [reply[:11], reply[11:]] if fragmented else [reply]
+    for notification in notifications:
+        await connection._on_notification(None, bytearray(notification))
+
+    await connection._ecdh_key_exchange()
+
+    writes = connection._client.write_gatt_char.call_args_list
+    assert len(writes) == 1
+    assert bytes(writes[0].args[1]) == PUBLIC_REQUEST
+    assert connection._encryption.session_key == INITIAL_KEY
+    assert connection._encryption.iv == IV
+    assert connection._state == ConnectionState.PUBLIC_KEY_RECEIVED
+    assert not connection._stage_reading
+
+
+@pytest.mark.usefixtures("fixed_key")
+async def test_type7_session_key_and_authentication(connection: Connection) -> None:
+    peer_reply = SimplePacketAssembler.encode(b"\x01\x00\x00" + PUBLIC_KEYS[1])
+    device_assembler = EncPacketAssembler(Type7Encryption(SESSION_KEY, IV))
+    auth_reply = await device_assembler.encode(Packet(0x35, 0x21, 0x35, 0x89, b"\x00"))
+    # The inbox and frame assemblers must handle stale opcodes, undersized
+    # replies, fragments, and duplicate key replies without breaking the handshake.
+    notifications = [
+        SimplePacketAssembler.encode(b"\x02" + bytes(32)),
+        SimplePacketAssembler.encode(b"\x01\x00\x00"),
+        peer_reply[:13],
+        peer_reply[13:],
+        peer_reply,
+        KEY_INFO_REPLY[:17],
+        KEY_INFO_REPLY[17:],
+        peer_reply,
+        auth_reply,
+    ]
+    for notification in notifications:
+        await connection._on_notification(None, bytearray(notification))
+    derived_keys = []
+    connection.on_session_key_derived(lambda key, iv: derived_keys.append((key, iv)))
+
+    await connection._init_ble_session_key()
+
+    assert connection._state == ConnectionState.AUTH_STATUS_RECEIVED
+    assert connection._initial_session_key == INITIAL_KEY
+    assert derived_keys == [(INITIAL_KEY, IV), (SESSION_KEY, IV)]
+    assert connection._errors == 0
+    await connection._auto_authentication()
+
+    writes = connection._client.write_gatt_char.call_args_list
+    assert len(writes) == 4
+    assert bytes(writes[0].args[1]) == PUBLIC_REQUEST
+    assert bytes(writes[1].args[1]) == SimplePacketAssembler.encode(b"\x02")
+    for write, command in zip(writes[2:], (0x89, 0x86), strict=True):
+        frame = bytes(write.args[1])
+        plaintext = unpad(
+            AES.new(SESSION_KEY, AES.MODE_CBC, IV).decrypt(frame[6:-2]), 16
+        )
+        packet = Packet.from_bytes(plaintext)
+        assert (packet.src, packet.dst, packet.cmd_set, packet.cmd_id) == (
+            0x21,
+            0x35,
+            0x35,
+            command,
+        )
+        assert packet.payload == (
+            b"632C5729BDA213663966F2E18019A3BC" if command == 0x86 else b""
+        )
+
+
+@pytest.mark.parametrize("encrypt_type", [0, 1])
+async def test_other_modes_do_not_use_ecdh(
+    connection: Connection, mocker: MockerFixture, encrypt_type: int
+) -> None:
+    connection._encrypt_type = encrypt_type
+    load_backend = mocker.patch.object(
+        ecdh, "_load_libcrypto", side_effect=AssertionError
+    )
+    mocker.patch.object(connection, "_start_data_pump")
+    mocker.patch.object(connection, "_wait_authenticated")
+
+    await connection._run_auth()
+
+    load_backend.assert_not_called()
+    if encrypt_type == 0:
+        assert connection._encryption is None
+    else:
+        assert (
+            connection._encryption.session_key
+            == hashlib.md5(connection._dev_sn.encode()).digest()
+        )
+        assert (
+            connection._encryption.iv
+            == hashlib.md5(connection._dev_sn[::-1].encode()).digest()
+        )
+
+
+@pytest.mark.parametrize("teardown", ["cancel", "timeout", "disconnect"])
+async def test_ecdh_wait_cleanup(
+    connection: Connection,
+    mocker: MockerFixture,
+    libcrypto: ctypes.CDLL,
+    teardown: str,
+) -> None:
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+    sent = asyncio.Event()
+    connection.on_data_send(lambda _: sent.set())
+    if teardown == "timeout":
+        connection._options.timeout = 0
+    task = asyncio.create_task(connection._ecdh_key_exchange())
+    connection._auth_task = task
+    try:
+        async with asyncio.timeout(5):
+            await sent.wait()
+            if teardown == "timeout":
+                with pytest.raises(TimeoutError):
+                    await task
+            else:
+                if teardown == "disconnect":
+                    connection.disconnected()
+                else:
+                    task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+    free_key.assert_called_once()
+    assert connection._encryption is None
+    assert not connection._stage_reading
+
+
+@pytest.mark.parametrize("curve_number", [0, 1, 2])
+async def test_bad_peer_aborts_authentication(
+    connection: Connection,
+    mocker: MockerFixture,
+    libcrypto: ctypes.CDLL,
+    curve_number: int,
+) -> None:
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+    reply = SimplePacketAssembler.encode(bytes([1, 0, curve_number]) + bytes(40))
+    await connection._on_notification(None, bytearray(reply))
+
+    await connection._run_auth()
+
+    assert connection._state == ConnectionState.ERROR_AUTH_FAILED
+    assert connection._encryption is None
+    connection._client.disconnect.assert_awaited_once()
+    free_key.assert_called_once()
+
+
+async def test_repeated_handshakes_generate_fresh_keys(connection: Connection) -> None:
+    reply = SimplePacketAssembler.encode(b"\x01\x00\x00" + PUBLIC_KEYS[1])
+    for _ in range(2):
+        await connection._on_notification(None, bytearray(reply))
+        await connection._ecdh_key_exchange()
+    writes = connection._client.write_gatt_char.call_args_list
+    assert bytes(writes[0].args[1]) != bytes(writes[1].args[1])

--- a/tests/eflib/test_ecdh.py
+++ b/tests/eflib/test_ecdh.py
@@ -1,0 +1,433 @@
+"""Native EVP compatibility, input validation, and ownership tests"""
+
+import asyncio
+import ctypes
+import subprocess
+import sys
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from custom_components.ef_ble.eflib import ecdh
+
+from .ecdh_vectors import PUBLIC_KEYS
+
+
+@pytest.mark.parametrize("scalar", PUBLIC_KEYS)
+async def test_fixed_private_key(
+    fixed_ecdh_key: Callable[[int], None], scalar: int
+) -> None:
+    fixed_ecdh_key(scalar)
+    async with ecdh.key_exchange() as key:
+        assert key.public_key == PUBLIC_KEYS[scalar]
+        assert await key.exchange(PUBLIC_KEYS[1]) == PUBLIC_KEYS[scalar][:20]
+    assert not key._key
+
+
+@pytest.mark.parametrize("scalar", PUBLIC_KEYS)
+async def test_fixed_peer_key(
+    fixed_ecdh_key: Callable[[int], None], scalar: int
+) -> None:
+    fixed_ecdh_key(1)
+    async with ecdh.key_exchange() as key:
+        assert await key.exchange(PUBLIC_KEYS[scalar]) == PUBLIC_KEYS[scalar][:20]
+
+
+async def test_fresh_keys_agree() -> None:
+    async with ecdh.key_exchange() as alice, ecdh.key_exchange() as bob:
+        assert alice.public_key != bob.public_key
+        assert len(alice.public_key) == len(bob.public_key) == 40
+        a_secret, b_secret = await asyncio.gather(
+            alice.exchange(bob.public_key), bob.exchange(alice.public_key)
+        )
+        assert a_secret == b_secret
+        assert len(a_secret) == 20
+    assert not alice._key and not bob._key
+
+
+@pytest.mark.parametrize("size", [0, 1, 20, 39, 41, 52, 56, 64, 65])
+async def test_rejects_wrong_peer_width(size: int) -> None:
+    async with ecdh.key_exchange() as key:
+        with pytest.raises(ValueError, match="40 bytes"):
+            await key.exchange(bytes(size))
+
+
+@pytest.mark.parametrize(
+    "point",
+    [
+        bytes(40),  # Not a point (the SEC1 infinity encoding is not a wire point).
+        b"\xff" * 40,
+        bytes.fromhex("ffffffffffffffffffffffffffffffff7fffffff") + PUBLIC_KEYS[1][20:],
+        PUBLIC_KEYS[1][:20] + bytes.fromhex("ffffffffffffffffffffffffffffffff7fffffff"),
+        PUBLIC_KEYS[1][:-1] + bytes([PUBLIC_KEYS[1][-1] ^ 1]),
+    ],
+)
+async def test_rejects_invalid_peer(point: bytes) -> None:
+    async with ecdh.key_exchange() as key:
+        with pytest.raises(ecdh.ECDHError, match="peer"):
+            await key.exchange(point)
+    assert not key._key
+
+
+def test_native_signatures(libcrypto: ctypes.CDLL) -> None:
+    for name, (restype, argtypes) in ecdh._SIGNATURES.items():
+        function = getattr(libcrypto, name)
+        assert function.restype is restype
+        assert function.argtypes == argtypes
+
+
+def test_missing_library(mocker: MockerFixture) -> None:
+    load = mocker.patch.object(
+        ecdh.ctypes, "CDLL", side_effect=OSError("not installed")
+    )
+    with pytest.raises(ecdh.ECDHError, match="OpenSSL 3 libcrypto"):
+        ecdh._load_libcrypto.__wrapped__()
+    load.assert_called_once_with(ecdh._LIBCRYPTO)
+
+
+def test_missing_symbol(mocker: MockerFixture) -> None:
+    lib = mocker.Mock(spec=[n for n in ecdh._SIGNATURES if n != "EVP_PKEY_generate"])
+    mocker.patch.object(ecdh.ctypes, "CDLL", return_value=lib)
+    with pytest.raises(ecdh.ECDHError, match="OpenSSL 3 libcrypto"):
+        ecdh._load_libcrypto.__wrapped__()
+
+
+@pytest.mark.parametrize("version", [0x10101000, 0x40000000])
+def test_wrong_openssl_version(mocker: MockerFixture, version: int) -> None:
+    lib = mocker.Mock()
+    lib.OpenSSL_version_num.return_value = version
+    mocker.patch.object(ecdh.ctypes, "CDLL", return_value=lib)
+    with pytest.raises(ecdh.ECDHError, match="requires OpenSSL 3"):
+        ecdh._load_libcrypto.__wrapped__()
+
+
+@pytest.mark.parametrize(
+    ("symbol", "call_number", "result", "keys_freed", "contexts_freed"),
+    [
+        ("EVP_PKEY_CTX_new_from_name", 1, None, 0, 0),
+        ("EVP_PKEY_keygen_init", 1, 0, 0, 1),
+        ("EVP_PKEY_CTX_set_group_name", 1, -2, 0, 1),
+        ("EVP_PKEY_generate", 1, 0, 0, 1),
+        ("EVP_PKEY_get_octet_string_param", 1, 0, 1, 1),
+        ("d2i_PUBKEY_ex", 1, None, 1, 1),
+        ("EVP_PKEY_get0_provider", 1, None, 2, 1),
+        ("EVP_PKEY_CTX_new_from_pkey", 1, None, 2, 1),
+        ("EVP_PKEY_CTX_new_from_pkey", 2, None, 2, 2),
+        ("EVP_PKEY_public_check", 1, 0, 2, 2),
+        ("EVP_PKEY_derive_init", 1, 0, 2, 3),
+        ("EVP_PKEY_CTX_set_ecdh_kdf_type", 1, 0, 2, 3),
+        ("EVP_PKEY_derive_set_peer", 1, 0, 2, 3),
+        ("EVP_PKEY_derive", 1, 0, 2, 3),
+        ("EVP_PKEY_derive", 2, 0, 2, 3),
+    ],
+)
+async def test_native_failure_cleanup(
+    mocker: MockerFixture,
+    libcrypto: ctypes.CDLL,
+    symbol: str,
+    call_number: int,
+    result: int | None,
+    keys_freed: int,
+    contexts_freed: int,
+) -> None:
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+    free_context = mocker.spy(libcrypto, "EVP_PKEY_CTX_free")
+    original = getattr(libcrypto, symbol)
+    calls = 0
+
+    def fail(*args: object) -> int | None:
+        nonlocal calls
+        calls += 1
+        if calls == call_number:
+            return result
+        return original(*args)
+
+    mocker.patch.object(libcrypto, symbol, side_effect=fail)
+    with pytest.raises(ecdh.ECDHError, match="OpenSSL"):
+        async with ecdh.key_exchange() as key:
+            await key.exchange(PUBLIC_KEYS[1])
+    assert free_key.call_count == keys_freed
+    assert free_context.call_count == contexts_freed
+
+
+async def test_keygen_failure_with_owned_output(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL
+) -> None:
+    original = libcrypto.EVP_PKEY_generate
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+
+    def fail(*args: object) -> int:
+        assert original(*args) == 1
+        return 0
+
+    mocker.patch.object(libcrypto, "EVP_PKEY_generate", side_effect=fail)
+    with pytest.raises(ecdh.ECDHError, match="generate"):
+        async with ecdh.key_exchange():
+            pytest.fail("Key generation should fail")
+    free_key.assert_called_once()
+
+
+@pytest.mark.parametrize(("size", "prefix"), [(40, 4), (42, 4), (41, 2)])
+async def test_invalid_public_export(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL, size: int, prefix: int
+) -> None:
+    original = libcrypto.EVP_PKEY_get_octet_string_param
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+
+    def export(*args: object) -> int:
+        assert original(*args) == 1
+        ctypes.cast(args[4], ctypes.POINTER(ctypes.c_size_t))[0] = size
+        args[2][0] = prefix
+        return 1
+
+    mocker.patch.object(
+        libcrypto, "EVP_PKEY_get_octet_string_param", side_effect=export
+    )
+    with pytest.raises(ecdh.ECDHError, match="public key encoding"):
+        async with ecdh.key_exchange():
+            pytest.fail("The malformed public key should not be sent")
+    free_key.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("call_number", "size"), [(1, 0), (1, 19), (1, 21), (2, 19), (2, 21)]
+)
+async def test_invalid_secret_size(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL, call_number: int, size: int
+) -> None:
+    original = libcrypto.EVP_PKEY_derive
+    calls = 0
+    cleanse = mocker.spy(libcrypto, "OPENSSL_cleanse")
+
+    def derive(*args: object) -> int:
+        nonlocal calls
+        calls += 1
+        assert original(*args) == 1
+        if calls == call_number:
+            ctypes.cast(args[2], ctypes.POINTER(ctypes.c_size_t))[0] = size
+        return 1
+
+    mocker.patch.object(libcrypto, "EVP_PKEY_derive", side_effect=derive)
+    with pytest.raises(ecdh.ECDHError, match="ECDH secret"):
+        async with ecdh.key_exchange() as key:
+            await key.exchange(PUBLIC_KEYS[1])
+    assert not key._key
+    if call_number == 2:
+        cleanse.assert_called_once()
+        assert bytes(cleanse.call_args.args[0]) == bytes(20)
+
+
+async def test_close_is_idempotent(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL
+) -> None:
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+    async with ecdh.key_exchange() as key:
+        key.close()
+        key.close()
+        with pytest.raises(ecdh.ECDHError, match="closed"):
+            await key.exchange(PUBLIC_KEYS[1])
+    free_key.assert_called_once()
+
+
+async def test_null_keygen_output(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL
+) -> None:
+    mocker.patch.object(libcrypto, "EVP_PKEY_generate", return_value=1)
+    with pytest.raises(ecdh.ECDHError, match="no EC key"):
+        async with ecdh.key_exchange():
+            pytest.fail("A null private key cannot be used")
+
+
+async def test_partial_der_decode(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL
+) -> None:
+    original = libcrypto.d2i_PUBKEY_ex
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+
+    def decode(*args: object) -> int:
+        key = original(*args)
+        assert key
+        cursor = ctypes.cast(args[1], ctypes.POINTER(ecdh._BYTE_PTR))
+        end = ctypes.cast(cursor[0], ctypes.c_void_p).value
+        cursor[0] = ctypes.cast(end - 1, ecdh._BYTE_PTR)
+        return key
+
+    mocker.patch.object(libcrypto, "d2i_PUBKEY_ex", side_effect=decode)
+    with pytest.raises(ecdh.ECDHError, match="import"):
+        async with ecdh.key_exchange() as key:
+            await key.exchange(PUBLIC_KEYS[1])
+    assert free_key.call_count == 2
+
+
+async def test_errors_are_drained_on_native_thread(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL
+) -> None:
+    original = libcrypto.ERR_get_error
+    calls = []
+
+    def get_error() -> int:
+        code = original()
+        calls.append((threading.get_ident(), code))
+        return code
+
+    mocker.patch.object(libcrypto, "ERR_get_error", side_effect=get_error)
+    async with ecdh.key_exchange() as key:
+        with pytest.raises(ecdh.ECDHError, match="peer"):
+            await key.exchange(bytes(40))
+    assert len(calls) > 1
+    assert calls[-1][1] == 0
+    assert all(thread != threading.get_ident() for thread, _ in calls)
+
+
+@pytest.mark.parametrize("phase", ["load", "generate", "derive", "unlock"])
+async def test_cancellation_during_native_work(
+    mocker: MockerFixture, libcrypto: ctypes.CDLL, phase: str
+) -> None:
+    loop = asyncio.get_running_loop()
+    paused = asyncio.Event()
+    finished = asyncio.Event()
+    resume = threading.Event()
+    owner = ecdh._KeyExchange()
+    mocker.patch.object(ecdh, "_KeyExchange", return_value=owner)
+    free_key = mocker.spy(libcrypto, "EVP_PKEY_free")
+
+    def pause() -> None:
+        assert threading.get_ident() != loop_thread
+        loop.call_soon_threadsafe(paused.set)
+        assert resume.wait(5), "Test did not release the native worker"
+
+    loop_thread = threading.get_ident()
+    if phase == "unlock":
+        # Pause just before releasing the operation lock, then cancel the task.
+        # Any _closed check inside the lock runs before this cancellation. Cleanup
+        # must still release the key.
+        lock = owner._lock
+        pausing_lock = mocker.MagicMock()
+        pausing_lock.__enter__.side_effect = lock.acquire
+
+        def unlock(*_args: object) -> None:
+            try:
+                pause()
+            finally:
+                lock.release()
+
+        pausing_lock.__exit__.side_effect = unlock
+        pausing_lock.acquire.side_effect = lock.acquire
+        pausing_lock.release.side_effect = lock.release
+        owner._lock = pausing_lock
+    else:
+        target, name = (
+            (ecdh, "_load_libcrypto")
+            if phase == "load"
+            else (
+                libcrypto,
+                "EVP_PKEY_generate" if phase == "generate" else "EVP_PKEY_derive",
+            )
+        )
+        original = getattr(target, name)
+
+        def delayed(*args: object) -> object:
+            result = original(*args)
+            if phase != "derive" or args[1] is not None:
+                pause()
+            return result
+
+        mocker.patch.object(target, name, side_effect=delayed)
+
+    method = "_derive" if phase == "derive" else "generate"
+    original_work = getattr(owner, method)
+
+    def work(*args: object) -> object:
+        try:
+            return original_work(*args)
+        finally:
+            loop.call_soon_threadsafe(finished.set)
+
+    mocker.patch.object(owner, method, side_effect=work)
+
+    async def handshake() -> None:
+        async with ecdh.key_exchange() as key:
+            if phase == "derive":
+                await key.exchange(PUBLIC_KEYS[1])
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(handshake())
+    try:
+        async with asyncio.timeout(5):
+            await paused.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # Cancellation must neither block the loop nor free a key in use.
+            free_key.assert_not_called()
+    finally:
+        resume.set()
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        async with asyncio.timeout(5):
+            await finished.wait()
+    assert not owner._key
+    assert free_key.call_count == (2 if phase == "derive" else 1)
+
+
+def test_native_stress_in_subprocess() -> None:
+    code = """
+import asyncio
+import runpy
+runpy.run_path("tests/eflib/conftest.py", run_name="tests.eflib.conftest")
+from custom_components.ef_ble.eflib.ecdh import ECDHError, key_exchange
+
+async def main():
+    for _ in range(100):
+        async with key_exchange() as a, key_exchange() as b:
+            assert await a.exchange(b.public_key) == await b.exchange(a.public_key)
+            try:
+                await a.exchange(bytes(40))
+            except ECDHError:
+                pass
+            else:
+                raise AssertionError("Invalid point accepted")
+        assert not a._key and not b._key
+
+asyncio.run(main())
+"""
+    _run_native_subprocess(code)
+
+
+def test_inherited_fips_policy_is_not_overridden() -> None:
+    code = """
+import asyncio
+import ctypes
+import runpy
+runpy.run_path("tests/eflib/conftest.py", run_name="tests.eflib.conftest")
+from custom_components.ef_ble.eflib import ecdh
+
+lib = ecdh._load_libcrypto()
+set_properties = lib.EVP_set_default_properties
+set_properties.restype = ctypes.c_int
+set_properties.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+assert set_properties(None, b"fips=yes") == 1
+
+async def main():
+    try:
+        async with ecdh.key_exchange():
+            raise AssertionError("SECP160r1 must not bypass the FIPS property")
+    except ecdh.ECDHError:
+        pass
+
+asyncio.run(main())
+"""
+    _run_native_subprocess(code)
+
+
+def _run_native_subprocess(code: str) -> None:
+    subprocess.run(
+        [sys.executable, "-B", "-X", "faulthandler", "-c", code],
+        cwd=Path(__file__).parents[2],
+        check=True,
+        timeout=60,
+        capture_output=True,
+    )


### PR DESCRIPTION
Use OpenSSL 3's EVP API through `ctypes` for the existing SECP160r1 handshake, replacing the `ecdsa` dependency that is marked as insecure.

Refs [#494](https://github.com/rabits/ha-ef-ble/issues/494).
