### PR TITLE
Restore the PowerStream charge limit numbers and name the battery limit entities

### DIFF
--- a/custom_components/ef_ble/eflib/devices/powerstream.py
+++ b/custom_components/ef_ble/eflib/devices/powerstream.py
@@ -142,20 +142,18 @@ class Device(DeviceBase, ProtobufProps):
             cmd_id=0x82,
         )
 
-    async def set_battery_charge_limit_min(self, limit: int) -> bool:
-        limit = max(0, min(limit, 30))
-
+    @controls.battery(battery_charge_limit_min, min=0, max=30)
+    async def set_battery_charge_limit_min(self, limit: float) -> bool:
         await self._send_ble_packet(
-            wn511_sys_pb2.bat_lower_pack(lower_limit=limit),
+            wn511_sys_pb2.bat_lower_pack(lower_limit=int(limit)),
             cmd_id=0x84,
         )
         return True
 
-    async def set_battery_charge_limit_max(self, limit: int) -> bool:
-        limit = max(50, min(limit, 100))
-
+    @controls.battery(battery_charge_limit_max, min=50, max=100)
+    async def set_battery_charge_limit_max(self, limit: float) -> bool:
         await self._send_ble_packet(
-            wn511_sys_pb2.bat_upper_pack(upper_limit=limit),
+            wn511_sys_pb2.bat_upper_pack(upper_limit=int(limit)),
             cmd_id=0x85,
         )
         return True

--- a/custom_components/ef_ble/translations/en.json
+++ b/custom_components/ef_ble/translations/en.json
@@ -1118,6 +1118,12 @@
       "backup_discharge_limit": {
         "name": "Discharge Limit"
       },
+      "battery_charge_limit_max": {
+        "name": "Battery Charge Limit"
+      },
+      "battery_charge_limit_min": {
+        "name": "Battery Discharge Limit"
+      },
       "ac_charging_speed": {
         "name": "AC Charging Speed"
       },

--- a/custom_components/ef_ble/translations/uk.json
+++ b/custom_components/ef_ble/translations/uk.json
@@ -1108,6 +1108,12 @@
       "backup_discharge_limit": {
         "name": "Ліміт розряджання"
       },
+      "battery_charge_limit_max": {
+        "name": "Ліміт заряджання батареї"
+      },
+      "battery_charge_limit_min": {
+        "name": "Ліміт розряджання батареї"
+      },
       "ac_charging_speed": {
         "name": "Швидкість заряджання AC"
       },

--- a/custom_components/ef_ble/translations/zh-Hans.json
+++ b/custom_components/ef_ble/translations/zh-Hans.json
@@ -1108,6 +1108,12 @@
       "backup_discharge_limit": {
         "name": "放电限制"
       },
+      "battery_charge_limit_max": {
+        "name": "电池充电限制"
+      },
+      "battery_charge_limit_min": {
+        "name": "电池放电限制"
+      },
       "ac_charging_speed": {
         "name": "交流充电速度"
       },


### PR DESCRIPTION
This PR restores the PowerStream's two battery charge limit numbers, which have been accidentally removed in v1.0.3 in port to new control system.

Resolves #505
