### PR TITLE
Recover from a stale host GATT cache and stop a failing connect loop from filling the log

### DIFF
--- a/custom_components/ef_ble/eflib/bluetooth.py
+++ b/custom_components/ef_ble/eflib/bluetooth.py
@@ -1,5 +1,8 @@
 """
-The BLE transport: which characteristics carry the protocol, and the host's GATT cache
+The BLE transport: which characteristics carry the protocol, and host-stack faults
+
+The fault predicates match on error text, and are deliberately narrow: treating an
+ordinary link failure as a host fault only slows a reconnect down.
 """
 
 from collections.abc import Callable
@@ -10,7 +13,7 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 
 from .exceptions import UnsupportedBluetoothProtocol
-from .logging_util import MaskingLogger
+from .logging_util import LogOptions, MaskingLogger
 
 # The characteristic pair each protocol generation carries its traffic on
 BT_PROTOCOL_UUIDS = {
@@ -59,6 +62,26 @@ async def start_notify(
     await client.start_notify(characteristic, callback, **kwargs)
 
 
+def is_stale_gatt_object(exc: Exception) -> bool:
+    """
+    Whether a subscribe failed against a characteristic the host cache invented
+
+    BlueZ also answers `Unlikely error` to a write against a peer that just dropped. A
+    clear costs nothing when nothing is cached, and `RemoveDevice` plus a re-discovery
+    when something is, which is the case worth paying for: both forms came back from a
+    host that was genuinely holding a dead handle.
+    """
+    text = str(exc).lower()
+    return "unknownobject" in text or "unlikely error" in text
+
+
+def is_empty_service_table(exc: Exception) -> bool:
+    """Whether the device resolved no characteristics at all, which no real one does"""
+    return isinstance(exc, UnsupportedBluetoothProtocol) and not (
+        exc.available_characteristics
+    )
+
+
 @runtime_checkable
 class SupportsCacheClear(Protocol):
     """A client that can drop its cached GATT database; plain `BleakClient` cannot"""
@@ -76,11 +99,15 @@ async def clear_gatt_cache(client: BleakClient | None, logger: MaskingLogger) ->
     if not isinstance(client, SupportsCacheClear):
         return
 
-    logger.warning("Clearing GATT cache to force service re-discovery")
     try:
-        if not await client.clear_cache():
-            # bleak itself can decline, and a caller that believed the cache was gone
-            # would keep reconnecting into the same broken table without knowing why
-            logger.warning("GATT cache was not cleared; this bleak version declined")
+        if await client.clear_cache():
+            logger.warning(
+                "Cleared the GATT cache, the next connect re-discovers services"
+            )
+        else:
+            # An ordinary outcome: nothing was cached for this device to begin with
+            logger.log_filtered(
+                LogOptions.CONNECTION_DEBUG, "GATT cache clear reported nothing to drop"
+            )
     except BleakError as e:
         logger.warning("Failed to clear GATT cache: %s", e)

--- a/custom_components/ef_ble/eflib/bluetooth.py
+++ b/custom_components/ef_ble/eflib/bluetooth.py
@@ -1,0 +1,86 @@
+"""
+The BLE transport: which characteristics carry the protocol, and the host's GATT cache
+"""
+
+from collections.abc import Callable
+from typing import Literal, Protocol, runtime_checkable
+
+from bleak import BleakClient
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.exc import BleakError
+
+from .exceptions import UnsupportedBluetoothProtocol
+from .logging_util import MaskingLogger
+
+# The characteristic pair each protocol generation carries its traffic on
+BT_PROTOCOL_UUIDS = {
+    "rfcomm": {
+        "notify": "00000003-0000-1000-8000-00805f9b34fb",
+        "write": "00000002-0000-1000-8000-00805f9b34fb",
+    },
+    "nordic_uart": {
+        "notify": "6e400003-b5a3-f393-e0a9-e50e24dcca9e",
+        "write": "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
+    },
+}
+
+
+def find_characteristic(
+    client: BleakClient, char_type: Literal["write", "notify"]
+) -> BleakGATTCharacteristic:
+    """
+    Return the characteristic carrying `char_type`, for either protocol generation
+
+    The raise carries what the device does expose, so a caller can tell an unsupported
+    device from an empty, and therefore stale, service table.
+    """
+    for uuids in BT_PROTOCOL_UUIDS.values():
+        if (found := client.services.get_characteristic(uuids[char_type])) is not None:
+            return found
+
+    raise UnsupportedBluetoothProtocol(
+        char_type,
+        [
+            f"{c.uuid} {c.description} {c.properties}"
+            for c in client.services.characteristics.values()
+        ],
+    )
+
+
+async def start_notify(
+    client: BleakClient,
+    characteristic: BleakGATTCharacteristic,
+    callback: Callable,
+    *,
+    use_bluez_start_notify: bool = False,
+) -> None:
+    """Subscribe, optionally letting BlueZ write the CCCD instead of bleak"""
+    kwargs = {"bluez": {"use_start_notify": True}} if use_bluez_start_notify else {}
+    await client.start_notify(characteristic, callback, **kwargs)
+
+
+@runtime_checkable
+class SupportsCacheClear(Protocol):
+    """A client that can drop its cached GATT database; plain `BleakClient` cannot"""
+
+    async def clear_cache(self) -> bool: ...
+
+
+async def clear_gatt_cache(client: BleakClient | None, logger: MaskingLogger) -> None:
+    """
+    Drop the host's cached GATT database, so the next connect re-discovers services
+
+    BlueZ can resolve services from a cache that no longer matches the device, and every
+    reconnect then reaches the same broken table.
+    """
+    if not isinstance(client, SupportsCacheClear):
+        return
+
+    logger.warning("Clearing GATT cache to force service re-discovery")
+    try:
+        if not await client.clear_cache():
+            # bleak itself can decline, and a caller that believed the cache was gone
+            # would keep reconnecting into the same broken table without knowing why
+            logger.warning("GATT cache was not cleared; this bleak version declined")
+    except BleakError as e:
+        logger.warning("Failed to clear GATT cache: %s", e)

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -272,6 +272,9 @@ class Connection:
         self._reconnect_task: asyncio.Task | None = None
         self._connection_attempt: int = 0
         self._reconnect_attempt: int = 0
+        # True only while `establish_connection` runs its own retries, which report
+        # every dropped attempt through our disconnected callback
+        self._establishing: bool = False
         self._reconnect = True
 
         self._connection_state: ConnectionState = None  # pyright: ignore[reportAttributeAccessIssue]
@@ -413,6 +416,7 @@ class Connection:
             # establish_connection needs a real retry count for BLE-level attempts (e.g.
             # when adapter slots are contested).
             ble_attempts = max_attempts if max_attempts != 0 else MAX_CONNECT_ATTEMPTS
+            self._establishing = True
             self._client = await establish_connection(
                 BleakClient,
                 self.ble_dev(),
@@ -443,6 +447,8 @@ class Connection:
         except BleakError as e:
             error = e
             self._set_state(ConnectionState.ERROR_BLEAK, e)
+        finally:
+            self._establishing = False
 
         if error is not None:
             await self._disconnect_client()
@@ -492,14 +498,20 @@ class Connection:
         # Traces the trigger: an unsolicited bleak drop shows bleak/asyncio frames here,
         # whereas a drop we requested shows our own `disconnect` chain.
         trigger = caller_chain()
-        self._logger.warning("Disconnected from device (%s)", trigger)
         self._client = None
 
         # NOTE(gnox): don't trigger disconnect/reconnect logic while
         # establish_connection is still retrying internally (bleak_retry_connector
         # manages its own retries and will raise on final failure)
-        if self._state is ConnectionState.ESTABLISHING_CONNECTION:
+        if self._establishing:
+            # One of those retries dropping is not a link we ever had, and a host that
+            # cannot reach the device produces a dozen of them per failing connect
+            self._logger.log_filtered(
+                LogOptions.CONNECTION_DEBUG, "Dropped while connecting (%s)", trigger
+            )
             return
+
+        self._logger.warning("Disconnected from device (%s)", trigger)
 
         if (inbox := self._inbox) is not None:
             # Woken rather than cancelled, see `_stop_data_pump`

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -26,6 +26,7 @@ from bleak_retry_connector import (
 )
 
 from . import keydata
+from .bluetooth import clear_gatt_cache, find_characteristic, start_notify
 from .encryption import EncryptionStrategy, Type1Encryption, Type7Encryption
 from .exceptions import (
     AuthErrors,
@@ -59,18 +60,6 @@ MAX_CONNECTION_ATTEMPTS = 10
 DISCONNECT_TIMEOUT = 5.0
 # Waited before DISCONNECT_TIMEOUT rather than inside it, so a teardown costs the sum
 PUMP_STOP_TIMEOUT = 1.0
-
-
-_BT_PROTOCOL_UUIDS = {
-    "rfcomm": {
-        "notify": "00000003-0000-1000-8000-00805f9b34fb",
-        "write": "00000002-0000-1000-8000-00805f9b34fb",
-    },
-    "nordic_uart": {
-        "notify": "6e400003-b5a3-f393-e0a9-e50e24dcca9e",
-        "write": "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
-    },
-}
 
 
 def _state_in(states: "Collection[ConnectionState | str]"):
@@ -881,19 +870,7 @@ class Connection:
         self._get_characteristics("write")
 
     async def _clear_gatt_cache(self) -> None:
-        # BlueZ can report `ServicesResolved` against an empty or stale cache (typically
-        # right after a bluetoothd restart or host update); without wiping it every
-        # reconnect keeps resolving the same broken service table. `clear_cache` is the
-        # `bleak_retry_connector.BleakClientWithServiceCache` interface, duck-typed via
-        # `getattr` because not every client implements it (plain `BleakClient` doesn't)
-        clear_cache = getattr(self._client, "clear_cache", None)
-        if clear_cache is None:
-            return
-        self._logger.warning("Clearing GATT cache to force service re-discovery")
-        try:
-            await clear_cache()
-        except BleakError as e:
-            self._logger.warning("Failed to clear GATT cache: %s", e)
+        await clear_gatt_cache(self._client, self._logger)
 
     async def _gen_session_key(self, seed: bytes, srand: bytes):
         """Implements the necessary part of the logic, rest is skipped"""
@@ -929,11 +906,12 @@ class Connection:
 
     async def _start_notify(self, callback: Callable):
         assert self._client is not None
-
-        kwargs = {}
-        if self._options.bluez_start_notify:
-            kwargs["bluez"] = {"use_start_notify": True}
-        await self._client.start_notify(self._notify_characteristic, callback, **kwargs)
+        await start_notify(
+            self._client,
+            self._notify_characteristic,
+            callback,
+            use_bluez_start_notify=self._options.bluez_start_notify,
+        )
 
     async def _on_notification(
         self, characteristic: BleakGATTCharacteristic, recv_data: bytearray
@@ -1428,17 +1406,7 @@ class Connection:
 
     def _get_characteristics(self, char_type: Literal["write", "notify"]):
         assert self._client is not None
-
-        for uuids in _BT_PROTOCOL_UUIDS.values():
-            if (
-                uuid := self._client.services.get_characteristic(uuids[char_type])
-            ) is not None:
-                return uuid
-        characteristic_list = [
-            f"{c.uuid} {c.description} {c.properties}"
-            for c in self._client.services.characteristics.values()
-        ]
-        raise UnsupportedBluetoothProtocol(char_type, characteristic_list)
+        return find_characteristic(self._client, char_type)
 
     @property
     def _notify_characteristic(self):

--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -26,7 +26,13 @@ from bleak_retry_connector import (
 )
 
 from . import keydata
-from .bluetooth import clear_gatt_cache, find_characteristic, start_notify
+from .bluetooth import (
+    clear_gatt_cache,
+    find_characteristic,
+    is_empty_service_table,
+    is_stale_gatt_object,
+    start_notify,
+)
 from .encryption import EncryptionStrategy, Type1Encryption, Type7Encryption
 from .exceptions import (
     AuthErrors,
@@ -419,7 +425,7 @@ class Connection:
             self._validate_characteristics()
         except UnsupportedBluetoothProtocol as e:
             error = e
-            if not e.available_characteristics:
+            if is_empty_service_table(e):
                 # An empty service table is a host-side GATT cache glitch, not the
                 # device genuinely lacking the protocol - wipe the cache so the
                 # reconnect re-discovers services instead of failing the same way.
@@ -459,6 +465,9 @@ class Connection:
         await self._stop_data_pump()
         self._inbox = asyncio.Queue()
 
+        # bleak can null `self._client` from its disconnected callback while the
+        # subscribe is still awaiting, and the cache still has to be cleared on it
+        client = self._client
         try:
             await self._start_notify(self._on_notification)
         except Exception as e:  # noqa: BLE001 - any subscribe failure is fatal here
@@ -469,6 +478,9 @@ class Connection:
                 "Failed to subscribe to notifications (%s); reconnecting", e
             )
             await self._disconnect_client()
+            if is_stale_gatt_object(e):
+                # Every reconnect resolves the same dead handle until the cache goes
+                await self._clear_gatt_cache(client)
             self.disconnected()
             return
 
@@ -869,8 +881,8 @@ class Connection:
         self._get_characteristics("notify")
         self._get_characteristics("write")
 
-    async def _clear_gatt_cache(self) -> None:
-        await clear_gatt_cache(self._client, self._logger)
+    async def _clear_gatt_cache(self, client: BleakClient | None = None) -> None:
+        await clear_gatt_cache(client or self._client, self._logger)
 
     async def _gen_session_key(self, seed: bytes, srand: bytes):
         """Implements the necessary part of the logic, rest is skipped"""


### PR DESCRIPTION
This PR recovers from a host GATT cache that has outlived the device's service table, and stops a permanently failing connect loop from filling the log. Subscribing to notifications can fail with `UnknownObject` or an `Unlikely Error` from BlueZ even though the characteristic lookup at connect time succeeded: the handle the host cached no longer exists on the peer. The cache is now cleared on that failure, so the next connect rediscovers services instead of resolving the same dead handle forever. The transport level concerns that made this hard to see (which characteristics carry the protocol, how a subscribe is issued, how a host fault is recognised) moved out of the connection state machine into their own module.

Full list of changes:

- **New `eflib/bluetooth.py` holds the BLE transport.** The protocol UUID table, `find_characteristic`, `start_notify` and `clear_gatt_cache` live there; `Connection` calls them and keeps only the state machine. No behaviour changes in this part, and `Connection._find_characteristic` / `_clear_gatt_cache` stay as thin wrappers so their call sites read the same.
- **The cached GATT database is dropped when a subscribe fails against a characteristic the host invented.** Previously only the empty-service-table check at connect time cleared it, which does not catch a table that resolves but points at handles the device no longer has.
- **`clear_cache` is typed instead of duck-typed.** A `SupportsCacheClear` protocol replaces the `getattr` lookup, and a client that declines to clear (some bleak versions return `False`) now says so in the log rather than letting the caller believe the cache is gone.
- **A drop reported while `establish_connection` is still retrying no longer logs as a disconnect.** `disconnected_callback` fires once per internal retry, and the handler already discards those, but it warned about each one first: a host that cannot reach the device produced around twelve warnings per failing connect cycle (measured at 119 warnings against 10 connect failures). They now go to the connection-debug log option alongside the other connect tracing, and a real disconnect still warns. The window is tracked by a flag around the call rather than by the connection state, so a state left behind by an unexpected error cannot silence later drops.
