### PR TITLE
Put the Wave 3 into standby from the climate entity and report its temperatures in Celsius

### DIFF
--- a/custom_components/ef_ble/eflib/devices/wave3.py
+++ b/custom_components/ef_ble/eflib/devices/wave3.py
@@ -132,7 +132,12 @@ class Device(DeviceBase, ProtobufProps):
 
     @computed_field
     def is_submode_available(self) -> bool:
-        return self.operating_mode in (OperatingMode.COOLING, OperatingMode.HEATING)
+        # A unit in standby reports no mode, so the submode it belongs to is not
+        # selectable either
+        return self.power is True and self.operating_mode in (
+            OperatingMode.COOLING,
+            OperatingMode.HEATING,
+        )
 
     @classmethod
     def check(cls, sn):
@@ -219,17 +224,37 @@ class Device(DeviceBase, ProtobufProps):
 
     @_climate.power(power)
     async def enable_power(self, enabled: bool):
+        """
+        Turn the unit off into standby rather than powering it down
+
+        `cfg_power_off` cuts the Bluetooth radio with it, so a unit switched off that
+        way can only be woken at the unit itself, which makes it a poor fit for the
+        climate entity's off state. Standby keeps the link up so the same entity can
+        turn it back on. This is the app's own home-screen toggle: `cfg_power_on` to
+        turn on and `cfg_sys_pause` to send it to standby, with powering down offered
+        separately.
+        """
         cfg = ac517_apl_comm_pb2.ConfigWrite()
         if enabled:
             cfg.cfg_power_on = True
         else:
-            cfg.cfg_power_off = True
+            cfg.cfg_sys_pause = True
         await self._send_config_packet(cfg)
+
+    @controls.button(enabled=False)
+    async def power_off(self) -> None:
+        await self._send_config_packet(
+            ac517_apl_comm_pb2.ConfigWrite(cfg_power_off=True)
+        )
 
     @_climate.mode()
     async def set_operating_mode(self, mode: OperatingMode):
+        """Set the operating mode, waking the unit from standby in the same write"""
         await self._send_config_packet(
-            ac517_apl_comm_pb2.ConfigWrite(cfg_wave_operating_mode=mode.value)
+            ac517_apl_comm_pb2.ConfigWrite(
+                cfg_power_on=True,
+                cfg_wave_operating_mode=mode.value,
+            )
         )
 
     @_climate.target_temp(

--- a/custom_components/ef_ble/sensor.py
+++ b/custom_components/ef_ble/sensor.py
@@ -217,9 +217,12 @@ def temperature(
 
 
 def _wave_unit(dev: "wave2.Device | wave3.Device"):
+    if isinstance(dev, wave3.Device):
+        return UnitOfTemperature.CELSIUS
+
     return (
         UnitOfTemperature.FAHRENHEIT
-        if dev.temp_unit in (units.Temperature.F, wave3.TemperatureUnit.FAHRENHEIT)
+        if dev.temp_unit is units.Temperature.F
         else UnitOfTemperature.CELSIUS
     )
 


### PR DESCRIPTION
This PR makes the Wave 3's climate entity turn the unit off into standby instead of powering it down, wakes it again from the same entity, and reports its temperature sensors in the unit the device actually sends. `cfg_power_off` cuts the Bluetooth radio along with the unit, so a Wave 3 switched off from Home Assistant could only be switched back on at the unit itself; the app's own home-screen toggle uses `cfg_sys_pause` for off and `cfg_power_on` for on, which keeps the link up. Powering down is still available, as a separate button that is disabled by default.

Full list of changes:

- **The climate off state sends the unit to standby, and on wakes it.** This is what the app does from the same control, and it leaves the device reachable, so the entity that turned it off can turn it back on.
- **Power off moved to its own button, disabled by default.** Pressing it drops the Bluetooth link with the unit, which is a deliberate action rather than a side effect of an off state.
- **A mode written to a sleeping unit carries the wake with it**, so calling the mode setter directly wakes the unit too rather than writing into a device that is still in standby.
- **The submode select is withheld while the unit is in standby**, since a unit in standby reports no operating mode for a submode to belong to.
- **Wave 3 temperature sensors report Celsius.** The device sends Celsius regardless of the unit its own display is set to, so the Fahrenheit setting was relabelling the value without converting it: an ambient temperature of 22.5 °C was shown as 22.5 °F. Home Assistant converts for display, so a user whose system is set to Fahrenheit now sees the right number.
- **Waking uses `cfg_power_on`.** An earlier attempt used a `cfg_sys_resume` field that looked like the obvious counterpart to `cfg_sys_pause`; regenerating the schema from the current EcoFlow app showed the device has no such field, which is why waking that way did nothing.

Resolves https://github.com/rabits/ha-ef-ble/discussions/470
