### PR TITLE
Authenticate with the binding refresh when a device reports its binding as unverified

### DIFF
--- a/custom_components/ef_ble/eflib/connection.py
+++ b/custom_components/ef_ble/eflib/connection.py
@@ -49,6 +49,11 @@ from .logging_util import ConnectionLogger, LogOptions, caller_chain
 from .packet import InvalidPacket, Packet
 from .props.utils import classproperty
 
+# The device answers the check when it still holds a verified binding for this account,
+# and the refresh when it does not; the app picks between them the same way
+AUTH_CHECK = 0x86
+AUTH_REFRESH = 0x85
+
 MAX_RECONNECT_ATTEMPTS = 2
 MAX_CONNECTION_ATTEMPTS = 10
 
@@ -236,6 +241,7 @@ class Connection:
         packet_version: int = 0x03,
         encrypt_type: int = 7,
         auth_header_dst: int = 0x35,
+        verified: bool = True,
     ) -> None:
         self._ble_dev = ble_dev
         self._address = ble_dev.address
@@ -246,6 +252,7 @@ class Connection:
         self._packet_parse = packet_parse
         self._packet_version = packet_version
         self._encrypt_type = encrypt_type
+        self._verified = verified
         self._encryption: EncryptionStrategy | None = None
         self._initial_session_key: bytes = b""
         self._frame_assembler: FrameAssembler | None = None
@@ -824,9 +831,14 @@ class Connection:
 
     @_auth_stage(ConnectionState.AUTHENTICATING)
     async def _auto_authentication(self):
+        # A device that no longer holds a verified binding refuses the check and can
+        # only be repaired by writing the secret back, which is what the app does when
+        # the advertisement says the binding is not verified
+        command = AUTH_CHECK if self._verified else AUTH_REFRESH
         self._logger.info(
             "autoAuthentication: Sending secretKey consists of user id and device "
-            "serial number",
+            "serial number (%s)",
+            "checking" if self._verified else "refreshing an unverified binding",
         )
 
         # Building payload for auth
@@ -839,7 +851,7 @@ class Connection:
             0x21,
             self._auth_header_dst,
             0x35,
-            0x86,
+            command,
             payload,
             0x01,
             0x01,
@@ -1151,7 +1163,7 @@ class Connection:
             is_auth_reply = (
                 packet.src == self._auth_header_dst
                 and packet.cmd_set == 0x35
-                and packet.cmd_id == 0x86
+                and packet.cmd_id in (AUTH_CHECK, AUTH_REFRESH)
             )
             authenticating = self._state == ConnectionState.AUTHENTICATING
 

--- a/custom_components/ef_ble/eflib/devicebase.py
+++ b/custom_components/ef_ble/eflib/devicebase.py
@@ -354,6 +354,10 @@ class DeviceBase(abc.ABC):
                     packet_parse=self.packet_parse,
                     packet_version=self.packet_version,
                     encrypt_type=self.scan_record.encrypt_type,
+                    verified=(
+                        self.scan_record.verified
+                        or not self.scan_record.support_verified
+                    ),
                     auth_header_dst=self.auth_header_dst,
                 )
                 .with_logging_options(self._logger.options)


### PR DESCRIPTION
This PR lets a device whose binding is no longer verified authenticate again on its own, instead of failing every connection until someone opens the EcoFlow app. A device advertises whether it still holds a verified binding for the account, and that flag decides which of two authentication messages it will accept: the one that checks the binding, or the one that writes it back. We only ever sent the check, so a device that stopped reporting itself as verified could never recover locally.

Both messages carry the same secret we already compute, so the fix is to send the one the device is asking for.

Full list of changes:

- **The authentication message is chosen from the advertised flag**, exactly as the app chooses it: the check while the device reports a verified binding, the refresh while it does not. A device that does not advertise the capability at all keeps the previous behaviour.
- **A device that answers the check by saying it needs binding first gets the refresh too**, once, whatever it advertised. That reply is the other way this state shows up, and it is what several older reports of this failure carried before they were closed with the advice to remove and re-add the device in the app.
- **Either reply is accepted as the authentication result**, since the device answers whichever message it was sent and the success code is the same for both.
- **The log line says which path was taken**, because the two failure modes look identical from the outside and a report of "authentication failed" is otherwise unactionable.
- Nothing is unbound and no network settings are touched, and the retry happens at most once per connection so a device that keeps refusing still fails rather than looping.

A device holding a binding for a *different* account is unaffected: asked to refresh with a secret that is not its own, it refuses and keeps the binding it has. So this cannot move a device between accounts, and it equally cannot repair that situation, which still needs the device to be removed and re-added.

Verified on a Delta 3 Plus. While the device advertised a verified binding it authenticated through the check as before, and a refresh was refused with an error code and the link dropped, which is what makes the flag worth reading rather than always writing. After clearing the binding the device advertised itself as unverified, and this branch authenticated it immediately over Bluetooth with no app and no internet involved. The needs-binding reply could not be reproduced on that device on demand, so that path is covered by unit-level checks rather than hardware; reporters whose devices fall into this state every few days are the ones who can confirm the recurring case, which no local test can reproduce.

Resolves #471